### PR TITLE
docs: monorepo + qualification + wiki drafts after Paxeer import

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,9 @@ security boundaries to satisfy tests.
 
 ## Implementation rules
 
-- Use C17 for the protocol runtime and Solidity `0.8.27` for Paxeer contracts.
+- Use C17 for the LayerX protocol runtime and Solidity `0.8.27` for LayerX settlement contracts.
+- Paxeer Network is a separate Go module under `paxeer-network/` with its own Makefile and CI (`make paxeer-build`, `make paxeer-lint`, `make paxeer-test`, `make paxeer-ci`).
+- Programs is a Rust workspace under `programs/` for the programmable LayerX runtime.
 - Preserve canonical byte encodings and result-code assignments. Both are
   protocol interfaces, not implementation details.
 - Use checked fixed-width integer arithmetic for every consensus-critical
@@ -68,6 +70,13 @@ make public-audit
 make build
 make test
 make test-contracts
+```
+
+Paxeer Network and the monorepo have separate optional gates that do not replace LayerX qualification:
+
+```sh
+make paxeer-ci       # Paxeer-specific evidence
+make monorepo-ci     # Cross-subsystem integrity
 ```
 
 Arithmetic, replay, recovery, settlement, and cross-architecture changes have

--- a/docs/MONOREPO.md
+++ b/docs/MONOREPO.md
@@ -1,0 +1,45 @@
+# Monorepo layout
+
+This repository is the canonical Sidiora Labs ecosystem monorepo for LayerX and the Paxeer Network. Co-location keeps the protocol, settlement network, contracts, developer surfaces, and their automation auditable in one place while preserving their separate build, release, deployment, and trust boundaries.
+
+## What lives where
+
+| Path | Subsystem | Build entry | Release tags |
+| --- | --- | --- | --- |
+| `src/`, `include/`, `agent/`, `human/`, `platform/`, `programs/`, `interop/`, `contracts/`, `spec/`, `tests/`, `fuzz/`, `migrations/` | LayerX protocol, agent interface, human control plane, developer platform, programmable runtime, interoperability gateway, and settlement contracts | Root `Makefile` | `vX.Y.Z` |
+| `paxeer-network/` | Paxeer Network node, EVM/RPC compatibility, storage engines, modules, contracts, Docker environments, and subsystem-local build manifests | `paxeer-network/Makefile` | `paxeer-network/vX.Y.Z` |
+
+## Build and release boundaries
+
+LayerX and Paxeer have independent build systems, release processes, and qualification gates:
+
+- **LayerX**: C17, Rust, Solidity, TypeScript. Built with the root `Makefile`. Qualified with `make ci`, replay, arithmetic, fault, and fuzz suites.
+- **Paxeer**: Go, Solidity, Rust, Docker. Built with `make paxeer-build`, `make paxeer-lint`, `make paxeer-test`, `make paxeer-ci`.
+- **Monorepo integrity**: `make monorepo-ci` runs cross-subsystem checks but does not replace either subsystem's own qualification.
+
+Release tags follow the pattern:
+- LayerX: `vX.Y.Z`
+- Paxeer: `paxeer-network/vX.Y.Z`
+
+## Trust boundaries
+
+Co-location in this repository does not grant one subsystem new authority over the other:
+
+- LayerX protocol execution, balance writes, and activity ordering remain under LayerX's deterministic runtime and specification.
+- Paxeer custody, checkpoint registration, guarantor bonds, challenges, and emergency exits remain under Paxeer's settlement contracts and chain.
+- Shared source control does not imply shared deployment authority, validator sets, or custody semantics.
+
+## Workflow naming
+
+GitHub workflows and CI jobs use prefixed names to make subsystem ownership clear:
+
+- LayerX workflows: `agent.yml`, `human.yml`, `platform.yml`, `programs-conformance.yml`
+- Paxeer workflows: `Paxeer / Build`, `Paxeer / Lint`, `Paxeer / Test`
+
+File paths under `paxeer-network/` trigger Paxeer-specific CI. Changes outside that directory do not run Paxeer builds unless explicitly configured.
+
+## Further reading
+
+- Root `README.md`: Ecosystem overview and repository layout
+- `CONTRIBUTING.md`: Contribution guidelines for both subsystems
+- `docs/QUALIFICATION.md`: Evidence levels and qualification gates

--- a/docs/QUALIFICATION.md
+++ b/docs/QUALIFICATION.md
@@ -79,3 +79,14 @@ Live contract deployment, validator mutation, custody migration, or a real-value
 canary requires an explicit owner-approved runbook. Repository tests may prepare
 that evidence but cannot satisfy or authorize the live gate by themselves.
 
+## Paxeer qualification
+
+Paxeer Network has its own qualification gates under `paxeer-network/`:
+
+```sh
+make paxeer-ci
+make monorepo-ci
+```
+
+Paxeer evidence is a separate gate from LayerX qualification. A passing Paxeer build does not imply LayerX qualification, and vice versa. Each subsystem qualifies independently against its own specification, and co-location in this monorepo grants neither system new protocol or deployment authority over the other.
+

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,75 @@
+# LayerX Ecosystem
+
+Welcome to the LayerX Ecosystem documentation. This repository is the canonical Sidiora Labs monorepo for LayerX and the Paxeer Network.
+
+## What is LayerX?
+
+LayerX is a deterministic execution and accounting network built for autonomous agents. It provides infrastructure for agent identity, delegated authority, payments, budgets, escrow, streams, trading, and settlement as one coherent system.
+
+Ordinary agent activity is executed and ordered inside LayerX. Periodic checkpoints are settled to Paxeer, where custody, finality, economic guarantees, disputes, and emergency exits live. This separation keeps the fast path fast without asking users to trust an opaque internal ledger.
+
+## What is Paxeer?
+
+Paxeer is the settlement layer that handles custody, checkpoint registration, guarantor bonds, challenges, withdrawals, and emergency exits for LayerX. While LayerX handles thousands or millions of activities, Paxeer registers periodic checkpoints and provides the custody guarantee.
+
+The Paxeer Network node source is co-located in this repository under `paxeer-network/` as part of the LayerX ecosystem monorepo. Co-location keeps the protocol, settlement network, and their automation auditable in one place while preserving separate build, release, and trust boundaries.
+
+## What is LayerX Programs?
+
+Programs is a programmable surface within LayerX that allows developers to deploy economic applications with capability-based kernel APIs, namespaced storage, explicit metering, and versioned ABIs. Programs is not a separate module ID—it is a runtime surface where guest code runs inside the `programs` module's namespace, with every monetary effect forced through 402LXP and no program ever holding direct balance-writing authority.
+
+## Development status
+
+LayerX is currently in **limited beta** (opening September 7, 2026). The protocol is source-available for inspection and security review under a temporary license that does not grant deployment rights.
+
+- Source code is open for inspection
+- Limited beta opens September 7, 2026
+- No public RPC endpoint yet
+- Inspection-only license until qualification completes
+
+Sidiora Labs intends to publish LayerX under an open-source license after protocol development and release qualification are complete.
+
+## Key properties
+
+Three rules sit at the center of LayerX:
+
+1. **One canonical history.** Every accepted or failed activity receives a global sequence. State roots are chained per activity, not only per batch.
+2. **One financial doorway.** `402LXP` is the only component allowed to write balances. Protocol modules produce validated transfer sets rather than mutating funds themselves.
+3. **One reproducible result.** Consensus-critical execution excludes floating point, local clock decisions, database iteration order, and other sources of nondeterminism.
+
+## What LayerX supports
+
+| Area | Responsibilities |
+| --- | --- |
+| Identity and authority | Agent DIDs, primary and session keys, scoped capability grants, rotation, recovery, revocation, and expiry |
+| Money movement | Authenticated sends and receives, asset accounts, deposits, withdrawals, and reserve accounting |
+| Spending controls | Holds, escrow, recurring budgets, delegated limits, approvals, and metered streams |
+| Agent commerce | Offers, commitments, tool-execution attestations, delivery, acceptance, and disputes |
+| Markets | Oracle intake, order books, positions, funding, margin, liquidation, and insurance accounting |
+| Network operation | Sequencing, replicas, batch construction, data availability, replay, fees, and metering |
+| Settlement | Guarantor attestations, checkpoint registration, custody reconciliation, claims, and emergency exits |
+
+## Fees
+
+LayerX charges a base fee of approximately ½¢ per 5,000 µUSDX of activity volume for network operation, sequencing, and data availability.
+
+## Repository structure
+
+This monorepo contains:
+
+- **LayerX protocol** (`src/`, `include/`, `agent/`, `human/`, `platform/`, `programs/`, `interop/`, `contracts/`, `spec/`)
+- **Paxeer Network** (`paxeer-network/`) with independent build, release tags (`paxeer-network/vX.Y.Z`), and trust boundaries
+
+Co-location keeps the ecosystem auditable while preserving separate deployment authority. See `docs/MONOREPO.md` for details.
+
+## Resources
+
+- [Protocol design](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/spec/layerx-protocol/design.md)
+- [Contributing guide](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/CONTRIBUTING.md)
+- [Security policy](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md)
+- [Qualification documentation](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/docs/QUALIFICATION.md)
+- [Monorepo layout](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/docs/MONOREPO.md)
+
+---
+
+LayerX is developed by [Sidiora Labs](https://github.com/Sidiora-Labs).

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,33 +1,20 @@
-# LayerX Ecosystem
+# Welcome to LayerX
 
-Welcome to the LayerX Ecosystem documentation. This repository is the canonical Sidiora Labs monorepo for LayerX and the Paxeer Network.
+LayerX is a deterministic execution and accounting network built for autonomous agents.
 
-## What is LayerX?
-
-LayerX is a deterministic execution and accounting network built for autonomous agents. It provides infrastructure for agent identity, delegated authority, payments, budgets, escrow, streams, trading, and settlement as one coherent system.
+**Limited beta opens September 7, 2026.** The source is available for inspection under a temporary license that does not yet grant deployment rights.
 
 Ordinary agent activity is executed and ordered inside LayerX. Periodic checkpoints are settled to Paxeer, where custody, finality, economic guarantees, disputes, and emergency exits live. This separation keeps the fast path fast without asking users to trust an opaque internal ledger.
 
+## Repository and monorepo structure
+
+This is the canonical Sidiora Labs monorepo for LayerX and the Paxeer Network. The Paxeer settlement node source lives under `paxeer-network/` with independent build, release tags (`paxeer-network/vX.Y.Z`), and trust boundaries. Co-location keeps the protocol, settlement network, and their automation auditable in one place while preserving separate deployment authority.
+
+LayerX Programs is a programmable surface—not a separate module ID—where guest code runs inside the `programs` module's namespace. Every monetary effect is forced through 402LXP; no program ever holds direct balance-writing authority.
+
 ## What is Paxeer?
 
-Paxeer is the settlement layer that handles custody, checkpoint registration, guarantor bonds, challenges, withdrawals, and emergency exits for LayerX. While LayerX handles thousands or millions of activities, Paxeer registers periodic checkpoints and provides the custody guarantee.
-
-The Paxeer Network node source is co-located in this repository under `paxeer-network/` as part of the LayerX ecosystem monorepo. Co-location keeps the protocol, settlement network, and their automation auditable in one place while preserving separate build, release, and trust boundaries.
-
-## What is LayerX Programs?
-
-Programs is a programmable surface within LayerX that allows developers to deploy economic applications with capability-based kernel APIs, namespaced storage, explicit metering, and versioned ABIs. Programs is not a separate module ID—it is a runtime surface where guest code runs inside the `programs` module's namespace, with every monetary effect forced through 402LXP and no program ever holding direct balance-writing authority.
-
-## Development status
-
-LayerX is currently in **limited beta** (opening September 7, 2026). The protocol is source-available for inspection and security review under a temporary license that does not grant deployment rights.
-
-- Source code is open for inspection
-- Limited beta opens September 7, 2026
-- No public RPC endpoint yet
-- Inspection-only license until qualification completes
-
-Sidiora Labs intends to publish LayerX under an open-source license after protocol development and release qualification are complete.
+Paxeer handles custody, checkpoint registration, guarantor bonds, challenges, withdrawals, and emergency exits. While LayerX processes thousands or millions of activities, Paxeer registers periodic checkpoints and provides the custody guarantee.
 
 ## Key properties
 
@@ -51,16 +38,9 @@ Three rules sit at the center of LayerX:
 
 ## Fees
 
-LayerX charges a base fee of approximately ½¢ per 5,000 µUSDX of activity volume for network operation, sequencing, and data availability.
+LayerX charges a base fee of 5,000 µUSDX per activity (approximately ½¢) for network operation, sequencing, and data availability. Congestion applies a 1×–64× multiplier measured from network load.
 
-## Repository structure
-
-This monorepo contains:
-
-- **LayerX protocol** (`src/`, `include/`, `agent/`, `human/`, `platform/`, `programs/`, `interop/`, `contracts/`, `spec/`)
-- **Paxeer Network** (`paxeer-network/`) with independent build, release tags (`paxeer-network/vX.Y.Z`), and trust boundaries
-
-Co-location keeps the ecosystem auditable while preserving separate deployment authority. See `docs/MONOREPO.md` for details.
+See `docs/MONOREPO.md` for build boundaries, workflow naming, and tag conventions.
 
 ## Resources
 

--- a/docs/wiki/Status.md
+++ b/docs/wiki/Status.md
@@ -1,0 +1,95 @@
+# Development status
+
+## Current status: Limited beta
+
+LayerX is under active development and release qualification.
+
+| Milestone | Status | Date |
+| --- | --- | --- |
+| Source publication | ✅ Complete | August 2026 |
+| Limited beta opens | 🔜 Upcoming | September 7, 2026 |
+| Public RPC endpoint | ⏳ Pending | After qualification |
+| Open-source license | ⏳ Pending | After qualification |
+
+## What is available now
+
+- **Source code**: Open for inspection and security review under temporary source-available terms
+- **Repository**: Full LayerX + Paxeer monorepo at [github.com/Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol)
+- **Documentation**: Protocol specifications, design documents, contributing guidelines, and qualification evidence
+- **Build system**: Complete build, test, and qualification infrastructure
+
+## Monorepo layout
+
+This repository contains both LayerX and Paxeer Network as a unified ecosystem monorepo:
+
+- **LayerX** builds, releases, and qualifies independently at the repository root
+- **Paxeer Network** builds, releases, and qualifies independently under `paxeer-network/`
+- See `docs/MONOREPO.md` for details on build boundaries, release tags, and trust separation
+
+## What is not yet available
+
+- **Public RPC endpoint**: No public LayerX node is accessible yet
+- **Production deployment**: No mainnet or production environment is live
+- **Deployment license**: Current license permits inspection only, not deployment or redistribution
+
+## Limited beta (September 7, 2026)
+
+The limited beta will provide:
+
+- Early access for approved participants
+- Controlled environment for testing agent workflows
+- Opportunity to provide feedback before broader release
+- Real protocol activity under controlled conditions
+
+Limited beta does not mean production-ready. The system remains under qualification, and breaking changes may still occur.
+
+## Fees
+
+When operational, LayerX will charge a base fee of approximately ½¢ per 5,000 µUSDX of activity volume for network operation, sequencing, and data availability. This is not zero-fee; it reflects the real cost of operating a deterministic accounting network with data availability and replay guarantees.
+
+## Qualification status
+
+LayerX qualification is layered by risk. Current status:
+
+| Evidence level | Status |
+| --- | --- |
+| Source integrity | ✅ In place |
+| Build and unit behavior | ✅ In place |
+| Runtime safety | 🔄 In progress |
+| Deterministic replay | 🔄 In progress |
+| Fault and adversarial behavior | 🔄 In progress |
+| Settlement qualification | ⏳ Pending |
+| Deployment evidence | ⏳ Pending |
+
+See [docs/QUALIFICATION.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/docs/QUALIFICATION.md) for the complete qualification framework.
+
+## Paxeer Network qualification
+
+Paxeer has its own independent qualification gates (`make paxeer-ci`, `make monorepo-ci`). Paxeer qualification is separate from LayerX qualification—one does not imply the other.
+
+## License timeline
+
+LayerX is currently available under temporary source-available terms that permit inspection and security review but do not grant deployment rights.
+
+Sidiora Labs intends to publish LayerX under an open-source license after protocol development and release qualification are complete. No timeline has been announced for that transition.
+
+## How to participate
+
+**Now:**
+- Inspect the source code
+- Review the specifications and design documents
+- Report security issues via [SECURITY.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md)
+
+**Limited beta (September 7):**
+- Apply for early access (details to be announced)
+- Test agent workflows in a controlled environment
+- Provide feedback on developer experience
+
+**After qualification:**
+- Use LayerX in production environments
+- Deploy your own nodes (when deployment license is available)
+- Build agent applications on top of LayerX
+
+---
+
+LayerX is developed by [Sidiora Labs](https://github.com/Sidiora-Labs). For questions or support, see [SUPPORT.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SUPPORT.md).

--- a/docs/wiki/Status.md
+++ b/docs/wiki/Status.md
@@ -34,36 +34,15 @@ This repository contains both LayerX and Paxeer Network as a unified ecosystem m
 
 ## Limited beta (September 7, 2026)
 
-The limited beta will provide:
-
-- Early access for approved participants
-- Controlled environment for testing agent workflows
-- Opportunity to provide feedback before broader release
-- Real protocol activity under controlled conditions
-
-Limited beta does not mean production-ready. The system remains under qualification, and breaking changes may still occur.
+Limited beta opens September 7, 2026. Limited beta does not mean production-ready. The system remains under qualification, and breaking changes may still occur.
 
 ## Fees
 
-When operational, LayerX will charge a base fee of approximately ½¢ per 5,000 µUSDX of activity volume for network operation, sequencing, and data availability. This is not zero-fee; it reflects the real cost of operating a deterministic accounting network with data availability and replay guarantees.
+LayerX charges a base fee of 5,000 µUSDX per activity (approximately ½¢) for network operation, sequencing, and data availability. Congestion applies a 1×–64× multiplier measured from network load. This is not zero-fee; it reflects the real cost of operating a deterministic accounting network with data availability and replay guarantees.
 
 ## Qualification status
 
-LayerX qualification is layered by risk. Current status:
-
-| Evidence level | Status |
-| --- | --- |
-| Source integrity | ✅ In place |
-| Build and unit behavior | ✅ In place |
-| Runtime safety | 🔄 In progress |
-| Deterministic replay | 🔄 In progress |
-| Fault and adversarial behavior | 🔄 In progress |
-| Settlement qualification | ⏳ Pending |
-| Deployment evidence | ⏳ Pending |
-
-See [docs/QUALIFICATION.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/docs/QUALIFICATION.md) for the complete qualification framework.
-
-## Paxeer Network qualification
+LayerX qualification is layered by risk. The authoritative acceptance criteria and current completion state are in [docs/QUALIFICATION.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/docs/QUALIFICATION.md) and [spec/layerx-protocol/tasks.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/spec/layerx-protocol/tasks.md).
 
 Paxeer has its own independent qualification gates (`make paxeer-ci`, `make monorepo-ci`). Paxeer qualification is separate from LayerX qualification—one does not imply the other.
 
@@ -79,11 +58,6 @@ Sidiora Labs intends to publish LayerX under an open-source license after protoc
 - Inspect the source code
 - Review the specifications and design documents
 - Report security issues via [SECURITY.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md)
-
-**Limited beta (September 7):**
-- Apply for early access (details to be announced)
-- Test agent workflows in a controlled environment
-- Provide feedback on developer experience
 
 **After qualification:**
 - Use LayerX in production environments


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documentation-only updates to reflect the ecosystem monorepo structure introduced in commit 2c19ff51 (Integrate Paxeer Network into the LayerX monorepo). This PR updates Contributing, Qualification, creates a new Monorepo layout guide, and provides reviewable wiki drafts for GitHub Wiki publishing.

**No runtime, code, test, or generated file changes.** This PR affects documentation files only.

## Files changed

### Updated existing documentation

- **CONTRIBUTING.md**: Added Paxeer as a separate Go module under `paxeer-network/` with its own Makefile and CI (`make paxeer-build|lint|test|ci`). Added Programs as a Rust workspace under `programs/`. Documented `make paxeer-*` and `make monorepo-ci` as optional extra gates that do not replace LayerX qualification. Security language preserved without weakening.

- **docs/QUALIFICATION.md**: Added short Paxeer qualification section clarifying that Paxeer evidence is a separate gate (`make paxeer-ci`, `make monorepo-ci`) and does not imply LayerX qualification or vice versa. Each subsystem qualifies independently.

### New documentation

- **docs/MONOREPO.md**: Short operator note on what lives where (LayerX at root, Paxeer under `paxeer-network/`), build/release/trust boundaries, workflow naming conventions (`Paxeer / ...` in workflows, paths under `paxeer-network/`), independent tag scheme (`vX.Y.Z` vs `paxeer-network/vX.Y.Z`), and clarification that co-location does not grant shared authority. Points to root README and QUALIFICATION.

- **docs/wiki/Home.md**: Reviewable wiki Home draft for manual publishing after merge. Updates existing wiki voice (deterministic execution + accounting for agents; Paxeer is settlement; limited beta Sept 7; source open for inspection; no public RPC yet). Adds that this repo is now the LayerX + Paxeer monorepo with `paxeer-network/` as the settlement node tree, and that Programs is a programmable surface (not a 9th module). Repo-true, favorable tone. Base fee ~½¢ / 5,000 µUSDX mentioned. No false mainnet/live/zero-fees claims.

- **docs/wiki/Status.md**: Reviewable wiki Status draft for manual publishing after merge. Development timeline scoreboard: limited beta Sept 7, source-available inspection license, no public endpoint, monorepo layout pointer, qualification status, and fee information. Not a closed sign—presents current availability and upcoming milestones.

### What was already current

- **Root README.md**: Already describes the ecosystem monorepo, `paxeer-network/` layout row, `make paxeer-build|lint|test|ci`, `make monorepo-ci`, independent release tags `paxeer-network/vX.Y.Z`, and the line that co-location grants neither LayerX nor Paxeer new protocol/deployment authority. **Not modified** per instructions.

- **CHANGELOG.md**: Already contains 2026-08-21 entry covering the monorepo import and programs-owned-accounts work. **Not modified**.

### What still needs manual work (after merge)

- **Wiki publishing**: `docs/wiki/Home.md` and `docs/wiki/Status.md` are drafts that Andrew can copy to the GitHub Wiki manually after reviewing and merging this PR. GitHub Wiki has no PR mechanism, so these are reviewable markdown files for manual transfer.

## Specification

- **Requirement clause(s)**: N/A (documentation-only)
- **Codify task**: N/A (ad-hoc documentation request from Andrew analyzing recent repo changes)
- **Compatibility impact**: None (no code, wire encoding, result codes, state roots, storage, or contract ABI changes)

## Verification

No runtime verification commands are applicable to documentation-only changes. All changes have been reviewed for:

- **Factual accuracy**: Claims match the current repository state (monorepo layout, Paxeer under `paxeer-network/`, Programs as runtime surface, limited beta Sept 7, inspection-only license)
- **Voice consistency**: Favorable but repo-true; no production-ready/mainnet-live/zero-fees claims
- **Generated file protection**: No edits to AGENTS.md, CLAUDE.md, or any file marked GENERATED from kvx
- **Manual review**: All prose reviewed for clarity, correctness, and adherence to voice guidelines

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. *(N/A — documentation-only, no generated specs touched)*
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants. *(N/A — no code changes)*
- [x] I added real positive, negative, and adversarial coverage appropriate to the change. *(N/A — documentation has no test surface)*
- [x] I ran `make public-audit` and the affected native or Solidity suites. *(N/A — documentation-only)*
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders. *(Confirmed — prose only)*
- [x] I am not representing local verification as production certification or deployment authorization. *(Confirmed — documentation makes no deployment claims)*

---

**Note**: This PR is ready for Andrew's review and merge. After merge, wiki drafts can be manually published to the GitHub Wiki. **Do NOT merge** until Andrew reviews—this was requested as a documentation update for his review only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d7081da-acd3-45b5-80e0-7e2343a78427?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d7081da-acd3-45b5-80e0-7e2343a78427&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

