### PR TITLE
Complete deploy/upgrade/migration lifecycle for task 20.1

### DIFF
--- a/programs/crates/layerx-programs-runtime/tests/lifecycle.rs
+++ b/programs/crates/layerx-programs-runtime/tests/lifecycle.rs
@@ -3,11 +3,26 @@ use layerx_programs_runtime::test_support::{
     OP_END, OP_I32_CONST, TYPE_I32,
 };
 use layerx_programs_runtime::{
-    Deploy, Lifecycle, LifecycleRefusal, Migration, ProgramId, Upgrade, UpgradePolicy, ABI_VERSION,
+    Deploy, Lifecycle, LifecycleRefusal, Migration, ProgramId, Upgrade, UpgradePolicy,
+    ValidatedModule, WasmEngine, WasmValue, ABI_VERSION,
 };
 
 fn program(byte: u8) -> ProgramId {
     ProgramId::new([byte; 32]).unwrap_or_else(|error| panic!("program id refused: {error}"))
+}
+
+fn call_deployed(wasm: &[u8], export: &str, args: &[WasmValue]) -> Vec<WasmValue> {
+    let engine =
+        WasmEngine::declared().unwrap_or_else(|error| panic!("engine construction refused: {error}"));
+    let validated: ValidatedModule = engine
+        .validate(wasm)
+        .unwrap_or_else(|error| panic!("deployed module refused: {error}"));
+    let mut instance = validated
+        .instantiate()
+        .unwrap_or_else(|fault| panic!("deployed module instantiation faulted: {fault}"));
+    instance
+        .call(export, args)
+        .unwrap_or_else(|fault| panic!("deployed export faulted: {fault}"))
 }
 
 fn migration_module() -> Vec<u8> {
@@ -93,6 +108,73 @@ fn immutable_is_default_and_upgrade_records_hash_history() {
     assert_eq!(receipt.version, 2);
     assert_eq!(receipt.old_code_hash, Some([7; 32]));
     assert!(receipt.migration.is_some());
+}
+
+#[test]
+fn deploy_call_upgrade_and_migration_run_end_to_end() {
+    let mut lifecycle = Lifecycle::declared()
+        .unwrap_or_else(|error| panic!("lifecycle construction refused: {error}"));
+
+    let deploy_receipt = lifecycle
+        .deploy(Deploy {
+            program: program(20),
+            code_hash: [21; 32],
+            wasm: add_module(),
+            abi_version: ABI_VERSION,
+            upgrade_policy: UpgradePolicy::Authority([22; 32]),
+        })
+        .unwrap_or_else(|error| panic!("deployment refused: {error}"));
+    assert_eq!(deploy_receipt.version, 1);
+    assert_eq!(deploy_receipt.old_code_hash, None);
+    assert!(deploy_receipt.migration.is_none());
+
+    assert_eq!(
+        lifecycle.callable(&deploy_receipt, false),
+        Err(LifecycleRefusal::UnverifiedReceipt)
+    );
+    let deployed = lifecycle
+        .callable(&deploy_receipt, true)
+        .unwrap_or_else(|error| panic!("verified deployment not callable: {error}"));
+    assert_eq!(deployed.code_hash, [21; 32]);
+    assert_eq!(
+        call_deployed(
+            &deployed.wasm,
+            "add",
+            &[WasmValue::I32(19), WasmValue::I32(23)],
+        ),
+        vec![WasmValue::I32(42)]
+    );
+
+    let upgrade_receipt = lifecycle
+        .upgrade(Upgrade {
+            program: program(20),
+            authority: [22; 32],
+            code_hash: [23; 32],
+            wasm: migration_module(),
+            abi_version: ABI_VERSION,
+            migration: Some(Migration {
+                export: "migrate".to_string(),
+            }),
+        })
+        .unwrap_or_else(|error| panic!("upgrade refused: {error}"));
+    assert_eq!(upgrade_receipt.version, 2);
+    assert_eq!(upgrade_receipt.old_code_hash, Some([21; 32]));
+    assert_eq!(upgrade_receipt.new_code_hash, [23; 32]);
+    assert!(upgrade_receipt.migration.is_some());
+
+    let upgraded = lifecycle
+        .callable(&upgrade_receipt, true)
+        .unwrap_or_else(|error| panic!("verified upgrade not callable: {error}"));
+    assert_eq!(upgraded.code_hash, [23; 32]);
+    assert_eq!(
+        call_deployed(&upgraded.wasm, "migrate", &[]),
+        vec![WasmValue::I32(0)]
+    );
+
+    let original = lifecycle
+        .callable(&deploy_receipt, true)
+        .unwrap_or_else(|error| panic!("original version not callable: {error}"));
+    assert_eq!(original.code_hash, [21; 32]);
 }
 
 #[test]

--- a/spec/layerx-platform/qualification.kvx
+++ b/spec/layerx-platform/qualification.kvx
@@ -157,3 +157,19 @@ symbol = "layerx_programs::Deprecation"
 observed = "The deprecation core (Deprecation::transition, Deprecation::read, ValueAccount, WindDownView, DeprecationRefusal, the exit-only WindDownStateAccess::ReadOnly guard and validate_transition's stranded-value refusal) was already present on main from commit 763df2b 'Enforce program deprecation wind-down exits', while task.20.3 status was still 'pending'. That prior work satisfied do_2, do_3, and the live-balance transition/refusal cases of do_5, but left no path reconstructing the retained ValueAccount wind-down state from a durable log: Deprecation::read depends on the in-memory wind_downs vector, so after a restart holding only the registry lifecycle history and the journalled activities, read() would refuse with InvalidTransition. That leaves ac_6's 'history ... replayable forever' clause unmet by the coordinator."
 assumption = "Task 20.3 adds Deprecation::replay, which re-applies the durable, append-only deprecation activity log in canonical (program, effective_sequence) order through the same stranded-value guard as a live transition, plus WindDownView status-surfacing helpers (status_label, is_wound_down, reachable_value) for do_4 and winddown.rs tests covering a multi-account live-balance wind-down, a single stranded account refusing the whole wind-down, log replay reconstructing identical state, and replay refusing a logged stranding activity. Human qualification will run 'make programs-test', confirm replay determinism matches live transition state byte-for-byte, and confirm the explorer/CLI surfaces consume the status label. Whether registry lifecycle_history should itself be replay-journalled like deployment records (currently only Deprecation's own activity log is replayable) is left for qualification to decide, since that would touch lib.rs outside task 20.3's declared files."
 severity = "note"
+
+[observation.20.1.1]
+task = "20.1"
+file = "spec/layerx-platform/spec.kvx"
+symbol = "task.20.1 status"
+observed = "The deploy, upgrade and migration lifecycle for task 20.1 was already present on main from commit 553ce2b (src/modules/programs/deploy.c, programs/crates/layerx-programs-runtime/src/lifecycle.rs and its FFI/artifact seams), yet task.20.1 remained status=pending while its dependant task.20.2 was already status=done. The dependency ordering (20.2 requires 20.1) and the merged artifacts both indicate 20.1 was implemented but never flipped to done."
+assumption = "20.1 is flipped to done and the pre-existing lifecycle artifacts are treated as its implementation. Human qualification will reconcile the wave-10 status ledger and confirm no other done task depends on a still-pending predecessor."
+severity = "note"
+
+[observation.20.1.2]
+task = "20.1"
+file = "programs/crates/layerx-programs-runtime/tests/lifecycle.rs"
+symbol = "deploy_call_upgrade_and_migration_run_end_to_end"
+observed = "do_5 asks for deploy, call, upgrade and migration exercised end to end. The pre-existing lifecycle tests covered deploy, upgrade, migration and receipt-gated callability but never instantiated and executed deployed code, so the call leg was untested. A new test now deploys an upgradeable program, resolves the verified deployment receipt, instantiates and calls the deployed export, upgrades under the declared authority with a migration hook, then instantiates and calls the upgraded export and reconfirms the original version still resolves. The C real-node end-to-end coverage lives in tests/programs/test_lifecycle.c under make programs-test and dispatches deploy and migrating upgrade through the real kernel registration."
+assumption = "Per phase rules the added Rust test was written but not compiled or run. Human qualification will run make programs-test (Rust workspace tests plus the C real-node lifecycle test) to confirm the full deploy/call/upgrade/migration path passes."
+severity = "note"

--- a/spec/layerx-platform/spec.kvx
+++ b/spec/layerx-platform/spec.kvx
@@ -2224,7 +2224,7 @@ status = "pending"
 
 [task.20.1]
 title = "Implement deploy, upgrade and migration activities"
-status = "pending"
+status = "done"
 wave = 10
 requires = ["19.4"]
 do_1 = "Implement deployment as an ordinary programs-module activity: validation, fee, registry write, callable on verified receipt, no governance touchpoint."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes LayerX platform task **20.1 — "Implement deploy, upgrade and migration activities"** (`pending → done`).

The programs-module deploy/upgrade/migration lifecycle already landed on `main` in commit `553ce2b` — `src/modules/programs/deploy.c` implements deployment as an ordinary programs-module activity (validation, gas/fee charge, registry write, receipt-gated callability, no governance touchpoint), the immutable-by-default upgrade policy with authority declared at deployment and old/new code hashes recorded, declared migration hooks run under the runtime's determinism/metering law, and typed refusals for unknown programs, incompatible ABI versions and failed validations with artifacts preserved for diagnosis. The matching Rust runtime lives in `programs/crates/layerx-programs-runtime/src/lifecycle.rs`. However task `20.1` was never flipped to `done`, even though its dependant `20.2` was already `done`.

This PR closes the one genuine gap in the acceptance criteria — do_5's **call** leg was never exercised end to end — and reconciles the spec ledger.

### Trust boundary

Touches the permissionless programs plane (deployment, upgrade, migration). No change to canonical encoding, result codes, state roots, or the 402LXP sole-writer invariant — this PR only adds test coverage and flips a spec status.

## Specification

- Requirement clause(s): `req.29` ac_1, ac_4, ac_7 (permissionless deployment, immutable-by-default upgrade with migration under the metering law, typed refusals with preserved artifacts).
- Codify task: `20.1` set to `status = "done"` in `spec/layerx-platform/spec.kvx` (only task changed).
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI: none. Test-only + spec-status + qualification-log changes.

## Changes

- `programs/crates/layerx-programs-runtime/tests/lifecycle.rs`: new `deploy_call_upgrade_and_migration_run_end_to_end` test. It deploys an upgradeable program, refuses callability on an unverified receipt, resolves the verified deployment receipt, then instantiates and **calls** the deployed export through the real deterministic runtime; upgrades under the declared authority with a migration hook (asserting version increment, old/new code hashes and the migration record), calls the upgraded export, and reconfirms the pre-upgrade receipt still resolves its original immutable version. Existing tests are unchanged.
- `spec/layerx-platform/spec.kvx`: task `20.1` `pending → done` (no other task touched).
- `spec/layerx-platform/qualification.kvx`: two observations recording (1) the wave-10 status inconsistency (20.1 pending while dependant 20.2 done and the artifacts already merged) and (2) that the added Rust test was written but, per phase rules, not compiled or run; the C real-node end-to-end coverage remains in `tests/programs/test_lifecycle.c` under `make programs-test`.

## Verification

Per the repository's implementation-phase rules (implement, do not build/test/repair), **no build, test, or lint gate was run**. The new test was authored to match the existing test style and the exported runtime API but has not been compiled or executed. `verify_cmd` for this task is `make programs-test` (Rust workspace tests plus the C `programs_lifecycle` real-node test); this belongs to the human qualification phase.

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors.
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants.
- [x] I added real positive, negative, and adversarial coverage appropriate to the change.
- [ ] I ran `make public-audit` and the affected native or Solidity suites. — Not run: implementation phase forbids build/test/repair; deferred to qualification.
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-832d4349-ee33-477e-8877-e42a720df9ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-832d4349-ee33-477e-8877-e42a720df9ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

