### PR TITLE
Add production remote KMS custody boundary

### DIFF
--- a/human/crates/layerx-human-service/src/agents/create.rs
+++ b/human/crates/layerx-human-service/src/agents/create.rs
@@ -20,7 +20,7 @@ use layerx_types::verify::VerificationLevel;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-use crate::custody::{CustodyError, KeyClass, KeyEntropy, KeyId, Keystore};
+use crate::custody::{CustodyError, KeyClass, KeyId, Keystore};
 use crate::store::{PrincipalScope, RowKey, StoreError, Table};
 
 const RECORD_VERSION: u8 = 1;
@@ -656,18 +656,7 @@ impl CreationJourney {
         let descriptor = match keystore.describe(scope.principal(), &key_id) {
             Ok(value) => value,
             Err(CustodyError::KeyNotFound) => {
-                let mut seed = [0_u8; 32];
-                let mut salt = [0_u8; 16];
-                let mut nonce = [0_u8; 24];
-                getrandom::fill(&mut seed).map_err(|_| AgentCreationError::EntropyUnavailable)?;
-                getrandom::fill(&mut salt).map_err(|_| AgentCreationError::EntropyUnavailable)?;
-                getrandom::fill(&mut nonce).map_err(|_| AgentCreationError::EntropyUnavailable)?;
-                match keystore.generate(
-                    scope.principal(),
-                    &key_id,
-                    KeyClass::AgentPrimary,
-                    KeyEntropy::new(seed, salt, nonce)?,
-                ) {
+                match keystore.create(scope.principal(), &key_id, KeyClass::AgentPrimary) {
                     Ok(public_key) => crate::custody::KeyDescriptor {
                         class: KeyClass::AgentPrimary,
                         public_key,

--- a/human/crates/layerx-human-service/src/custody/mod.rs
+++ b/human/crates/layerx-human-service/src/custody/mod.rs
@@ -1,8 +1,14 @@
 //! KMS-backed custody for human and managed-agent signing keys.
 
+mod provider;
 mod sessions;
 mod signer;
 
+pub use provider::{
+    KmsProvider, PrincipalKeyBinding, ProviderDeployment, ProviderKeyDescription,
+    ProviderKeyReference, ProviderSignRequest, RemoteCustodySigner, RemoteKmsProvider,
+    RotationState,
+};
 pub use sessions::{
     AgentContractError, AgentSessionContract, AgentSessionProvision, AgentSessionSecret,
     ManagedAgentState, PlainTime, ProtocolIdentitySnapshot, ProvisionEvidence, RenewalOutcome,
@@ -22,11 +28,10 @@ use std::fs;
 use std::io;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
-use layerx_crypto::keystore::{Keystore as KeyEnvelope, KeystoreEntropy, KeystoreError};
-use layerx_crypto::local::LocalSigner;
-use layerx_crypto::redact::Secret;
-use layerx_crypto::signer::{SignError, Signer as _};
+use layerx_crypto::keystore::{KeystoreEntropy, KeystoreError};
+use layerx_crypto::signer::SignError;
 use zeroize::Zeroizing;
 
 use crate::audit::AuditError;
@@ -34,7 +39,8 @@ use crate::store::{PrincipalId, StoreError};
 
 const IDENTITY_DOMAIN: &[u8] = b"layerx-human-custody/v1";
 const RECORD_MAGIC: &[u8; 4] = b"LXCK";
-const RECORD_VERSION: u8 = 1;
+const RECORD_VERSION: u8 = 2;
+const LEGACY_RECORD_VERSION: u8 = 1;
 const PRINCIPALS_DIR: &str = "principals";
 const KEY_FILE_SUFFIX: &str = ".key";
 const TEMP_FILE_SUFFIX: &str = ".key.tmp";
@@ -112,8 +118,9 @@ impl KeyClass {
     }
 }
 
-/// Caller-supplied entropy for one generated key: the private seed and the
-/// envelope entropy, zeroized on release and never rendered.
+/// Development-only caller-supplied entropy for the file-envelope provider.
+/// Production providers generate primary keys remotely and never accept this
+/// type. Its private seed and envelope entropy are zeroized on release.
 pub struct KeyEntropy {
     seed: Zeroizing<[u8; 32]>,
     envelope: KeystoreEntropy,
@@ -151,6 +158,24 @@ pub enum KmsError {
     Refused,
     /// The sealed envelope bytes are malformed.
     InvalidEnvelope,
+    /// Provider configuration cannot satisfy the bounded protocol.
+    InvalidConfiguration,
+    /// A provider key reference is empty or exceeds its bound.
+    InvalidReference,
+    /// The mutually authenticated provider identity could not be established.
+    Authentication,
+    /// The provider exceeded the declared operation deadline.
+    Timeout,
+    /// The provider returned a malformed or cross-operation response.
+    InvalidResponse,
+    /// The named provider key does not exist.
+    KeyNotFound,
+    /// The provider rejected a conflicting lifecycle operation.
+    Conflict,
+    /// The provider response did not match the principal-scoped key record.
+    Integrity,
+    /// A development-only operation was requested from a production provider.
+    DevelopmentOnly,
 }
 
 impl Display for KmsError {
@@ -159,58 +184,24 @@ impl Display for KmsError {
             Self::Unavailable => "key-management service is unavailable",
             Self::Refused => "key-management service refused the operation",
             Self::InvalidEnvelope => "sealed key envelope is malformed",
+            Self::InvalidConfiguration => "key-management service configuration is invalid",
+            Self::InvalidReference => "key-management key reference is invalid",
+            Self::Authentication => "key-management service authentication failed",
+            Self::Timeout => "key-management service operation timed out",
+            Self::InvalidResponse => "key-management service returned an invalid response",
+            Self::KeyNotFound => "key-management service key does not exist",
+            Self::Conflict => "key-management service lifecycle operation conflicted",
+            Self::Integrity => "key-management key reference integrity failed",
+            Self::DevelopmentOnly => "operation is available only with the development provider",
         })
     }
 }
 
 impl std::error::Error for KmsError {}
 
-/// The boundary inside which private key material exists in the clear. Every
-/// implementation seals seeds into ciphertext envelopes and unseals them only
-/// into zeroizing memory, and none exposes key material on any surface.
-trait KmsKeyProvider: std::fmt::Debug + Send + Sync {
-    /// Returns the non-secret root key reference this provider seals under.
-    fn key_reference(&self) -> &str;
-
-    /// Reports whether the provider can currently reach its root material.
-    ///
-    /// # Errors
-    ///
-    /// Returns the typed unavailability or refusal the next operation would hit.
-    fn probe(&self) -> Result<(), KmsError>;
-
-    /// Seals one private seed into a ciphertext envelope bound to the exact
-    /// identity and network.
-    ///
-    /// # Errors
-    ///
-    /// Returns a typed refusal and never a partially sealed envelope.
-    fn seal(
-        &self,
-        identity: &[u8],
-        network_id: u32,
-        seed: &[u8; 32],
-        entropy: KeystoreEntropy,
-    ) -> Result<Vec<u8>, KmsError>;
-
-    /// Unseals one envelope into zeroizing memory under the exact identity and
-    /// network it was sealed for.
-    ///
-    /// # Errors
-    ///
-    /// Refuses foreign identities, foreign networks and tampered envelopes.
-    fn unseal(
-        &self,
-        identity: &[u8],
-        network_id: u32,
-        envelope: &[u8],
-    ) -> Result<Secret<[u8; 32]>, KmsError>;
-}
-
-/// Working KMS provider performing authenticated envelope encryption under a
-/// root secret the operator mounts at a declared path. The root secret is read
-/// per operation into zeroizing memory and never cached, so removing the mount
-/// makes the provider honestly unavailable rather than silently degraded.
+/// Development-only envelope provider. It performs authenticated envelope
+/// encryption under a file-mounted root secret and is rejected by
+/// [`Keystore::open_production`]. Production uses [`RemoteKmsProvider`].
 pub struct EnvelopeKms {
     key_reference: String,
     secret_path: PathBuf,
@@ -239,7 +230,7 @@ impl EnvelopeKms {
         })
     }
 
-    fn root_secret(&self) -> Result<Zeroizing<Vec<u8>>, KmsError> {
+    pub(super) fn root_secret(&self) -> Result<Zeroizing<Vec<u8>>, KmsError> {
         let file = fs::File::open(&self.secret_path).map_err(|_| KmsError::Unavailable)?;
         let mut secret = Zeroizing::new(Vec::with_capacity(KMS_SECRET_MINIMUM));
         file.take(
@@ -263,7 +254,7 @@ impl std::fmt::Debug for EnvelopeKms {
     }
 }
 
-fn seal_refusal(error: KeystoreError) -> KmsError {
+pub(super) fn seal_refusal(error: KeystoreError) -> KmsError {
     match error {
         KeystoreError::MalformedStorage => KmsError::InvalidEnvelope,
         KeystoreError::InvalidInput
@@ -271,42 +262,6 @@ fn seal_refusal(error: KeystoreError) -> KmsError {
         | KeystoreError::NetworkMismatch
         | KeystoreError::KeyDerivation
         | KeystoreError::AuthenticationFailed => KmsError::Refused,
-    }
-}
-
-impl KmsKeyProvider for EnvelopeKms {
-    fn key_reference(&self) -> &str {
-        &self.key_reference
-    }
-
-    fn probe(&self) -> Result<(), KmsError> {
-        self.root_secret().map(|_| ())
-    }
-
-    fn seal(
-        &self,
-        identity: &[u8],
-        network_id: u32,
-        seed: &[u8; 32],
-        entropy: KeystoreEntropy,
-    ) -> Result<Vec<u8>, KmsError> {
-        let root = self.root_secret()?;
-        let envelope =
-            KeyEnvelope::seal(seed, &root, identity, network_id, entropy).map_err(seal_refusal)?;
-        envelope.to_bytes().map_err(seal_refusal)
-    }
-
-    fn unseal(
-        &self,
-        identity: &[u8],
-        network_id: u32,
-        envelope: &[u8],
-    ) -> Result<Secret<[u8; 32]>, KmsError> {
-        let root = self.root_secret()?;
-        let envelope = KeyEnvelope::from_bytes(envelope).map_err(seal_refusal)?;
-        envelope
-            .open(&root, identity, network_id)
-            .map_err(seal_refusal)
     }
 }
 
@@ -319,6 +274,7 @@ pub enum CustodyError {
     InvalidEntropy,
     InvalidLimits,
     InvalidEvidence,
+    DevelopmentProviderInProduction,
     CorruptState(&'static str),
     KeyExists,
     KeyNotFound,
@@ -350,6 +306,7 @@ impl CustodyError {
             Self::InvalidEntropy => "invalid-entropy",
             Self::InvalidLimits => "invalid-limits",
             Self::InvalidEvidence => "invalid-evidence",
+            Self::DevelopmentProviderInProduction => "development-kms-in-production",
             Self::CorruptState(_) => "corrupt-state",
             Self::KeyExists => "key-exists",
             Self::KeyNotFound => "key-not-found",
@@ -358,6 +315,15 @@ impl CustodyError {
             Self::Kms(KmsError::Unavailable) => "kms-unavailable",
             Self::Kms(KmsError::Refused) => "kms-refused",
             Self::Kms(KmsError::InvalidEnvelope) => "kms-invalid-envelope",
+            Self::Kms(KmsError::InvalidConfiguration) => "kms-invalid-configuration",
+            Self::Kms(KmsError::InvalidReference) => "kms-invalid-reference",
+            Self::Kms(KmsError::Authentication) => "kms-authentication",
+            Self::Kms(KmsError::Timeout) => "kms-timeout",
+            Self::Kms(KmsError::InvalidResponse) => "kms-invalid-response",
+            Self::Kms(KmsError::KeyNotFound) => "kms-key-not-found",
+            Self::Kms(KmsError::Conflict) => "kms-conflict",
+            Self::Kms(KmsError::Integrity) => "kms-integrity",
+            Self::Kms(KmsError::DevelopmentOnly) => "kms-development-only",
             Self::Sign(SignError::DisclosureMismatch(_)) => "disclosure-mismatch",
             Self::Sign(SignError::InvalidDisclosure) => "disclosure-invalid",
             Self::Sign(_) => "signer-refused",
@@ -385,6 +351,9 @@ impl Display for CustodyError {
             Self::InvalidEntropy => formatter.write_str("key entropy is invalid"),
             Self::InvalidLimits => formatter.write_str("signing limits must be non-zero"),
             Self::InvalidEvidence => formatter.write_str("step-up evidence is invalid"),
+            Self::DevelopmentProviderInProduction => {
+                formatter.write_str("development file-envelope KMS is forbidden in production")
+            }
             Self::CorruptState(reason) => write!(formatter, "corrupt custody state: {reason}"),
             Self::KeyExists => formatter.write_str("custody key already exists"),
             Self::KeyNotFound => formatter.write_str("custody key does not exist"),
@@ -458,6 +427,14 @@ pub enum Availability {
     Unavailable,
 }
 
+/// Aggregate integrity of principal-scoped provider key references.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeyReferenceIntegrity {
+    Verified,
+    Failed,
+    Unknown,
+}
+
 /// Degradation state surfaced for the custody service.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CustodyStatus {
@@ -465,6 +442,11 @@ pub struct CustodyStatus {
     pub kms: Availability,
     /// Whether the sealed-record storage can be reached.
     pub storage: Availability,
+    /// Whether every persisted provider handle describes the expected key and
+    /// principal binding.
+    pub key_references: KeyReferenceIntegrity,
+    /// Aggregate provider-reported key rotation state.
+    pub rotation: RotationState,
 }
 
 impl CustodyStatus {
@@ -472,8 +454,13 @@ impl CustodyStatus {
     #[must_use]
     pub const fn degraded(self) -> bool {
         !matches!(
-            (self.kms, self.storage),
-            (Availability::Available, Availability::Available)
+            (self.kms, self.storage, self.key_references, self.rotation),
+            (
+                Availability::Available,
+                Availability::Available,
+                KeyReferenceIntegrity::Verified,
+                RotationState::Stable
+            )
         )
     }
 }
@@ -481,34 +468,92 @@ impl CustodyStatus {
 struct KeyRecord {
     class: KeyClass,
     public_key: [u8; 32],
-    envelope: Vec<u8>,
+    binding_digest: Option<[u8; 32]>,
+    provider_reference: ProviderKeyReference,
 }
 
-/// KMS-backed keystore holding every human and managed-agent private key as a
-/// sealed envelope under one principal subtree. Key material at rest is
-/// ciphertext only; unsealed seeds live exclusively in zeroizing memory and no
-/// method returns private material.
+/// KMS-backed keystore holding only provider references and public key facts
+/// under principal-scoped subtrees. Production private keys never enter this
+/// process and no method returns private material.
 #[derive(Debug)]
 pub struct Keystore {
     root: PathBuf,
     network_id: u32,
-    provider: EnvelopeKms,
+    provider: Arc<dyn KmsProvider>,
 }
 
 impl Keystore {
-    /// Opens the keystore at `root` for one network under one KMS provider.
+    /// Opens the production keystore at `root` for one network under a remote
+    /// KMS/HSM provider. Development-only providers are always refused.
     ///
     /// # Errors
     ///
-    /// Refuses network zero, foreign entries in the principals tree, and
-    /// storage failures.
-    pub fn open(
+    /// Refuses development providers, unavailable remote providers, network
+    /// zero, foreign entries in the principals tree and storage failures.
+    pub fn open<P>(
+        root: impl AsRef<Path>,
+        network_id: u32,
+        provider: P,
+    ) -> Result<Self, CustodyError>
+    where
+        P: KmsProvider + 'static,
+    {
+        Self::open_shared(root, network_id, Arc::new(provider), true)
+    }
+
+    /// Opens the explicitly development-only file-envelope keystore.
+    ///
+    /// # Errors
+    ///
+    /// Returns invalid-network, corrupt-tree and storage failures. This method
+    /// cannot accept a production provider.
+    pub fn open_development(
         root: impl AsRef<Path>,
         network_id: u32,
         provider: EnvelopeKms,
     ) -> Result<Self, CustodyError> {
+        Self::open_shared(root, network_id, Arc::new(provider), false)
+    }
+
+    /// Opens a production keystore and refuses a development-only provider or
+    /// an unreachable remote boundary before service startup completes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed refusal for a development provider, provider readiness
+    /// failure, invalid network, corrupt custody tree or storage failure.
+    pub fn open_production<P>(
+        root: impl AsRef<Path>,
+        network_id: u32,
+        provider: P,
+    ) -> Result<Self, CustodyError>
+    where
+        P: KmsProvider + 'static,
+    {
+        Self::open(root, network_id, provider)
+    }
+
+    fn open_shared(
+        root: impl AsRef<Path>,
+        network_id: u32,
+        provider: Arc<dyn KmsProvider>,
+        production: bool,
+    ) -> Result<Self, CustodyError> {
         if network_id == 0 {
             return Err(CustodyError::InvalidNetwork);
+        }
+        let provider_reference = provider.provider_reference();
+        if provider_reference.is_empty()
+            || provider_reference.len() > KEY_REFERENCE_LIMIT
+            || provider_reference.as_bytes().contains(&0)
+        {
+            return Err(CustodyError::InvalidKeyReference);
+        }
+        if production && provider.deployment() != ProviderDeployment::Production {
+            return Err(CustodyError::DevelopmentProviderInProduction);
+        }
+        if production {
+            provider.probe()?;
         }
         let root = root.as_ref().to_path_buf();
         fs::create_dir_all(&root)?;
@@ -530,7 +575,23 @@ impl Keystore {
     /// Returns the non-secret KMS root key reference in use.
     #[must_use]
     pub fn key_reference(&self) -> &str {
-        self.provider.key_reference()
+        self.provider.provider_reference()
+    }
+
+    /// Creates a key wholly inside the selected provider and returns only its
+    /// public verification key.
+    ///
+    /// # Errors
+    ///
+    /// Refuses duplicates and returns typed provider, integrity and storage
+    /// failures without persisting a partial record.
+    pub fn create(
+        &self,
+        principal: &PrincipalId,
+        key: &KeyId,
+        class: KeyClass,
+    ) -> Result<[u8; 32], CustodyError> {
+        self.create_with(principal, key, class, None)
     }
 
     /// Generates one key inside the KMS boundary and returns only its public
@@ -547,19 +608,32 @@ impl Keystore {
         class: KeyClass,
         entropy: KeyEntropy,
     ) -> Result<[u8; 32], CustodyError> {
+        if self.provider.deployment() != ProviderDeployment::DevelopmentOnly {
+            return Err(CustodyError::Kms(KmsError::DevelopmentOnly));
+        }
+        self.create_with(principal, key, class, Some(entropy))
+    }
+
+    fn create_with(
+        &self,
+        principal: &PrincipalId,
+        key: &KeyId,
+        class: KeyClass,
+        entropy: Option<KeyEntropy>,
+    ) -> Result<[u8; 32], CustodyError> {
         let directory = self.create_principal_directory(principal)?;
         let path = directory.join(format!("{}{KEY_FILE_SUFFIX}", key.as_str()));
         if fs::symlink_metadata(&path).is_ok() {
             return Err(CustodyError::KeyExists);
         }
-        let identity = identity_bytes(principal, key, class);
-        let KeyEntropy { seed, envelope } = entropy;
-        let public_key = LocalSigner::new(*seed).public_key();
-        let sealed = self
-            .provider
-            .seal(&identity, self.network_id, &seed, envelope)?;
-        drop(seed);
-        let record = encode_record(class, &public_key, &sealed)?;
+        let binding = self.binding(principal, key, class)?;
+        let description = match entropy {
+            Some(entropy) => self.provider.create_development_key(&binding, entropy)?,
+            None => self.provider.create_key(&binding)?,
+        };
+        require_description(&binding, class, None, &description)?;
+        let public_key = description.public_key();
+        let record = encode_record(class, &description)?;
         write_atomic(
             &directory,
             &format!("{}{KEY_FILE_SUFFIX}", key.as_str()),
@@ -569,7 +643,8 @@ impl Keystore {
         Ok(public_key)
     }
 
-    /// Describes one held key without touching the KMS boundary.
+    /// Describes one held key and verifies its provider reference against the
+    /// principal-scoped local record.
     ///
     /// # Errors
     ///
@@ -580,10 +655,77 @@ impl Keystore {
         key: &KeyId,
     ) -> Result<KeyDescriptor, CustodyError> {
         let record = self.read_record(principal, key)?;
+        let binding = self.binding(principal, key, record.class)?;
+        self.require_record_binding(&binding, &record)?;
+        let description = self
+            .provider
+            .describe_key(&binding, &record.provider_reference)?;
+        require_description(
+            &binding,
+            record.class,
+            Some(record.public_key),
+            &description,
+        )?;
+        if description.reference() != &record.provider_reference {
+            return Err(CustodyError::Kms(KmsError::Integrity));
+        }
         Ok(KeyDescriptor {
             class: record.class,
-            public_key: record.public_key,
+            public_key: description.public_key(),
         })
+    }
+
+    /// Rotates one key inside the provider and atomically replaces only its
+    /// opaque handle and public facts in local storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns typed provider, principal-binding and storage failures.
+    pub fn rotate(
+        &self,
+        principal: &PrincipalId,
+        key: &KeyId,
+    ) -> Result<KeyDescriptor, CustodyError> {
+        let record = self.read_record(principal, key)?;
+        let binding = self.binding(principal, key, record.class)?;
+        self.require_record_binding(&binding, &record)?;
+        let description = self
+            .provider
+            .rotate_key(&binding, &record.provider_reference)?;
+        require_description(&binding, record.class, None, &description)?;
+        if self.provider.deployment() == ProviderDeployment::Production
+            && description.reference() != &record.provider_reference
+        {
+            return Err(CustodyError::Kms(KmsError::Integrity));
+        }
+        let bytes = encode_record(record.class, &description)?;
+        replace_atomic(
+            &self.principal_directory(principal),
+            &format!("{}{KEY_FILE_SUFFIX}", key.as_str()),
+            &format!("{}{TEMP_FILE_SUFFIX}", key.as_str()),
+            &bytes,
+        )?;
+        Ok(KeyDescriptor {
+            class: record.class,
+            public_key: description.public_key(),
+        })
+    }
+
+    /// Destroys one provider key before removing its local opaque record.
+    ///
+    /// # Errors
+    ///
+    /// Returns typed provider, principal-binding and storage failures. A
+    /// provider refusal never removes the local record.
+    pub fn destroy(&self, principal: &PrincipalId, key: &KeyId) -> Result<(), CustodyError> {
+        let record = self.read_record(principal, key)?;
+        let binding = self.binding(principal, key, record.class)?;
+        self.require_record_binding(&binding, &record)?;
+        self.provider
+            .destroy_key(&binding, &record.provider_reference)?;
+        fs::remove_file(self.key_path(principal, key))?;
+        fs::File::open(self.principal_directory(principal))?.sync_all()?;
+        Ok(())
     }
 
     /// Lists one principal's key identifiers in deterministic order.
@@ -628,31 +770,155 @@ impl Keystore {
             Ok(()) => Availability::Available,
             Err(_) => Availability::Unavailable,
         };
-        let storage = if self.root.is_dir() {
-            Availability::Available
-        } else {
-            Availability::Unavailable
+        let (storage, key_references, rotation) = match self.inspect_records() {
+            Ok((key_references, rotation)) => (Availability::Available, key_references, rotation),
+            Err(_) => (
+                Availability::Unavailable,
+                KeyReferenceIntegrity::Unknown,
+                RotationState::Unknown,
+            ),
         };
-        CustodyStatus { kms, storage }
+        CustodyStatus {
+            kms,
+            storage,
+            key_references,
+            rotation,
+        }
     }
 
-    pub(crate) fn unseal_signer(
+    pub(crate) fn remote_signer(
         &self,
         principal: &PrincipalId,
         key: &KeyId,
-    ) -> Result<(LocalSigner, KeyClass), CustodyError> {
+    ) -> Result<RemoteCustodySigner, CustodyError> {
         let record = self.read_record(principal, key)?;
-        let identity = identity_bytes(principal, key, record.class);
-        let seed = self
+        let binding = self.binding(principal, key, record.class)?;
+        self.require_record_binding(&binding, &record)?;
+        let description = self
             .provider
-            .unseal(&identity, self.network_id, &record.envelope)?;
-        let signer = LocalSigner::from_secret(seed);
-        if signer.public_key() != record.public_key {
-            return Err(CustodyError::CorruptRecord(
-                "sealed key does not match its recorded public key",
-            ));
+            .describe_key(&binding, &record.provider_reference)?;
+        require_description(
+            &binding,
+            record.class,
+            Some(record.public_key),
+            &description,
+        )?;
+        if description.reference() != &record.provider_reference {
+            return Err(CustodyError::Kms(KmsError::Integrity));
         }
-        Ok((signer, record.class))
+        Ok(RemoteCustodySigner::new(
+            Arc::clone(&self.provider),
+            binding,
+            description,
+            record.class,
+        ))
+    }
+
+    fn binding(
+        &self,
+        principal: &PrincipalId,
+        key: &KeyId,
+        class: KeyClass,
+    ) -> Result<PrincipalKeyBinding, CustodyError> {
+        PrincipalKeyBinding::new(
+            identity_bytes(principal, key, class),
+            self.network_id,
+            class,
+            self.provider.provider_reference(),
+        )
+    }
+
+    fn require_record_binding(
+        &self,
+        binding: &PrincipalKeyBinding,
+        record: &KeyRecord,
+    ) -> Result<(), CustodyError> {
+        if record
+            .binding_digest
+            .is_some_and(|digest| !layerx_crypto::ct::eq_fixed(&digest, &binding.digest()))
+        {
+            return Err(CustodyError::Kms(KmsError::Integrity));
+        }
+        Ok(())
+    }
+
+    fn inspect_records(&self) -> Result<(KeyReferenceIntegrity, RotationState), CustodyError> {
+        require_directory(&self.root, "custody root is not a directory")?;
+        let principals = self.root.join(PRINCIPALS_DIR);
+        if !principals.try_exists()? {
+            return Ok((KeyReferenceIntegrity::Verified, RotationState::Stable));
+        }
+        require_directory(&principals, "principals path is not a directory")?;
+        let mut integrity = KeyReferenceIntegrity::Verified;
+        let mut rotation = RotationState::Stable;
+        for principal_entry in fs::read_dir(principals)? {
+            let principal_entry = principal_entry?;
+            let Some(principal_name) = principal_entry.file_name().to_str().map(str::to_owned)
+            else {
+                integrity = KeyReferenceIntegrity::Failed;
+                continue;
+            };
+            let Ok(principal) = PrincipalId::new(principal_name) else {
+                integrity = KeyReferenceIntegrity::Failed;
+                continue;
+            };
+            for key_entry in fs::read_dir(principal_entry.path())? {
+                let key_entry = key_entry?;
+                let Some(key_name) = key_entry.file_name().to_str().map(str::to_owned) else {
+                    integrity = KeyReferenceIntegrity::Failed;
+                    continue;
+                };
+                if key_name.ends_with(TEMP_FILE_SUFFIX) {
+                    continue;
+                }
+                let Some(stem) = key_name.strip_suffix(KEY_FILE_SUFFIX) else {
+                    integrity = KeyReferenceIntegrity::Failed;
+                    continue;
+                };
+                let Ok(key) = KeyId::new(stem) else {
+                    integrity = KeyReferenceIntegrity::Failed;
+                    continue;
+                };
+                let record = match self.read_record(&principal, &key) {
+                    Ok(record) => record,
+                    Err(CustodyError::Io(error)) => return Err(CustodyError::Io(error)),
+                    Err(_) => {
+                        integrity = KeyReferenceIntegrity::Failed;
+                        continue;
+                    }
+                };
+                let binding = self.binding(&principal, &key, record.class)?;
+                if self.require_record_binding(&binding, &record).is_err() {
+                    integrity = KeyReferenceIntegrity::Failed;
+                    continue;
+                }
+                match self
+                    .provider
+                    .describe_key(&binding, &record.provider_reference)
+                {
+                    Ok(description)
+                        if require_description(
+                            &binding,
+                            record.class,
+                            Some(record.public_key),
+                            &description,
+                        )
+                        .is_ok()
+                            && description.reference() == &record.provider_reference =>
+                    {
+                        rotation = merge_rotation(rotation, description.rotation());
+                    }
+                    Err(KmsError::Unavailable | KmsError::Timeout | KmsError::Authentication) => {
+                        if integrity != KeyReferenceIntegrity::Failed {
+                            integrity = KeyReferenceIntegrity::Unknown;
+                        }
+                        rotation = RotationState::Unknown;
+                    }
+                    Ok(_) | Err(_) => integrity = KeyReferenceIntegrity::Failed,
+                }
+            }
+        }
+        Ok((integrity, rotation))
     }
 
     fn principal_directory(&self, principal: &PrincipalId) -> PathBuf {
@@ -722,20 +988,49 @@ fn identity_bytes(principal: &PrincipalId, key: &KeyId, class: KeyClass) -> Vec<
     identity
 }
 
+fn require_description(
+    binding: &PrincipalKeyBinding,
+    class: KeyClass,
+    expected_public_key: Option<[u8; 32]>,
+    description: &ProviderKeyDescription,
+) -> Result<(), CustodyError> {
+    if binding.class() != class
+        || !layerx_crypto::ct::eq_fixed(&description.binding_digest(), &binding.digest())
+        || expected_public_key.is_some_and(|public_key| {
+            !layerx_crypto::ct::eq_fixed(&public_key, &description.public_key())
+        })
+    {
+        return Err(CustodyError::Kms(KmsError::Integrity));
+    }
+    Ok(())
+}
+
+const fn merge_rotation(current: RotationState, next: RotationState) -> RotationState {
+    match (current, next) {
+        (RotationState::Failed, _) | (_, RotationState::Failed) => RotationState::Failed,
+        (RotationState::Unknown, _) | (_, RotationState::Unknown) => RotationState::Unknown,
+        (RotationState::InProgress, _) | (_, RotationState::InProgress) => {
+            RotationState::InProgress
+        }
+        (RotationState::Stable, RotationState::Stable) => RotationState::Stable,
+    }
+}
+
 fn encode_record(
     class: KeyClass,
-    public_key: &[u8; 32],
-    envelope: &[u8],
+    description: &ProviderKeyDescription,
 ) -> Result<Vec<u8>, CustodyError> {
-    let envelope_length = u32::try_from(envelope.len())
-        .map_err(|_| CustodyError::CorruptRecord("envelope exceeds encoding bounds"))?;
-    let mut output = Vec::with_capacity(4 + 1 + 1 + 32 + 4 + envelope.len());
+    let reference = description.reference().as_bytes();
+    let reference_length = u32::try_from(reference.len())
+        .map_err(|_| CustodyError::CorruptRecord("provider reference exceeds encoding bounds"))?;
+    let mut output = Vec::with_capacity(4 + 1 + 1 + 32 + 32 + 4 + reference.len());
     output.extend_from_slice(RECORD_MAGIC);
     output.push(RECORD_VERSION);
     output.push(class.code());
-    output.extend_from_slice(public_key);
-    output.extend_from_slice(&envelope_length.to_be_bytes());
-    output.extend_from_slice(envelope);
+    output.extend_from_slice(&description.public_key());
+    output.extend_from_slice(&description.binding_digest());
+    output.extend_from_slice(&reference_length.to_be_bytes());
+    output.extend_from_slice(reference);
     Ok(output)
 }
 
@@ -744,7 +1039,8 @@ fn decode_record(bytes: &[u8]) -> Result<KeyRecord, CustodyError> {
     if reader.take(4)? != RECORD_MAGIC {
         return Err(CustodyError::CorruptRecord("invalid record header"));
     }
-    if reader.byte()? != RECORD_VERSION {
+    let version = reader.byte()?;
+    if !matches!(version, LEGACY_RECORD_VERSION | RECORD_VERSION) {
         return Err(CustodyError::CorruptRecord("unknown record version"));
     }
     let class = KeyClass::from_code(reader.byte()?)?;
@@ -752,13 +1048,25 @@ fn decode_record(bytes: &[u8]) -> Result<KeyRecord, CustodyError> {
         .take(32)?
         .try_into()
         .map_err(|_| CustodyError::CorruptRecord("truncated public key"))?;
-    let envelope_length = reader.length()?;
-    let envelope = reader.take(envelope_length)?.to_vec();
+    let binding_digest = if version == RECORD_VERSION {
+        Some(
+            reader
+                .take(32)?
+                .try_into()
+                .map_err(|_| CustodyError::CorruptRecord("truncated key binding"))?,
+        )
+    } else {
+        None
+    };
+    let reference_length = reader.length()?;
+    let provider_reference = ProviderKeyReference::new(reader.take(reference_length)?.to_vec())
+        .map_err(CustodyError::Kms)?;
     reader.finish()?;
     Ok(KeyRecord {
         class,
         public_key,
-        envelope,
+        binding_digest,
+        provider_reference,
     })
 }
 
@@ -881,6 +1189,33 @@ fn write_atomic(
         };
     }
     fs::remove_file(temp_path)?;
+    fs::File::open(directory)?.sync_all()?;
+    Ok(())
+}
+
+fn replace_atomic(
+    directory: &Path,
+    final_name: &str,
+    temp_name: &str,
+    bytes: &[u8],
+) -> Result<(), CustodyError> {
+    use std::io::Write as _;
+
+    let temp_path = directory.join(temp_name);
+    let mut file = fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp_path)?;
+    if let Err(error) = file.write_all(bytes).and_then(|()| file.sync_all()) {
+        drop(file);
+        let _ = fs::remove_file(&temp_path);
+        return Err(CustodyError::Io(error));
+    }
+    drop(file);
+    if let Err(error) = fs::rename(&temp_path, directory.join(final_name)) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(CustodyError::Io(error));
+    }
     fs::File::open(directory)?.sync_all()?;
     Ok(())
 }

--- a/human/crates/layerx-human-service/src/custody/provider.rs
+++ b/human/crates/layerx-human-service/src/custody/provider.rs
@@ -1,0 +1,1068 @@
+use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use layerx_client::lni::transport::{
+    ConnectionGate, FrameTransport, Limits, MutualTlsConfig, Tls, TransportError,
+};
+use layerx_crypto::disclosure::{bind, Disclosure};
+use layerx_crypto::local::LocalSigner;
+use layerx_crypto::signer::{sign_disclosed, Signer as _};
+use layerx_types::payload::ModuleRegistry;
+use sha2::{Digest as _, Sha256};
+use zeroize::Zeroizing;
+
+use super::{seal_refusal, CustodyError, EnvelopeKms, KeyClass, KeyEntropy, KmsError};
+
+const PROVIDER_REFERENCE_LIMIT: usize = 4096;
+const PROVIDER_FRAME_LIMIT: usize = 2_097_152;
+const PROVIDER_MAGIC: &[u8; 4] = b"LXKP";
+const PROVIDER_VERSION: u16 = 1;
+const SIGNATURE_DOMAIN: &[u8] = b"LXP/v1/signature-preimage\0";
+const OP_PROBE: u8 = 0;
+const OP_CREATE: u8 = 1;
+const OP_DESCRIBE: u8 = 2;
+const OP_ROTATE: u8 = 3;
+const OP_DESTROY: u8 = 4;
+const OP_SIGN: u8 = 5;
+const STATUS_OK: u8 = 0;
+const STATUS_REFUSED: u8 = 1;
+const STATUS_NOT_FOUND: u8 = 2;
+const STATUS_CONFLICT: u8 = 3;
+const STATUS_UNAVAILABLE: u8 = 4;
+const STATUS_INTEGRITY: u8 = 5;
+
+/// Whether a custody provider may be selected by a production service.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProviderDeployment {
+    DevelopmentOnly,
+    Production,
+}
+
+/// Redacted rotation state returned by the key-management boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RotationState {
+    Stable,
+    InProgress,
+    Failed,
+    Unknown,
+}
+
+impl RotationState {
+    fn from_code(value: u8) -> Result<Self, KmsError> {
+        match value {
+            0 => Ok(Self::Stable),
+            1 => Ok(Self::InProgress),
+            2 => Ok(Self::Failed),
+            3 => Ok(Self::Unknown),
+            _ => Err(KmsError::InvalidResponse),
+        }
+    }
+}
+
+/// Opaque provider-owned handle. It is persisted but never returned by the
+/// human API and its debug representation never reveals its bytes.
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderKeyReference(Vec<u8>);
+
+impl ProviderKeyReference {
+    /// Creates a bounded, non-empty provider handle.
+    ///
+    /// # Errors
+    ///
+    /// Refuses empty and oversized handles before they reach storage or the
+    /// remote boundary.
+    pub fn new(bytes: Vec<u8>) -> Result<Self, KmsError> {
+        if bytes.is_empty() || bytes.len() > PROVIDER_REFERENCE_LIMIT {
+            return Err(KmsError::InvalidReference);
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Borrows the opaque bytes for a provider implementation.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Debug for ProviderKeyReference {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProviderKeyReference")
+            .field("bytes", &"[redacted]")
+            .field("length", &self.0.len())
+            .finish()
+    }
+}
+
+/// Principal-scoped identity presented on every provider operation.
+#[derive(Clone, Eq, PartialEq)]
+pub struct PrincipalKeyBinding {
+    identity: Vec<u8>,
+    digest: [u8; 32],
+    network_id: u32,
+    class: KeyClass,
+}
+
+impl PrincipalKeyBinding {
+    pub(super) fn new(
+        identity: Vec<u8>,
+        network_id: u32,
+        class: KeyClass,
+        provider_reference: &str,
+    ) -> Result<Self, CustodyError> {
+        let identity_length =
+            u32::try_from(identity.len()).map_err(|_| CustodyError::InvalidKeyReference)?;
+        let provider_length = u32::try_from(provider_reference.len())
+            .map_err(|_| CustodyError::InvalidKeyReference)?;
+        let mut hasher = Sha256::new();
+        hasher.update(b"layerx-human/provider-key-binding/v1\0");
+        hasher.update(identity_length.to_be_bytes());
+        hasher.update(&identity);
+        hasher.update(provider_length.to_be_bytes());
+        hasher.update(provider_reference.as_bytes());
+        hasher.update(network_id.to_be_bytes());
+        let digest = hasher.finalize().into();
+        Ok(Self {
+            identity,
+            digest,
+            network_id,
+            class,
+        })
+    }
+
+    /// Returns the non-reversible principal/key binding sent to a remote KMS.
+    #[must_use]
+    pub const fn digest(&self) -> [u8; 32] {
+        self.digest
+    }
+
+    /// Returns the network whose signatures this key may produce.
+    #[must_use]
+    pub const fn network_id(&self) -> u32 {
+        self.network_id
+    }
+
+    /// Returns the primary-key class held by the provider.
+    #[must_use]
+    pub const fn class(&self) -> KeyClass {
+        self.class
+    }
+
+    pub(super) fn identity(&self) -> &[u8] {
+        &self.identity
+    }
+}
+
+impl Debug for PrincipalKeyBinding {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PrincipalKeyBinding")
+            .field("identity", &"[redacted]")
+            .field("digest", &self.digest)
+            .field("network_id", &self.network_id)
+            .field("class", &self.class)
+            .finish()
+    }
+}
+
+/// Public key facts returned by create, describe and rotate. Private material
+/// is absent by construction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderKeyDescription {
+    reference: ProviderKeyReference,
+    public_key: [u8; 32],
+    binding_digest: [u8; 32],
+    rotation: RotationState,
+}
+
+impl ProviderKeyDescription {
+    /// Constructs a complete provider response.
+    ///
+    /// # Errors
+    ///
+    /// Refuses zero public keys and zero binding digests.
+    pub fn new(
+        reference: ProviderKeyReference,
+        public_key: [u8; 32],
+        binding_digest: [u8; 32],
+        rotation: RotationState,
+    ) -> Result<Self, KmsError> {
+        if public_key == [0; 32] || binding_digest == [0; 32] {
+            return Err(KmsError::InvalidResponse);
+        }
+        Ok(Self {
+            reference,
+            public_key,
+            binding_digest,
+            rotation,
+        })
+    }
+
+    #[must_use]
+    pub fn reference(&self) -> &ProviderKeyReference {
+        &self.reference
+    }
+
+    #[must_use]
+    pub const fn public_key(&self) -> [u8; 32] {
+        self.public_key
+    }
+
+    #[must_use]
+    pub const fn binding_digest(&self) -> [u8; 32] {
+        self.binding_digest
+    }
+
+    #[must_use]
+    pub const fn rotation(&self) -> RotationState {
+        self.rotation
+    }
+}
+
+/// Exact request admitted to a provider signer. It always carries both the
+/// canonical bytes and the structured disclosure used to approve them.
+#[derive(Clone, Copy)]
+pub struct ProviderSignRequest<'a> {
+    canonical_bytes: &'a [u8],
+    disclosure: &'a Disclosure,
+    registry: &'a ModuleRegistry,
+    expected_public_key: [u8; 32],
+}
+
+impl<'a> ProviderSignRequest<'a> {
+    pub(super) const fn new(
+        canonical_bytes: &'a [u8],
+        disclosure: &'a Disclosure,
+        registry: &'a ModuleRegistry,
+        expected_public_key: [u8; 32],
+    ) -> Self {
+        Self {
+            canonical_bytes,
+            disclosure,
+            registry,
+            expected_public_key,
+        }
+    }
+
+    /// Borrows the exact canonical byte string approved by the caller.
+    #[must_use]
+    pub const fn canonical_bytes(&self) -> &'a [u8] {
+        self.canonical_bytes
+    }
+
+    /// Borrows the structured disclosure paired with the bytes.
+    #[must_use]
+    pub const fn disclosure(&self) -> &'a Disclosure {
+        self.disclosure
+    }
+
+    /// Borrows the negotiated module registry used for re-validation.
+    #[must_use]
+    pub const fn registry(&self) -> &'a ModuleRegistry {
+        self.registry
+    }
+
+    /// Returns the public key against which every response is verified.
+    #[must_use]
+    pub const fn expected_public_key(&self) -> [u8; 32] {
+        self.expected_public_key
+    }
+
+    fn validate(self) -> Result<ValidatedSignRequest, CustodyError> {
+        let rebound = bind(self.canonical_bytes, self.registry)
+            .map_err(|error| CustodyError::Sign(layerx_crypto::signer::SignError::from(error)))?;
+        if rebound != *self.disclosure {
+            return Err(CustodyError::Sign(
+                layerx_crypto::signer::SignError::DisclosureMismatch("canonical_bytes"),
+            ));
+        }
+        let reencoded = self
+            .disclosure
+            .reencode()
+            .map_err(|error| CustodyError::Sign(layerx_crypto::signer::SignError::from(error)))?;
+        if !layerx_crypto::ct::eq(&reencoded, self.canonical_bytes) {
+            return Err(CustodyError::Sign(
+                layerx_crypto::signer::SignError::DisclosureMismatch("canonical_bytes"),
+            ));
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(SIGNATURE_DOMAIN);
+        hasher.update(self.canonical_bytes);
+        Ok(ValidatedSignRequest {
+            canonical_digest: hasher.finalize().into(),
+            disclosure: encode_disclosure(self.disclosure)?,
+        })
+    }
+}
+
+impl Debug for ProviderSignRequest<'_> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProviderSignRequest")
+            .field("canonical_bytes", &"[redacted]")
+            .field("disclosure", &"[validated at provider boundary]")
+            .field("expected_public_key", &self.expected_public_key)
+            .finish()
+    }
+}
+
+struct ValidatedSignRequest {
+    canonical_digest: [u8; 32],
+    disclosure: Vec<u8>,
+}
+
+/// Future returned by object-safe KMS provider signing.
+pub type KmsSignFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<[u8; 64], CustodyError>> + Send + 'a>>;
+
+/// Public production custody boundary. Implementations own key creation,
+/// description, rotation, destruction and signing; none can return private key
+/// material through this interface.
+pub trait KmsProvider: Debug + Send + Sync {
+    /// Returns the bounded, non-secret provider or partition reference.
+    #[must_use]
+    fn provider_reference(&self) -> &str;
+
+    /// Declares whether this implementation is permitted in production.
+    #[must_use]
+    fn deployment(&self) -> ProviderDeployment;
+
+    /// Probes the authenticated provider boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns the exact availability, authentication or provider refusal.
+    fn probe(&self) -> Result<(), KmsError>;
+
+    /// Creates a primary key inside the provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed provider refusal and never partial key material.
+    fn create_key(&self, binding: &PrincipalKeyBinding)
+        -> Result<ProviderKeyDescription, KmsError>;
+
+    /// Development-only deterministic creation used by local fixtures.
+    ///
+    /// # Errors
+    ///
+    /// Returns `DevelopmentOnly` unless the implementation is explicitly a
+    /// development provider, or its typed creation refusal.
+    fn create_development_key(
+        &self,
+        _binding: &PrincipalKeyBinding,
+        _entropy: KeyEntropy,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        Err(KmsError::DevelopmentOnly)
+    }
+
+    /// Describes an existing provider key without exporting it.
+    ///
+    /// # Errors
+    ///
+    /// Returns typed absence, availability, authentication and integrity
+    /// refusals.
+    fn describe_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError>;
+
+    /// Rotates an existing provider key and returns its new public facts.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed lifecycle or provider refusal.
+    fn rotate_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError>;
+
+    /// Destroys a provider key. No key bytes are returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed lifecycle or provider refusal.
+    fn destroy_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<(), KmsError>;
+
+    /// Signs only a complete disclosure-bound request and returns only the
+    /// public signature bytes.
+    ///
+    /// # Errors
+    ///
+    /// The returned future resolves to a disclosure, provider, integrity or
+    /// signature refusal.
+    fn sign<'a>(
+        &'a self,
+        binding: &'a PrincipalKeyBinding,
+        reference: &'a ProviderKeyReference,
+        request: ProviderSignRequest<'a>,
+    ) -> KmsSignFuture<'a>;
+}
+
+/// Signer handle owned by the service but backed exclusively by a provider
+/// key reference. It contains no private material and has no export method.
+#[derive(Clone)]
+pub struct RemoteCustodySigner {
+    provider: Arc<dyn KmsProvider>,
+    binding: PrincipalKeyBinding,
+    reference: ProviderKeyReference,
+    public_key: [u8; 32],
+    class: KeyClass,
+}
+
+impl RemoteCustodySigner {
+    pub(super) fn new(
+        provider: Arc<dyn KmsProvider>,
+        binding: PrincipalKeyBinding,
+        description: ProviderKeyDescription,
+        class: KeyClass,
+    ) -> Self {
+        Self {
+            provider,
+            binding,
+            reference: description.reference,
+            public_key: description.public_key,
+            class,
+        }
+    }
+
+    /// Returns the public verification key for this provider handle.
+    #[must_use]
+    pub const fn public_key(&self) -> [u8; 32] {
+        self.public_key
+    }
+
+    /// Returns the primary-key class without exposing the provider handle.
+    #[must_use]
+    pub const fn class(&self) -> KeyClass {
+        self.class
+    }
+
+    /// Sends the exact canonical bytes and matching disclosure to the provider
+    /// and returns only the signature.
+    ///
+    /// # Errors
+    ///
+    /// Refuses a changed disclosure, a provider failure or a signature that
+    /// does not verify against the recorded public key.
+    pub async fn sign_disclosed(
+        &self,
+        canonical_bytes: &[u8],
+        disclosure: &Disclosure,
+        registry: &ModuleRegistry,
+    ) -> Result<[u8; 64], CustodyError> {
+        self.provider
+            .sign(
+                &self.binding,
+                &self.reference,
+                ProviderSignRequest::new(canonical_bytes, disclosure, registry, self.public_key),
+            )
+            .await
+    }
+}
+
+impl Debug for RemoteCustodySigner {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RemoteCustodySigner")
+            .field("provider", &"[remote KMS/HSM]")
+            .field("binding", &self.binding)
+            .field("reference", &"[redacted]")
+            .field("public_key", &self.public_key)
+            .field("class", &self.class)
+            .finish()
+    }
+}
+
+/// Production provider speaking the bounded LayerX KMS protocol over mutual
+/// TLS to a remote KMS/HSM gateway. Every operation opens a fresh authenticated
+/// connection, so a failed connection cannot silently reuse cached authority.
+pub struct RemoteKmsProvider {
+    provider_reference: String,
+    endpoint: SocketAddr,
+    server_name: String,
+    tls: MutualTlsConfig,
+    gate: ConnectionGate,
+    limits: Limits,
+}
+
+impl RemoteKmsProvider {
+    /// Configures a production remote provider from an authenticated transport.
+    ///
+    /// # Errors
+    ///
+    /// Refuses invalid provider references, empty server identities and
+    /// transport limits before the provider can be selected. Production
+    /// startup authenticates the parsed DNS identity through `probe`.
+    pub fn new(
+        provider_reference: impl Into<String>,
+        endpoint: SocketAddr,
+        server_name: impl Into<String>,
+        tls: MutualTlsConfig,
+        limits: Limits,
+    ) -> Result<Self, CustodyError> {
+        let provider_reference = provider_reference.into();
+        if provider_reference.is_empty()
+            || provider_reference.len() > super::KEY_REFERENCE_LIMIT
+            || provider_reference.as_bytes().contains(&0)
+        {
+            return Err(CustodyError::InvalidKeyReference);
+        }
+        let server_name = server_name.into();
+        if server_name.is_empty() || server_name.as_bytes().contains(&0) {
+            return Err(CustodyError::Kms(KmsError::Authentication));
+        }
+        let limits = limits
+            .validate()
+            .map_err(|_| CustodyError::Kms(KmsError::InvalidConfiguration))?;
+        if limits.maximum_frame_bytes > PROVIDER_FRAME_LIMIT {
+            return Err(CustodyError::Kms(KmsError::InvalidConfiguration));
+        }
+        Ok(Self {
+            provider_reference,
+            endpoint,
+            server_name,
+            tls,
+            gate: ConnectionGate::new(limits.maximum_connections),
+            limits,
+        })
+    }
+
+    fn call(&self, operation: u8, request: Vec<u8>) -> Result<Vec<u8>, KmsError> {
+        if request.len() > self.limits.maximum_frame_bytes {
+            return Err(KmsError::InvalidConfiguration);
+        }
+        let server_name = self
+            .server_name
+            .clone()
+            .try_into()
+            .map_err(|_| KmsError::Authentication)?;
+        let mut transport = Tls::connect(
+            self.endpoint,
+            server_name,
+            &self.tls,
+            &self.gate,
+            self.limits,
+        )
+        .map_err(map_transport)?;
+        transport.send(&request).map_err(map_transport)?;
+        let response = transport.receive().map_err(map_transport)?;
+        decode_response(operation, &response)
+    }
+
+    fn key_operation(
+        &self,
+        operation: u8,
+        binding: &PrincipalKeyBinding,
+        reference: Option<&ProviderKeyReference>,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        let request = encode_key_request(operation, &self.provider_reference, binding, reference)?;
+        let response = self.call(operation, request)?;
+        decode_description(&response, binding)
+    }
+}
+
+impl Debug for RemoteKmsProvider {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RemoteKmsProvider")
+            .field("provider_reference", &self.provider_reference)
+            .field("endpoint", &"[mutually authenticated remote endpoint]")
+            .field("server_name", &self.server_name)
+            .field("limits", &self.limits)
+            .finish_non_exhaustive()
+    }
+}
+
+impl KmsProvider for RemoteKmsProvider {
+    fn provider_reference(&self) -> &str {
+        &self.provider_reference
+    }
+
+    fn deployment(&self) -> ProviderDeployment {
+        ProviderDeployment::Production
+    }
+
+    fn probe(&self) -> Result<(), KmsError> {
+        let request = encode_header(OP_PROBE, &self.provider_reference)?;
+        let response = self.call(OP_PROBE, request)?;
+        if response.is_empty() {
+            Ok(())
+        } else {
+            Err(KmsError::InvalidResponse)
+        }
+    }
+
+    fn create_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        self.key_operation(OP_CREATE, binding, None)
+    }
+
+    fn describe_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        self.key_operation(OP_DESCRIBE, binding, Some(reference))
+    }
+
+    fn rotate_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        self.key_operation(OP_ROTATE, binding, Some(reference))
+    }
+
+    fn destroy_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<(), KmsError> {
+        let request = encode_key_request(
+            OP_DESTROY,
+            &self.provider_reference,
+            binding,
+            Some(reference),
+        )?;
+        let response = self.call(OP_DESTROY, request)?;
+        if response.is_empty() {
+            Ok(())
+        } else {
+            Err(KmsError::InvalidResponse)
+        }
+    }
+
+    fn sign<'a>(
+        &'a self,
+        binding: &'a PrincipalKeyBinding,
+        reference: &'a ProviderKeyReference,
+        request: ProviderSignRequest<'a>,
+    ) -> KmsSignFuture<'a> {
+        Box::pin(async move {
+            let validated = request.validate()?;
+            let frame = encode_sign_request(
+                &self.provider_reference,
+                binding,
+                reference,
+                request.canonical_bytes,
+                &validated,
+            )?;
+            let response = self.call(OP_SIGN, frame)?;
+            let signature: [u8; 64] = response
+                .as_slice()
+                .try_into()
+                .map_err(|_| CustodyError::Kms(KmsError::InvalidResponse))?;
+            layerx_crypto::ed25519::verify_digest(
+                &request.expected_public_key,
+                &signature,
+                &validated.canonical_digest,
+            )
+            .map_err(|_| {
+                CustodyError::Sign(layerx_crypto::signer::SignError::ReturnedSignatureInvalid)
+            })?;
+            Ok(signature)
+        })
+    }
+}
+
+impl KmsProvider for EnvelopeKms {
+    fn provider_reference(&self) -> &str {
+        &self.key_reference
+    }
+
+    fn deployment(&self) -> ProviderDeployment {
+        ProviderDeployment::DevelopmentOnly
+    }
+
+    fn probe(&self) -> Result<(), KmsError> {
+        self.root_secret().map(|_| ())
+    }
+
+    fn create_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        let mut seed = Zeroizing::new([0_u8; 32]);
+        let mut salt = [0_u8; 16];
+        let mut nonce = [0_u8; 24];
+        getrandom::fill(&mut *seed).map_err(|_| KmsError::Unavailable)?;
+        getrandom::fill(&mut salt).map_err(|_| KmsError::Unavailable)?;
+        getrandom::fill(&mut nonce).map_err(|_| KmsError::Unavailable)?;
+        let entropy = KeyEntropy::new(*seed, salt, nonce).map_err(|_| KmsError::Refused)?;
+        self.create_development_key(binding, entropy)
+    }
+
+    fn create_development_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        entropy: KeyEntropy,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        let KeyEntropy { seed, envelope } = entropy;
+        let public_key = LocalSigner::new(*seed).public_key();
+        let root = self.root_secret()?;
+        let envelope = layerx_crypto::keystore::Keystore::seal(
+            &seed,
+            &root,
+            binding.identity(),
+            binding.network_id,
+            envelope,
+        )
+        .map_err(seal_refusal)?;
+        let reference = ProviderKeyReference::new(envelope.to_bytes().map_err(seal_refusal)?)?;
+        ProviderKeyDescription::new(reference, public_key, binding.digest, RotationState::Stable)
+    }
+
+    fn describe_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        let root = self.root_secret()?;
+        let envelope = layerx_crypto::keystore::Keystore::from_bytes(reference.as_bytes())
+            .map_err(seal_refusal)?;
+        let seed = envelope
+            .open(&root, binding.identity(), binding.network_id)
+            .map_err(seal_refusal)?;
+        let public_key = LocalSigner::from_secret(seed).public_key();
+        ProviderKeyDescription::new(
+            reference.clone(),
+            public_key,
+            binding.digest,
+            RotationState::Stable,
+        )
+    }
+
+    fn rotate_key(
+        &self,
+        binding: &PrincipalKeyBinding,
+        _reference: &ProviderKeyReference,
+    ) -> Result<ProviderKeyDescription, KmsError> {
+        self.create_key(binding)
+    }
+
+    fn destroy_key(
+        &self,
+        _binding: &PrincipalKeyBinding,
+        _reference: &ProviderKeyReference,
+    ) -> Result<(), KmsError> {
+        Ok(())
+    }
+
+    fn sign<'a>(
+        &'a self,
+        binding: &'a PrincipalKeyBinding,
+        reference: &'a ProviderKeyReference,
+        request: ProviderSignRequest<'a>,
+    ) -> KmsSignFuture<'a> {
+        Box::pin(async move {
+            let _ = request.validate()?;
+            let root = self.root_secret()?;
+            let envelope = layerx_crypto::keystore::Keystore::from_bytes(reference.as_bytes())
+                .map_err(seal_refusal)?;
+            let seed = envelope
+                .open(&root, binding.identity(), binding.network_id)
+                .map_err(seal_refusal)?;
+            let signer = LocalSigner::from_secret(seed);
+            if signer.public_key() != request.expected_public_key {
+                return Err(CustodyError::Kms(KmsError::Integrity));
+            }
+            sign_disclosed(
+                &signer,
+                request.canonical_bytes,
+                request.disclosure,
+                request.registry,
+            )
+            .await
+            .map(|signature| *signature.as_bytes())
+            .map_err(CustodyError::Sign)
+        })
+    }
+}
+
+fn encode_header(operation: u8, provider_reference: &str) -> Result<Vec<u8>, KmsError> {
+    let mut writer = WireWriter::new();
+    writer.fixed(PROVIDER_MAGIC)?;
+    writer.u16(PROVIDER_VERSION)?;
+    writer.u8(operation)?;
+    writer.bytes(provider_reference.as_bytes(), super::KEY_REFERENCE_LIMIT)?;
+    Ok(writer.finish())
+}
+
+fn encode_key_request(
+    operation: u8,
+    provider_reference: &str,
+    binding: &PrincipalKeyBinding,
+    reference: Option<&ProviderKeyReference>,
+) -> Result<Vec<u8>, KmsError> {
+    let mut writer = WireWriter::from_bytes(encode_header(operation, provider_reference)?);
+    writer.fixed(&binding.digest)?;
+    writer.u32(binding.network_id)?;
+    writer.u8(binding.class.code())?;
+    match reference {
+        Some(reference) => writer.bytes(reference.as_bytes(), PROVIDER_REFERENCE_LIMIT)?,
+        None => writer.bytes(&[], PROVIDER_REFERENCE_LIMIT)?,
+    }
+    Ok(writer.finish())
+}
+
+fn encode_sign_request(
+    provider_reference: &str,
+    binding: &PrincipalKeyBinding,
+    reference: &ProviderKeyReference,
+    canonical: &[u8],
+    validated: &ValidatedSignRequest,
+) -> Result<Vec<u8>, CustodyError> {
+    let mut writer = WireWriter::from_bytes(encode_header(OP_SIGN, provider_reference)?);
+    writer.fixed(&binding.digest)?;
+    writer.u32(binding.network_id)?;
+    writer.u8(binding.class.code())?;
+    writer.bytes(reference.as_bytes(), PROVIDER_REFERENCE_LIMIT)?;
+    writer.fixed(&validated.canonical_digest)?;
+    writer.bytes(canonical, PROVIDER_FRAME_LIMIT)?;
+    writer.bytes(&validated.disclosure, PROVIDER_FRAME_LIMIT)?;
+    let frame = writer.finish();
+    if frame.len() > PROVIDER_FRAME_LIMIT {
+        return Err(CustodyError::Kms(KmsError::InvalidConfiguration));
+    }
+    Ok(frame)
+}
+
+fn encode_disclosure(disclosure: &Disclosure) -> Result<Vec<u8>, CustodyError> {
+    let mut writer = WireWriter::new();
+    writer.u8(1)?;
+    writer.u32(disclosure.activity_type.value())?;
+    writer.bytes(&disclosure.actor, 255)?;
+    writer.bytes(&disclosure.authority, 524_288)?;
+    writer.u32(
+        u32::try_from(disclosure.counterparties.len())
+            .map_err(|_| CustodyError::Kms(KmsError::InvalidConfiguration))?,
+    )?;
+    for counterparty in &disclosure.counterparties {
+        writer.u8(match counterparty.role {
+            layerx_crypto::disclosure::CounterpartyRole::Payer => 1,
+            layerx_crypto::disclosure::CounterpartyRole::Recipient => 2,
+        })?;
+        writer.fixed(&counterparty.account)?;
+    }
+    writer.u32(
+        u32::try_from(disclosure.amounts.len())
+            .map_err(|_| CustodyError::Kms(KmsError::InvalidConfiguration))?,
+    )?;
+    for amount in &disclosure.amounts {
+        writer.u8(match amount.role {
+            layerx_crypto::disclosure::AmountRole::Transfer => 1,
+            layerx_crypto::disclosure::AmountRole::SpendingLimit => 2,
+        })?;
+        writer.fixed(&amount.value.to_be_bytes())?;
+    }
+    writer.fixed(&disclosure.asset)?;
+    writer.fixed(&disclosure.fee_limit.to_be_bytes())?;
+    writer.fixed(&disclosure.expiry.not_before.to_be_bytes())?;
+    writer.fixed(&disclosure.expiry.not_after.to_be_bytes())?;
+    writer.fixed(&disclosure.expiry.payload_expires_at.to_be_bytes())?;
+    writer.fixed(&disclosure.idempotency_key)?;
+    match disclosure.evm_payout_binding {
+        Some(binding) => {
+            writer.u8(1)?;
+            writer.fixed(&binding.did_id)?;
+            writer.u32(binding.network_id)?;
+            writer.fixed(&binding.payout_address)?;
+            writer.fixed(&binding.ownership_signature_digest)?;
+        }
+        None => writer.u8(0)?,
+    }
+    Ok(writer.finish())
+}
+
+fn decode_response(operation: u8, bytes: &[u8]) -> Result<Vec<u8>, KmsError> {
+    let mut reader = WireReader::new(bytes);
+    if reader.fixed(4)? != PROVIDER_MAGIC
+        || reader.u16()? != PROVIDER_VERSION
+        || reader.u8()? != operation
+    {
+        return Err(KmsError::InvalidResponse);
+    }
+    let status = reader.u8()?;
+    if status == STATUS_OK {
+        return Ok(reader.remaining().to_vec());
+    }
+    if !reader.remaining().is_empty() {
+        return Err(KmsError::InvalidResponse);
+    }
+    match status {
+        STATUS_REFUSED => Err(KmsError::Refused),
+        STATUS_NOT_FOUND => Err(KmsError::KeyNotFound),
+        STATUS_CONFLICT => Err(KmsError::Conflict),
+        STATUS_UNAVAILABLE => Err(KmsError::Unavailable),
+        STATUS_INTEGRITY => Err(KmsError::Integrity),
+        _ => Err(KmsError::InvalidResponse),
+    }
+}
+
+fn decode_description(
+    bytes: &[u8],
+    binding: &PrincipalKeyBinding,
+) -> Result<ProviderKeyDescription, KmsError> {
+    let mut reader = WireReader::new(bytes);
+    let reference = ProviderKeyReference::new(reader.bytes(PROVIDER_REFERENCE_LIMIT)?.to_vec())?;
+    let public_key = reader
+        .fixed(32)?
+        .try_into()
+        .map_err(|_| KmsError::InvalidResponse)?;
+    let binding_digest = reader
+        .fixed(32)?
+        .try_into()
+        .map_err(|_| KmsError::InvalidResponse)?;
+    let rotation = RotationState::from_code(reader.u8()?)?;
+    reader.finish()?;
+    if !layerx_crypto::ct::eq_fixed(&binding_digest, &binding.digest) {
+        return Err(KmsError::Integrity);
+    }
+    ProviderKeyDescription::new(reference, public_key, binding_digest, rotation)
+}
+
+fn map_transport(error: TransportError) -> KmsError {
+    match error {
+        TransportError::Deadline => KmsError::Timeout,
+        TransportError::TlsConfiguration => KmsError::Authentication,
+        TransportError::Frame(_) | TransportError::PeerShutdown | TransportError::Backpressure => {
+            KmsError::InvalidResponse
+        }
+        TransportError::ConnectionFailure(_)
+        | TransportError::ConnectionLimit
+        | TransportError::StreamLimit => KmsError::Unavailable,
+    }
+}
+
+struct WireWriter {
+    bytes: Vec<u8>,
+}
+
+impl WireWriter {
+    fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    fn from_bytes(bytes: Vec<u8>) -> Self {
+        Self { bytes }
+    }
+
+    fn u8(&mut self, value: u8) -> Result<(), KmsError> {
+        self.extend(&[value])
+    }
+
+    fn u16(&mut self, value: u16) -> Result<(), KmsError> {
+        self.extend(&value.to_be_bytes())
+    }
+
+    fn u32(&mut self, value: u32) -> Result<(), KmsError> {
+        self.extend(&value.to_be_bytes())
+    }
+
+    fn fixed(&mut self, value: &[u8]) -> Result<(), KmsError> {
+        self.extend(value)
+    }
+
+    fn bytes(&mut self, value: &[u8], maximum: usize) -> Result<(), KmsError> {
+        if value.len() > maximum {
+            return Err(KmsError::InvalidConfiguration);
+        }
+        let length = u32::try_from(value.len()).map_err(|_| KmsError::InvalidConfiguration)?;
+        self.u32(length)?;
+        self.extend(value)
+    }
+
+    fn extend(&mut self, value: &[u8]) -> Result<(), KmsError> {
+        let next = self
+            .bytes
+            .len()
+            .checked_add(value.len())
+            .ok_or(KmsError::InvalidConfiguration)?;
+        if next > PROVIDER_FRAME_LIMIT {
+            return Err(KmsError::InvalidConfiguration);
+        }
+        self.bytes.extend_from_slice(value);
+        Ok(())
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+struct WireReader<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> WireReader<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn fixed(&mut self, length: usize) -> Result<&'a [u8], KmsError> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(KmsError::InvalidResponse)?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or(KmsError::InvalidResponse)?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, KmsError> {
+        Ok(self.fixed(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, KmsError> {
+        let bytes = self
+            .fixed(2)?
+            .try_into()
+            .map_err(|_| KmsError::InvalidResponse)?;
+        Ok(u16::from_be_bytes(bytes))
+    }
+
+    fn u32(&mut self) -> Result<u32, KmsError> {
+        let bytes = self
+            .fixed(4)?
+            .try_into()
+            .map_err(|_| KmsError::InvalidResponse)?;
+        Ok(u32::from_be_bytes(bytes))
+    }
+
+    fn bytes(&mut self, maximum: usize) -> Result<&'a [u8], KmsError> {
+        let length = usize::try_from(self.u32()?).map_err(|_| KmsError::InvalidResponse)?;
+        if length > maximum {
+            return Err(KmsError::InvalidResponse);
+        }
+        self.fixed(length)
+    }
+
+    fn remaining(&self) -> &'a [u8] {
+        &self.bytes[self.offset..]
+    }
+
+    fn finish(self) -> Result<(), KmsError> {
+        if self.offset == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(KmsError::InvalidResponse)
+        }
+    }
+}

