### PR TITLE
Polish public repository metadata and documentation

### DIFF
--- a/METADATA_UPDATES.md
+++ b/METADATA_UPDATES.md
@@ -1,0 +1,61 @@
+# LayerX-Protocol Public Metadata Updates
+
+This document describes the metadata and documentation improvements made to polish the Sidiora-Labs organization and LayerX-Protocol repository.
+
+## Completed Changes
+
+### 1. README.md Licensing Clarification ✅
+- Added prominent source-available notice at the top of the README
+- Made it immediately clear that the repository is for inspection/security review only
+- Moved the notice before the project description for maximum visibility
+
+### 2. License Review ✅
+- Reviewed LICENSE file - no changes needed, text is correct
+- Confirmed no stale Matrix/PaxLabs references in the codebase
+
+## Required Manual Actions
+
+### 3. GitHub Repository Metadata
+The GitHub CLI lacks permission to edit repository settings. Please manually update:
+
+**Repository Description:**
+```
+Deterministic execution and accounting network for autonomous agents (source-available; Sidiora Labs)
+```
+
+**Repository Topics to Add:**
+- `agents`
+- `protocol`
+- `paxeer`
+- `sidiora`
+- `autonomous-agents`
+- `settlement`
+- `deterministic`
+
+**How to apply:**
+1. Go to https://github.com/Sidiora-Labs/LayerX-Protocol/settings
+2. Update the Description field under "About"
+3. Add the topics listed above under "Topics"
+
+### 4. Organization Profile Update
+A patch file has been created at `org-profile-update.patch` to improve the Sidiora-Labs organization profile with links to key projects.
+
+**To apply the org profile changes:**
+1. Clone or navigate to `Sidiora-Labs/.github`
+2. Apply the patch: `git apply org-profile-update.patch`
+3. Review the changes to `profile/README.md`
+4. Commit and push: `git commit -m "Add project links to org profile" && git push`
+
+Alternatively, manually edit `Sidiora-Labs/.github/profile/README.md` to add a "Projects" section with links to:
+- LayerX Protocol
+- Centra
+- Machine Genome
+
+The full proposed content is in the patch file.
+
+## Verification
+
+After manual steps are completed:
+1. Visit https://github.com/Sidiora-Labs/LayerX-Protocol to verify description and topics
+2. Visit https://github.com/Sidiora-Labs to verify the org profile shows project links
+3. Confirm the org card no longer looks empty/unfinished

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 **A deterministic execution and accounting network built for autonomous agents.**
 
+> **Source-available for inspection and security review.** This repository is not yet licensed for deployment or redistribution. See [License](#license).
+
 [Website](https://layerx.paxeer.app/) · [Protocol design](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/spec/layerx-protocol/design.md) · [Contributing](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/CONTRIBUTING.md) · [Security](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md)
 
 LayerX gives autonomous agents a shared place to transact, coordinate work, delegate authority, and produce verifiable records of what happened. It is designed for activity that is too frequent, too granular, or too latency-sensitive to place directly on a settlement chain.
 
 Ordinary agent activity is executed and ordered inside LayerX. Periodic checkpoints are settled to Paxeer, where custody, finality, economic guarantees, disputes, and emergency exits live. This separation keeps the fast path fast without asking users to trust an opaque internal ledger.
 
-LayerX is under active development and release qualification. The repository is currently source-available for inspection and security review. It is not yet licensed for deployment or redistribution. See [License](#license) for details.
+LayerX is under active development and release qualification.
 
 ## Why LayerX exists
 

--- a/org-profile-update.patch
+++ b/org-profile-update.patch
@@ -1,0 +1,24 @@
+diff --git a/profile/README.md b/profile/README.md
+index 6d9d9e3..f3b7564 100644
+--- a/profile/README.md
++++ b/profile/README.md
+@@ -18,6 +18,19 @@ Sidiora Labs researches and builds the memory, coordination, and exchange layers
+ 
+ ---
+ 
++## Projects
++
++### [LayerX Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol)
++A deterministic execution and accounting network for autonomous agents. Separates high-frequency agent activity from settlement-layer finality, providing verifiable records of everything that happens.
++
++### [Centra](https://github.com/Sidiora-Labs/Centra)
++Agent identity, authority, and custody infrastructure. Manages DIDs, session keys, scoped capability grants, and human approval workflows across custodial boundaries.
++
++### [Machine Genome](https://github.com/Sidiora-Labs/Machine-Genome)
++Memory and knowledge foundations for autonomous systems. Provides structured knowledge graphs, memory persistence, and reasoning infrastructure for agents that need to learn and adapt.
++
++---
++
+ <div align="center">
+ 
+ <sub>© 2026 Sidiora Labs Inc.</sub>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR polishes the public-facing metadata and documentation for the LayerX-Protocol repository to improve first-impression clarity and organization profile completeness. No code, protocol, or license legal text is changed.

**Changes:**
1. **README.md**: Added prominent source-available licensing notice at the very top (blockquote format) to immediately communicate that this is inspection/security-review only, not licensed for deployment/redistribution
2. **METADATA_UPDATES.md**: Added comprehensive documentation of required manual GitHub repository metadata updates (description, topics) that require admin permissions
3. **org-profile-update.patch**: Created patch file for improving the Sidiora-Labs organization profile with project links

**Rationale:**
- The licensing intent was already stated in the README but appeared after the project description, making it easy to miss
- The GitHub repository card shows no description or topics, making the org appear unfinished
- The Sidiora-Labs org profile lacks links to key projects (LayerX, Centra, Machine Genome)

## Specification

This is a documentation and metadata polish, not a protocol change.

- Requirement clause(s): N/A (not a protocol change)
- Codify task: N/A (not a protocol change)
- Compatibility impact: None - no wire encoding, result codes, state roots, storage, or contract changes

## Verification

No compilation or test verification required for documentation changes.

**Files changed:**
```
git diff main..HEAD --name-only
README.md
METADATA_UPDATES.md
org-profile-update.patch
```

**License review:**
- Confirmed LICENSE file text remains unchanged
- Verified no stale Matrix/PaxLabs references exist in codebase (all "matrix" mentions are test/CI matrices)

## Required Manual Actions

The following changes require repository admin permissions and should be applied after this PR merges:

1. **Set repository description** (via Settings → About):
   ```
   Deterministic execution and accounting network for autonomous agents (source-available; Sidiora Labs)
   ```

2. **Add repository topics**: agents, protocol, paxeer, sidiora, autonomous-agents, settlement, deterministic

3. **Update org profile**: Apply `org-profile-update.patch` to `Sidiora-Labs/.github` repository

See `METADATA_UPDATES.md` for detailed instructions.

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. (N/A - documentation only)
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants. (N/A - no code changes)
- [x] I added real positive, negative, and adversarial coverage appropriate to the change. (N/A - documentation only)
- [x] I ran `make public-audit` and the affected native or Solidity suites. (N/A - documentation only, but verified no stale references)
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50b014d1-e06a-4102-8e79-7d5f8e456393?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b014d1-e06a-4102-8e79-7d5f8e456393&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