--- a/human/crates/layerx-human-service/src/custody/signer.rs
+++ b/human/crates/layerx-human-service/src/custody/signer.rs
@@ -2,7 +2,6 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Mutex, MutexGuard};
 
 use layerx_crypto::disclosure::Disclosure;
-use layerx_crypto::signer::{sign_disclosed, Signer as _};
 use layerx_types::payload::ModuleRegistry;
 
 use crate::audit::{
@@ -337,7 +336,7 @@ impl CustodySigner {
             return Err(error);
         }
 
-        let (signer, _class) = match self.keystore.unseal_signer(request.principal, request.key) {
+        let signer = match self.keystore.remote_signer(request.principal, request.key) {
             Ok(signer) => signer,
             Err(error) => {
                 self.append_decision(&request, Some(disclosure_digest), Some(&error))?;
@@ -345,17 +344,12 @@ impl CustodySigner {
             }
         };
         let signer_public_key = signer.public_key();
-        let signature = match sign_disclosed(
-            &signer,
-            request.canonical_bytes,
-            request.disclosure,
-            &self.registry,
-        )
-        .await
+        let signature = match signer
+            .sign_disclosed(request.canonical_bytes, request.disclosure, &self.registry)
+            .await
         {
-            Ok(signature) => *signature.as_bytes(),
+            Ok(signature) => signature,
             Err(error) => {
-                let error = CustodyError::Sign(error);
                 self.append_decision(&request, Some(disclosure_digest), Some(&error))?;
                 return Err(error);
             }
@@ -408,7 +402,7 @@ impl CustodySigner {
             return Err(error);
         }
 
-        let (signer, _class) = match self.keystore.unseal_signer(request.principal, request.key) {
+        let signer = match self.keystore.remote_signer(request.principal, request.key) {
             Ok(signer) => signer,
             Err(error) => {
                 append_decision_to_scope(scope, &request, Some(disclosure_digest), Some(&error))?;
@@ -416,17 +410,12 @@ impl CustodySigner {
             }
         };
         let signer_public_key = signer.public_key();
-        let signature = match sign_disclosed(
-            &signer,
-            request.canonical_bytes,
-            request.disclosure,
-            &self.registry,
-        )
-        .await
+        let signature = match signer
+            .sign_disclosed(request.canonical_bytes, request.disclosure, &self.registry)
+            .await
         {
-            Ok(signature) => *signature.as_bytes(),
+            Ok(signature) => signature,
             Err(error) => {
-                let error = CustodyError::Sign(error);
                 append_decision_to_scope(scope, &request, Some(disclosure_digest), Some(&error))?;
                 return Err(error);
             }

--- a/human/crates/layerx-human-service/src/health.rs
+++ b/human/crates/layerx-human-service/src/health.rs
@@ -1,5 +1,7 @@
 use layerx_paxeer_client::{BoundaryHealth, BoundaryStatus};
 
+use crate::custody::{Availability, CustodyStatus, KeyReferenceIntegrity, RotationState};
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ComponentHealth {
     Ready,
@@ -27,7 +29,93 @@ pub struct ServiceReadiness {
     pub unavailable: Vec<HealthComponent>,
 }
 
+/// Redacted custody details safe for status responses, logs and metrics. The
+/// model deliberately carries no provider reference, key identifier, payload
+/// or principal value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RedactedCustodyHealth {
+    pub provider: ComponentHealth,
+    pub storage: ComponentHealth,
+    pub key_references: ComponentHealth,
+    pub rotation: ComponentHealth,
+}
+
+impl RedactedCustodyHealth {
+    /// Projects internal custody status into fixed, non-secret reason strings.
+    #[must_use]
+    pub fn from_status(status: CustodyStatus) -> Self {
+        Self {
+            provider: match status.kms {
+                Availability::Available => ComponentHealth::Ready,
+                Availability::Unavailable => ComponentHealth::Degraded {
+                    reason: "remote custody provider unavailable".to_owned(),
+                },
+            },
+            storage: match status.storage {
+                Availability::Available => ComponentHealth::Ready,
+                Availability::Unavailable => ComponentHealth::Unavailable {
+                    reason: "custody record storage unavailable".to_owned(),
+                },
+            },
+            key_references: match status.key_references {
+                KeyReferenceIntegrity::Verified => ComponentHealth::Ready,
+                KeyReferenceIntegrity::Failed => ComponentHealth::Unavailable {
+                    reason: "custody key-reference integrity failed".to_owned(),
+                },
+                KeyReferenceIntegrity::Unknown => ComponentHealth::Degraded {
+                    reason: "custody key-reference integrity is unknown".to_owned(),
+                },
+            },
+            rotation: match status.rotation {
+                RotationState::Stable => ComponentHealth::Ready,
+                RotationState::InProgress => ComponentHealth::Degraded {
+                    reason: "custody key rotation is in progress".to_owned(),
+                },
+                RotationState::Failed => ComponentHealth::Degraded {
+                    reason: "custody key rotation failed".to_owned(),
+                },
+                RotationState::Unknown => ComponentHealth::Degraded {
+                    reason: "custody key rotation state is unknown".to_owned(),
+                },
+            },
+        }
+    }
+
+    fn service_component(&self) -> ComponentHealth {
+        for component in [
+            &self.storage,
+            &self.key_references,
+            &self.provider,
+            &self.rotation,
+        ] {
+            if matches!(component, ComponentHealth::Unavailable { .. }) {
+                return component.clone();
+            }
+        }
+        for component in [
+            &self.provider,
+            &self.key_references,
+            &self.rotation,
+            &self.storage,
+        ] {
+            if matches!(component, ComponentHealth::Degraded { .. }) {
+                return component.clone();
+            }
+        }
+        ComponentHealth::Ready
+    }
+}
+
 impl ServiceHealth {
+    /// Merges custody readiness into the existing human-service component
+    /// while retaining a separately consumable redacted custody projection.
+    #[must_use]
+    pub fn with_custody_status(mut self, status: CustodyStatus) -> Self {
+        let custody = RedactedCustodyHealth::from_status(status).service_component();
+        self.human_service = merge_component(self.human_service, custody);
+        self
+    }
+
     #[must_use]
     pub fn readiness(&self) -> ServiceReadiness {
         let mut unavailable = Vec::new();
@@ -44,5 +132,15 @@ impl ServiceHealth {
             ready: unavailable.is_empty(),
             unavailable,
         }
+    }
+}
+
+fn merge_component(current: ComponentHealth, custody: ComponentHealth) -> ComponentHealth {
+    match (&current, &custody) {
+        (ComponentHealth::Unavailable { .. }, _)
+        | (_, ComponentHealth::Ready)
+        | (ComponentHealth::Degraded { .. }, ComponentHealth::Degraded { .. }) => current,
+        (_, ComponentHealth::Unavailable { .. })
+        | (ComponentHealth::Ready, ComponentHealth::Degraded { .. }) => custody,
     }
 }

--- a/human/crates/layerx-human-service/src/onboarding/mod.rs
+++ b/human/crates/layerx-human-service/src/onboarding/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
 use crate::audit::{AuditChain, AuditError, AuditEvent, IdentityEvent};
-use crate::custody::{CustodyError, KeyClass, KeyEntropy, KeyId, Keystore};
+use crate::custody::{CustodyError, KeyClass, KeyId, Keystore};
 use crate::store::{EvidenceRef, PrincipalScope, RowKey, StoreError, Table};
 use crate::trace::TraceId;
 
@@ -573,9 +573,7 @@ impl OnboardingJourney {
         let descriptor = match keystore.describe(scope.principal(), &key_id) {
             Ok(descriptor) => descriptor,
             Err(CustodyError::KeyNotFound) => {
-                let entropy = fresh_key_entropy()?;
-                match keystore.generate(scope.principal(), &key_id, KeyClass::HumanPrimary, entropy)
-                {
+                match keystore.create(scope.principal(), &key_id, KeyClass::HumanPrimary) {
                     Ok(public_key) => crate::custody::KeyDescriptor {
                         class: KeyClass::HumanPrimary,
                         public_key,
@@ -1253,16 +1251,6 @@ fn hash_text(digest: &mut Sha256, value: &str) {
     let length = u32::try_from(value.len()).unwrap_or(u32::MAX);
     digest.update(length.to_be_bytes());
     digest.update(value.as_bytes());
-}
-
-fn fresh_key_entropy() -> Result<KeyEntropy, OnboardingError> {
-    let mut seed = [0_u8; 32];
-    let mut salt = [0_u8; 16];
-    let mut nonce = [0_u8; 24];
-    getrandom::fill(&mut seed).map_err(|_| OnboardingError::EntropyUnavailable)?;
-    getrandom::fill(&mut salt).map_err(|_| OnboardingError::EntropyUnavailable)?;
-    getrandom::fill(&mut nonce).map_err(|_| OnboardingError::EntropyUnavailable)?;
-    KeyEntropy::new(seed, salt, nonce).map_err(Into::into)
 }
 
 fn encode_key_evidence(

--- a/human/crates/layerx-human-service/tests/agent_create.rs
+++ b/human/crates/layerx-human-service/tests/agent_create.rs
@@ -60,7 +60,7 @@ impl Fixture {
         fs::write(&kms_secret, [0x42; 64]).unwrap_or_else(|error| panic!("KMS secret: {error}"));
         let kms = EnvelopeKms::new("kms://agent-create", kms_secret)
             .unwrap_or_else(|error| panic!("KMS: {error}"));
-        let keystore = Keystore::open(root.join("custody"), NETWORK_ID, kms)
+        let keystore = Keystore::open_development(root.join("custody"), NETWORK_ID, kms)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let governance = ModuleRegistration::new(
             ModuleId::Governance,

--- a/human/crates/layerx-human-service/tests/custody.rs
+++ b/human/crates/layerx-human-service/tests/custody.rs
@@ -176,7 +176,7 @@ impl Fixture {
     fn keystore(&self) -> Keystore {
         let provider = EnvelopeKms::new("file-kms://human-primary", &self.secret_path)
             .unwrap_or_else(|error| panic!("KMS provider: {error}"));
-        Keystore::open(&self.custody_root, NETWORK_ID, provider)
+        Keystore::open_development(&self.custody_root, NETWORK_ID, provider)
             .unwrap_or_else(|error| panic!("keystore: {error}"))
     }
 
@@ -670,7 +670,7 @@ fn principal_symlinks_are_refused_before_any_key_access() {
     let provider = EnvelopeKms::new("file-kms://human-primary", &fixture.secret_path)
         .unwrap_or_else(|error| panic!("KMS provider: {error}"));
     assert!(matches!(
-        Keystore::open(&fixture.custody_root, NETWORK_ID, provider),
+        Keystore::open_development(&fixture.custody_root, NETWORK_ID, provider),
         Err(CustodyError::CorruptRecord("foreign principals entry"))
     ));
 }

--- a/human/crates/layerx-human-service/tests/deposit.rs
+++ b/human/crates/layerx-human-service/tests/deposit.rs
@@ -982,7 +982,7 @@ impl Fixture {
         fs::write(&secret, [0x42; 64]).unwrap_or_else(|error| panic!("KMS root: {error}"));
         let provider = EnvelopeKms::new("file-kms://human-primary", &secret)
             .unwrap_or_else(|error| panic!("KMS provider: {error}"));
-        let keystore = Keystore::open(root.join("custody"), NETWORK_ID, provider)
+        let keystore = Keystore::open_development(root.join("custody"), NETWORK_ID, provider)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let custody_key =
             KeyId::new("human-primary").unwrap_or_else(|error| panic!("key id: {error}"));

--- a/human/crates/layerx-human-service/tests/journey_faults.rs
+++ b/human/crates/layerx-human-service/tests/journey_faults.rs
@@ -679,7 +679,7 @@ impl Fixture {
         let principal = principal("alice");
         let provider = EnvelopeKms::new("file-kms://human-primary", &secret_path)
             .unwrap_or_else(|error| panic!("KMS provider: {error}"));
-        let keystore = Keystore::open(root.join("custody"), NETWORK_ID, provider)
+        let keystore = Keystore::open_development(root.join("custody"), NETWORK_ID, provider)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let key = KeyId::new("human-primary").unwrap_or_else(|error| panic!("key id: {error}"));
         let public_key = keystore

--- a/human/crates/layerx-human-service/tests/move_money.rs
+++ b/human/crates/layerx-human-service/tests/move_money.rs
@@ -675,7 +675,7 @@ impl Fixture {
         let principal = principal("alice");
         let provider = EnvelopeKms::new("file-kms://human-primary", &secret)
             .unwrap_or_else(|error| panic!("provider: {error}"));
-        let keystore = Keystore::open(root.join("custody"), NETWORK_ID, provider)
+        let keystore = Keystore::open_development(root.join("custody"), NETWORK_ID, provider)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let key = KeyId::new("human-primary").unwrap_or_else(|error| panic!("key: {error}"));
         let public_key = keystore

--- a/human/crates/layerx-human-service/tests/onboarding.rs
+++ b/human/crates/layerx-human-service/tests/onboarding.rs
@@ -54,7 +54,7 @@ impl Fixture {
         let (store, digest) = install_and_open(&store_root, &map, retention_uniform(10));
         let kms = EnvelopeKms::new("kms://onboarding-primary", secret_path.clone())
             .unwrap_or_else(|error| panic!("KMS: {error}"));
-        let keystore = Keystore::open(&custody_root, NETWORK_ID, kms)
+        let keystore = Keystore::open_development(&custody_root, NETWORK_ID, kms)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let did = ActivityType::new(ModuleId::Governance, 1)
             .unwrap_or_else(|error| panic!("DID activity: {error:?}"));

--- a/human/crates/layerx-human-service/tests/session_keys.rs
+++ b/human/crates/layerx-human-service/tests/session_keys.rs
@@ -614,7 +614,7 @@ fn keystore(
     fs::write(&secret_path, [0xa5; 64]).unwrap_or_else(|error| panic!("KMS root: {error}"));
     let provider = EnvelopeKms::new("file-kms://rotation", secret_path)
         .unwrap_or_else(|error| panic!("KMS provider: {error}"));
-    let keystore = Keystore::open(root.join("sealed"), NETWORK_ID, provider)
+    let keystore = Keystore::open_development(root.join("sealed"), NETWORK_ID, provider)
         .unwrap_or_else(|error| panic!("keystore: {error}"));
     let current =
         KeyId::new("current-primary").unwrap_or_else(|error| panic!("current key id: {error}"));

--- a/human/crates/layerx-human-service/tests/withdraw.rs
+++ b/human/crates/layerx-human-service/tests/withdraw.rs
@@ -672,7 +672,7 @@ impl Fixture {
         let principal = principal("alice");
         let provider = EnvelopeKms::new("file-kms://human-primary", &secret_path)
             .unwrap_or_else(|error| panic!("KMS provider: {error}"));
-        let keystore = Keystore::open(root.join("custody"), NETWORK_ID, provider)
+        let keystore = Keystore::open_development(root.join("custody"), NETWORK_ID, provider)
             .unwrap_or_else(|error| panic!("keystore: {error}"));
         let key = KeyId::new("human-primary").unwrap_or_else(|error| panic!("key id: {error}"));
         keystore

--- a/spec/layerx-platform/qualification.kvx
+++ b/spec/layerx-platform/qualification.kvx
@@ -6,6 +6,30 @@ observed = "The Programs transition expands module-registration commitments to i
 assumption = "Human qualification will replay roots immediately before and after Programs activation to confirm the intended version boundary."
 severity = "note"
 
+[observation.5.8.1]
+task = "5.8"
+file = "human/crates/layerx-human-service/tests/custody.rs"
+symbol = "copied_principal_record_cannot_cross_the_authenticated_kms_identity"
+observed = "The inherited assertion expects a copied principal record to return KmsError::Refused. The provider-backed record now carries an explicit principal/key binding digest and rejects the copy earlier as KmsError::Integrity, which is the new typed key-reference-integrity refusal required by task 5.8. The assertion was left intact rather than weakened or silently rewritten during implementation."
+assumption = "Human qualification will confirm the more specific integrity refusal and update the expected taxonomy only if the production provider contract is accepted."
+severity = "check-conflict"
+
+[observation.5.8.2]
+task = "5.8"
+file = "spec/layerx-platform/spec.kvx"
+symbol = "task.5.8 touches"
+observed = "The declared touch list names provider.rs, signer.rs and health.rs but omits custody/mod.rs, the two production key-creation call sites and development fixture constructors. The required public provider export, provider-backed record format, production startup refusal and remote key-creation path cannot be wired without those omitted files, so strict scope guard reports the necessary implementation paths outside the declaration."
+assumption = "Human qualification will review the necessary integration paths and reconcile task.5.8's touch declaration rather than removing the production boundary wiring."
+severity = "task-scope"
+
+[observation.5.8.3]
+task = "5.8"
+file = "human/crates/layerx-human-service/src/custody/mod.rs"
+symbol = "Keystore::open"
+observed = "Task 5.8 requires replacing the mounted-root-secret production path but specifies no import or migration ceremony for existing v1 file-envelope primary keys. The implementation keeps legacy envelope records readable only through the explicitly development-only constructor and makes production startup accept only a ready remote provider; it does not unwrap and re-import old primary keys into application memory."
+assumption = "Before production cutover, human qualification will define and exercise a protocol key-rotation ceremony from every legacy primary key to a remotely generated KMS/HSM key, then confirm no legacy envelope is needed by production startup."
+severity = "migration-boundary"
+
 [observation.19.4.2]
 task = "19.4"
 file = "include/layerx/lxp_receipt.h"

--- a/spec/layerx-platform/spec.kvx
+++ b/spec/layerx-platform/spec.kvx
@@ -1053,7 +1053,7 @@ reqs = ["5.1","5.4","5.6","5.8"]
 
 [task.5.8]
 title = "Replace the mounted root secret with a production KMS boundary"
-status = "pending"
+status = "implemented"
 wave = 7
 requires = ["5.3"]
 work_kind = "implementation"

--- a/spec/layerx-platform/tasks.md
+++ b/spec/layerx-platform/tasks.md
@@ -280,7 +280,7 @@ surface makes the evidence portable while custody never leaves Paxeer.
     - Implement rebinding under step-up, keeping the old binding effective until the new receipt verifies, with the security notification.
     - Enforce the single-active-binding invariant, record every binding with its receipts in the audit trail, and test binding and rebinding end to end against a real core.
     - _Requirements: 5.1, 5.4, 5.6, 5.8_
-  - [ ] 5.8 Replace the mounted root secret with a production KMS boundary
+  - [ ] 5.8 Replace the mounted root secret with a production KMS boundary — **Implemented - qualification pending**
     - Refactor custody around a public provider boundary whose production implementation creates, describes, rotates and destroys human and managed-agent keys in a remote KMS or HSM without exporting private key material.
     - Move disclosure-bound signing into that provider so the service submits the exact canonical digest and receives only a signature; no production path may unseal a primary key into application memory.
     - Bind provider key references to principal-scoped records and preserve step-up, audit, rate-limit and typed-refusal semantics across provider failures.


### PR DESCRIPTION
## Summary

Describe the change, the affected trust boundary, and why it is necessary.

## Specification

- Requirement clause(s):
- Codify task:
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI:

## Verification

List every command run and its exact outcome. Explain any gate not run.

## Checklist

- [ ] I changed KVX/source documents rather than generated specification mirrors.
- [ ] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants.
- [ ] I added real positive, negative, and adversarial coverage appropriate to the change.
- [ ] I ran `make public-audit` and the affected native or Solidity suites.
- [ ] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [ ] I am not representing local verification as production certification or deployment authorization.

