### PR TITLE
docs: paxeer-network README + MCP/A2A/mirrors + wiki Developers/Security drafts

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -7,3 +7,7 @@ The LayerX Node Interface is the sole boundary to the C17 core. Agent crates nev
 This Rust 2021 workspace owns agent-facing types, canonical encoding, cryptography, proof verification, the boundary client, daemon API, daemon, MCP server, and SDK. It builds independently from the C core through the `agent-*` Make targets at the repository root.
 
 `make agent-check-boundary` enforces the node-interface boundary by rejecting forbidden storage dependencies, node-private paths, C-core linkage, generated bindings, and unapproved C-layout declarations. An exception is a protocol design change: it must be added to the published stable ABI allowlist through the specification process and cannot be suppressed with a source comment.
+
+## MCP
+
+The MCP server is [`crates/layerx-mcp`](crates/layerx-mcp/README.md): one tenant, one scope set, daemon-only routing. Interop MCP/A2A transports and the `layerx install mcp` / `layerx install a2a` CLI live next door in [`interop/`](../interop/README.md) and `platform/cli/`.

--- a/agent/crates/layerx-mcp/README.md
+++ b/agent/crates/layerx-mcp/README.md
@@ -1,0 +1,47 @@
+# layerx-mcp
+
+Tenant- and scope-bound Model Context Protocol tools for LayerX. A model gets the tools its bound scope allows. It does not get protocol authority.
+
+Every call routes through `layerx-agentd`. There is no MCP-only write path and no tool-owned connection to the C17 core. Authority is fixed at server startup from an ordinary daemon session and capability.
+
+This crate lives in the agent workspace (`agent/`). Related surfaces:
+
+| Surface | Location |
+| --- | --- |
+| This server | `agent/crates/layerx-mcp` |
+| Daemon | `agent/crates/layerx-agentd` |
+| MCP / A2A as interop transports | [`interop/`](../../../interop/README.md) |
+| `layerx install mcp` / `layerx mcp serve` | `platform/cli/` |
+| Tool design (normative) | [`spec/layerx-agent-interface/docs/mcp-tools.md`](../../../spec/layerx-agent-interface/docs/mcp-tools.md) |
+
+## Tools in this crate
+
+Read tools are absent from the list when the bound scope does not include them:
+
+| Tool | Kind |
+| --- | --- |
+| `balance.get` | read |
+| `history.list` | read |
+| `receipt.get` | read |
+| `checkpoint.get` | read |
+| `proof.get` | read |
+| `availability.get` | read |
+| `activity.prepare` | write |
+| `activity.disclose` | write |
+| `activity.sign` | write |
+| `activity.submit` | write |
+| `activity.track` | write |
+
+Write tools follow the ordinary daemon path: prepare, disclose, sign, submit, track. Outcomes are evidence-shaped (`Executed` + receipt, `Unknown`, or `Failed`). Read-only deployment omits write tools entirely.
+
+Untrusted tool arguments cannot change tenant, scope, or counterparty. See `src/untrusted.rs` and `src/validate.rs`.
+
+## Test
+
+From the monorepo root:
+
+```sh
+make agent-test
+```
+
+Crate tests include `scope`, `read`, `write`, `approval`, `readonly`, and `injection` (`agent/tests/mcp/injection.rs`).

--- a/docs/wiki-drafts/Developers.md
+++ b/docs/wiki-drafts/Developers.md
@@ -1,0 +1,148 @@
+<!-- Wiki draft for https://github.com/Sidiora-Labs/LayerX-Protocol/wiki/Developers
+     Andrew copies this after merge. Wiki has no PR flow. -->
+
+# Developers
+
+Run from source. Limited beta opens September 7. Source is open for inspection while we qualify the public lane.
+
+There is no public LayerX RPC to point an agent at yet. The node, SDKs, MCP tools, interop transports, and the Paxeer Network tree are in this monorepo today.
+
+This wiki is LayerX Protocol by Sidiora Labs (LXP1), settling on Paxeer Network (EVM chain ID `125`). The repository is [Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol).
+
+---
+
+## Five ways in
+
+| Path | What you get | Where it lives |
+| --- | --- | --- |
+| Node | Run the protocol locally | `cmd/layerxd`, `cmd/layerxctl`, `cmd/layerx-verify`, `cmd/layerx-genesis` |
+| SDK / daemon | Call LayerX from an agent process | `agent/` — Rust workspace: types, canonical encoding, crypto, proofs, daemon, SDKs |
+| MCP tools | Hand a scoped key to an agent | `agent/crates/layerx-mcp` — one tenant, one scope, daemon-only routing. CLI installer: `platform/cli/` (`layerx install mcp`) |
+| Interop | Speak x402, AP2, A2A, and the rest at the edge | `interop/` — adapters translate; they do not write balances |
+| Paxeer | Settlement and custody L1 | `paxeer-network/` — `paxd`, EVM/RPC, chain modules. LayerX settlement contracts stay in repo-root `contracts/` |
+
+The agent workspace has no protocol authority. Every state change is a signed LayerX activity. The node interface is the only boundary into the C17 core. `402LXP` is the only balance writer.
+
+---
+
+## Build the node
+
+From the repository root:
+
+```
+make build
+make test
+make test-contracts
+```
+
+Broader gates:
+
+```
+make public-audit
+make ci
+```
+
+The core runtime is C17. LayerX settlement contracts are Solidity `0.8.27`. Agent, human, and platform workspaces are Rust.
+
+---
+
+## Build the agent interface
+
+Agent crates build independently of the C core:
+
+```
+make agent-check-boundary
+```
+
+`make agent-check-boundary` rejects storage dependencies, node-private paths, and C-core linkage. The agent layer never invents protocol state.
+
+Languages called out on the site: Rust, TypeScript, Python. Generated / language SDKs live under `agent/sdk` and `agent/tools/sdk-gen`.
+
+MCP in this workspace: [`agent/crates/layerx-mcp`](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/agent/crates/layerx-mcp/README.md). Tools are evidence-shaped (`balance.get`, `receipt.get`, `activity.submit`, …). A read-only deployment omits write tools. Design note: [MCP tools](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/spec/layerx-agent-interface/docs/mcp-tools.md).
+
+---
+
+## MCP and A2A
+
+Two complementary surfaces — both real, neither a second ledger.
+
+| Surface | Role |
+| --- | --- |
+| Agent MCP server | `agent/crates/layerx-mcp` — bound at startup to one tenant and one scope; every call goes through `layerx-agentd` |
+| Interop transports | `interop/` labels `http`, `mcp`, and `a2a`. x402 buyer / seller / facilitator run on all three. There is no standalone `layerx-a2a` crate |
+| CLI installers | `layerx install mcp` and `layerx install a2a` in `platform/cli/`. Copy: [install](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/platform/docs/content/install.md), [interop guide](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/platform/docs/content/guide/interop.md) |
+
+A2A is a transport and a loopback agent-card runtime, not a custody path.
+
+---
+
+## Ethereum and Solana mirrors
+
+Batch mirror archives live in `interop/crates/layerx-mirror`. Publisher and verifier binaries: `layerx-mirror-publisher`, `layerx-mirror-verify`. On-chain archive programs: `interop/contracts/ethereum-mirror/`, `interop/contracts/solana-mirror/`.
+
+Mirrors are presence, not custody. Anyone can verify a LayerX receipt from a mirror. Funds do not move to Ethereum or Solana. Settlement stays on Paxeer.
+
+```
+make interop-build
+make interop-test
+```
+
+Live publisher / verify targets (`make mirror-live`, `make mirror-verify-live`) are operator qualification entrypoints.
+
+---
+
+## Migrations
+
+Three different words, three directories:
+
+| Kind | Location |
+| --- | --- |
+| LayerX genesis / cutover from the prior Go system | `spec/layerx-protocol/docs/migration.md`, SQL in `migrations/`, CLI in `cmd/layerx-genesis/` |
+| Ethereum / Solana source-chain import | `interop/crates/layerx-migrate` — [operations](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/interop/crates/layerx-migrate/OPERATIONS.md) |
+| Paxeer EVM store migrations | `paxeer-network/modules/evm/migrations/` (chain-internal) |
+
+---
+
+## Build Paxeer (in this repo)
+
+Paxeer Network is checked in under `paxeer-network/`. It is the settlement L1, not a LayerX rewrite.
+
+From the monorepo root:
+
+```
+make paxeer-build
+make paxeer-lint
+make paxeer-test
+make paxeer-ci
+```
+
+From `paxeer-network/`:
+
+```
+make build
+make test
+forge install && forge build
+```
+
+Subtree README: [`paxeer-network/README.md`](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/paxeer-network/README.md). Docs index: [`paxeer-network/docs/`](https://github.com/Sidiora-Labs/LayerX-Protocol/tree/main/paxeer-network/docs).
+
+---
+
+## What you can do now
+
+- Inspect and replay the protocol from source
+- Run a local node and verify batches (`layerx-verify`)
+- Wire an agent to canonical encoding, signatures, and receipts
+- Scope a key and attach MCP tools to that key
+- Read the interop adapters, mirror publisher, and migration verifiers
+- Build `paxd` from `paxeer-network/`
+
+What opens September 7 is limited beta access to the public lane — not a rewrite of these binaries, and not a public LayerX RPC.
+
+---
+
+## Spec first
+
+Normative behavior is KVX in `spec/`. Generated Markdown is easier to read; changes begin in KVX.
+
+Payments: Payments · Fees. Security model: Security. Project stage: Status. Settlement: still Paxeer.

--- a/docs/wiki-drafts/Security.md
+++ b/docs/wiki-drafts/Security.md
@@ -1,0 +1,108 @@
+<!-- Wiki draft for https://github.com/Sidiora-Labs/LayerX-Protocol/wiki/Security
+     Andrew copies this after merge. Wiki has no PR flow. -->
+
+# Security
+
+Bonded replay, then Paxeer custody. A batch is not "proven valid." A threshold of bonded guarantors re-runs it and puts money behind the claim.
+
+Site: Security model · Normative: Threat model (`LXP1`)
+
+Report a suspected vulnerability through GitHub private vulnerability reporting — see the repo [SECURITY.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md). Do not open a public issue.
+
+Limited beta opens September 7. Source is open for inspection while we qualify the public lane.
+
+---
+
+## What the protocol protects
+
+| Value | Custody on Paxeer; LayerX balances only move through `402LXP` |
+| --- | --- |
+| History | One append-only activity log; indexes are disposable |
+| Authority | Keys, session keys, grants, revocations — live state, not HTTP middleware |
+| Replay | Honest nodes on the same history compute the same state roots |
+| Exit | Emergency withdrawal against the last finalized checkpoint, without a live sequencer |
+
+Full asset list and attack catalogue: threat model §§1–4.
+
+There is no LayerX token. USDX is the unit agents hold inside LayerX. USDL is the asset held on Paxeer L1 behind it. PAX is Paxeer's gas token.
+
+---
+
+## Guarantors
+
+Independent operators download the complete batch, verify every signature, replay every transition, recompute the roots, and sign only on byte-identical results.
+
+They can attest or withhold. They cannot rewrite state.
+
+A checkpoint accepted on Paxeer means: a bonded quorum claims to have replayed this batch and stored its data. That is an economic attestation, not a validity proof. If a threshold colludes — or they all run the same buggy binary — an invalid root can be finalized. The answer is bonds, slashing, a challenge window, and the right to exit — not a slogan that the math "proved" the batch.
+
+Walk the ladder on Finality (L0 → L4).
+
+---
+
+## What stands behind a batch
+
+| Control | Role |
+| --- | --- |
+| Bonds | Slashable stake sized against value that can move in one challenge window |
+| Challenge window | Anyone may submit a re-execution disagreement before withdrawals finalize |
+| Withdrawal limits | Caps how fast value can leave if a quorum is wrong |
+| Data availability | Guarantors attest they hold the batch and must serve it |
+| Emergency exit | Last finalized checkpoint + membership proof + nullifier. No sequencer required |
+
+The sequencer is trusted for liveness and short-horizon order, not for validity. A lying sequencer produces a batch no guarantor attests. Equivocation is slashable on Paxeer.
+
+---
+
+## Who is trusted for what
+
+| Actor | Trusted for | Not trusted for |
+| --- | --- | --- |
+| Agent | Its own keys and counterparties | Encoding, sequences, asserted balances |
+| Sequencer | Order, batches, timestamps in bounds | Validity, minting, forging receipts |
+| Guarantor | Independent full replay and DA | Individual honesty or liveness |
+| Service (402) | Its own price and delivery claim | Debiting anyone without a live grant |
+| MCP / A2A client | The tools its bound scope lists | Inventing authority, writing balances, skipping the daemon |
+| Mirror operator | Publishing a retrievable archive | Custody, settlement, minting |
+| Migration adapter | Verifying an external source claim | Constructing LayerX payload bytes or substituting a batch signer |
+| Paxeer contracts | Custody, checkpoints, slashing, exits | LayerX business logic |
+
+---
+
+## MCP and A2A
+
+Model transports are convenient. They are not a new authority.
+
+The agent MCP server (`agent/crates/layerx-mcp`) binds one tenant and one scope at startup. Tools outside that scope are absent, not present-and-refusing. Every call goes through `layerx-agentd`, so capability, budget, rate limits, and audit apply as they do for any other client. Untrusted tool text cannot change the bound principal.
+
+Interop MCP and A2A are ingress labels on the gateway and on x402 (`interop/`). They carry the same validated objects as HTTP. Adapters translate; `402LXP` still writes the balance. There is no standalone A2A crate and no MCP-only settlement path.
+
+Read-only deployments omit write tools. Success is a verified receipt, not a sentence a model can reread as "paid."
+
+---
+
+## Mirrors
+
+Ethereum and Solana mirrors (`interop/crates/layerx-mirror`) publish batch commitments and retrievable data. They are archives.
+
+A receipt can be verified from a mirror with LayerX infrastructure unavailable. A lagging mirror says it is lagging. Tampered archive bytes fail verification.
+
+Mirrors are not vaults, portals, or settlement domains. Withdrawal and emergency exit remain Paxeer exclusively.
+
+---
+
+## Paxeer, now in this repository
+
+The Paxeer Network node lives in `paxeer-network/` of [Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol). LayerX settlement contracts (custody, checkpoints, bonds, claims, exits) remain in repo-root `contracts/`.
+
+Checking the L1 into the monorepo makes review easier. It does not move custody onto LayerX, and it does not give Paxeer a second write path into `402LXP`. Settlement is still Paxeer (EVM chain ID `125`).
+
+---
+
+## Report a vulnerability
+
+Use the repository Security tab (private advisory). Include commit, component, reproduction, violated invariant, and whether sequencer / guarantor / governance / custody privilege is required.
+
+No public issue, no probing infrastructure you do not own. Policy: [SECURITY.md](https://github.com/Sidiora-Labs/LayerX-Protocol/blob/main/SECURITY.md).
+
+Fees that pay sequencers, guarantors, and the insurance fund: Fees.

--- a/interop/README.md
+++ b/interop/README.md
@@ -1,0 +1,63 @@
+# LayerX interoperability workspace
+
+Adapters at the edge. They translate someone else's protocol into LayerX-shaped evidence, and they never write balances. `402LXP` remains the only balance writer. Custody and withdrawal guarantees stay on Paxeer.
+
+This is the Rust workspace in `interop/`. It is not a second ledger.
+
+## Where to start
+
+| Surface | What it is | Where it lives |
+| --- | --- | --- |
+| Gateway | Transport-neutral routes, redaction, adapter host | `crates/layerx-interop-gateway`, executable composition in `crates/layerx-interop-service` |
+| MCP / A2A transports | Ingress labels `mcp` and `a2a` next to `http` | Gateway `IngressTransport`; x402 `TransportKind` |
+| x402 v2 | Buyer, seller, facilitator over HTTP, MCP, and A2A | `crates/layerx-x402` — [COMPATIBILITY.md](crates/layerx-x402/COMPATIBILITY.md) |
+| Ethereum / Solana mirrors | Batch archive publication and verification. Pure archives: no vault, no portal, no custody | `crates/layerx-mirror`; contracts in `contracts/ethereum-mirror/` and `contracts/solana-mirror/`; deploy notes in `deploy/mirror/` |
+| Ethereum / Solana migration | Source-chain verifiers and the `migration` adapter | `crates/layerx-migrate` — [OPERATIONS.md](crates/layerx-migrate/OPERATIONS.md) |
+| Portable receipts | Verify LayerX receipts without a live node | `crates/layerx-portable` — [PORTABILITY.md](PORTABILITY.md) |
+| Other adapters | AP2, UCP, Visa TAP, fiat rails | `crates/layerx-ap2`, `crates/layerx-ucp`, `crates/layerx-visa-tap`, `crates/layerx-fiat` |
+
+There is no standalone `layerx-a2a` crate. A2A is a transport on the gateway and on x402, plus the CLI installer in `platform/cli/`.
+
+## Two MCP surfaces
+
+| Surface | Role |
+| --- | --- |
+| `agent/crates/layerx-mcp` | Tenant- and scope-bound MCP server that routes every call through `layerx-agentd` |
+| This workspace + `platform/cli/` | MCP as an interop ingress; `layerx install mcp` / `layerx mcp serve` from the developer CLI |
+
+Normative MCP tool design: [`spec/layerx-agent-interface/docs/mcp-tools.md`](../spec/layerx-agent-interface/docs/mcp-tools.md). CLI install copy: [`platform/docs/content/install.md`](../platform/docs/content/install.md) and [`platform/docs/content/guide/interop.md`](../platform/docs/content/guide/interop.md).
+
+## Mirrors are archives
+
+`layerx-mirror-publisher` and `layerx-mirror-verify` publish and check batch commitments on Ethereum and Solana. Anyone can verify LayerX state from a mirror. Funds do not live on those chains. Settlement stays on Paxeer (EVM chain ID `125`), whose node now lives in [`paxeer-network/`](../paxeer-network/).
+
+Remote signer framing: [`deploy/mirror/signer-protocol.md`](deploy/mirror/signer-protocol.md).
+
+## Migrations (three different things)
+
+| Kind | Location |
+| --- | --- |
+| ETH / Solana source migration into LayerX | this workspace, `crates/layerx-migrate` |
+| LayerX genesis / cutover from the prior Go system | [`spec/layerx-protocol/docs/migration.md`](../spec/layerx-protocol/docs/migration.md) and [`migrations/`](../migrations/) |
+| Paxeer EVM store migrations | `paxeer-network/modules/evm/migrations/` (chain-internal; not a LayerX surface) |
+
+## Build and test
+
+From the monorepo root:
+
+```sh
+make interop-build
+make interop-test
+make interop-lint
+make interop-test-x402
+make interop-test-migration
+```
+
+Mirror publisher / verifier binaries:
+
+```sh
+cargo build --locked --release --manifest-path interop/Cargo.toml --package layerx-mirror --bin layerx-mirror-publisher
+cargo build --locked --release --manifest-path interop/Cargo.toml --package layerx-mirror --bin layerx-mirror-verify
+```
+
+`make mirror-live` and `make mirror-verify-live` are qualification entrypoints; they require operator configuration and are not a public RPC.

--- a/interop/crates/layerx-migrate/README.md
+++ b/interop/crates/layerx-migrate/README.md
@@ -1,0 +1,9 @@
+# layerx-migrate
+
+Ethereum and Solana source-chain verifiers for the `migration` interop adapter. This crate imports provenance against pinned source deployments. It does not write LayerX balances and it is not the C17 genesis cutover.
+
+Operator contract: [`OPERATIONS.md`](OPERATIONS.md). Workspace index: [`../../README.md`](../../README.md).
+
+LayerX genesis / cutover (different surface): [`spec/layerx-protocol/docs/migration.md`](../../../spec/layerx-protocol/docs/migration.md) and [`migrations/`](../../../migrations/README.md).
+
+From the monorepo root: `make interop-test-migration`. The ignored live-testnet suite is `make interop-test-migration-testnets` (manual workflow, operator environment).

--- a/interop/crates/layerx-mirror/README.md
+++ b/interop/crates/layerx-mirror/README.md
@@ -1,0 +1,14 @@
+# layerx-mirror
+
+Publishes LayerX batch archives to Ethereum and Solana, and verifies those archives. Pure archives: commitments plus retrievable data. No vault, no portal, no custody.
+
+Settlement stays on Paxeer. See the workspace index: [`../../README.md`](../../README.md).
+
+| Binary | Role |
+| --- | --- |
+| `layerx-mirror-publisher` | `cargo run --bin layerx-mirror-publisher -- <config.json>` |
+| `layerx-mirror-verify` | `cargo run --bin layerx-mirror-verify -- <config.json>` |
+
+On-chain programs: `interop/contracts/ethereum-mirror/`, `interop/contracts/solana-mirror/`. Remote signer framing: [`../../deploy/mirror/signer-protocol.md`](../../deploy/mirror/signer-protocol.md).
+
+From the monorepo root: `make interop-build`, `make interop-test`. Operator live targets: `make mirror-live`, `make mirror-verify-live`.

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,22 @@
+# LayerX migrations
+
+SQL and genesis artefacts for the C17 LayerX node: import sections, disposable projections, and the history index. This directory is not Ethereum/Solana migration tooling and not Paxeer's in-chain EVM store migrations.
+
+| File | Role |
+| --- | --- |
+| `0001_genesis_sections.sql` | Genesis import sections, per-asset totals, historical commitments |
+| `0001_projection.sql` | Rebuildable projection (balances, receipts, watermark) |
+| `0007_history_index.sql` | History index over the append-only log |
+
+The activity log is authoritative. These tables are projections and import bookkeeping; they can be rebuilt.
+
+## Related surfaces
+
+| Kind | Location |
+| --- | --- |
+| Normative genesis / cutover procedure | [`spec/layerx-protocol/docs/migration.md`](../spec/layerx-protocol/docs/migration.md) |
+| Genesis CLI | `cmd/layerx-genesis/` |
+| Ethereum / Solana source-chain migration | [`interop/crates/layerx-migrate`](../interop/crates/layerx-migrate/OPERATIONS.md) |
+| Paxeer EVM store migrations | `paxeer-network/modules/evm/migrations/` |
+
+`402LXP` is the only balance writer after genesis. Custody reconciliation is against Paxeer, not against a mirror chain.

--- a/paxeer-network/README.md
+++ b/paxeer-network/README.md
@@ -1,0 +1,89 @@
+# Paxeer Network
+
+**EVM Layer 1 (chain ID `125`). The settlement and custody layer for LayerX.**
+
+Paxeer is where LayerX checkpoints, custody, guarantor bonds, challenges, withdrawals, and emergency exits live. Ordinary LayerX activity stays on LayerX. Periodic checkpoints settle here so custody never leaves an L1 that can be replayed independently of the LayerX sequencer.
+
+This directory is that network: the `paxd` node, EVM/RPC surface, chain modules, storage engines, and Paxeer-native contracts. It lives in the [Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol) monorepo next to LayerX so the two can be reviewed together. Co-location does not grant LayerX authority over Paxeer, or the reverse. Each side keeps its own build, release tags, and trust boundary.
+
+LayerX is under active development and release qualification. Limited beta opens September 7. Source is available for inspection while that work finishes.
+
+## How it sits next to LayerX
+
+| Path | Owns |
+| --- | --- |
+| Repository root (`src/`, `include/`, `agent/`, `human/`, `platform/`, `programs/`, `interop/`) | LayerX execution: activities, `402LXP` balances, receipts, agent and human surfaces |
+| [`contracts/`](../contracts/) at the repository root | LayerX settlement contracts deployed *on* Paxeer: custody, checkpoints, bonds, claims, disputes, exits |
+| **This directory (`paxeer-network/`)** | Paxeer Network itself: `paxd`, EVM execution, JSON-RPC, chain modules, Docker, node distribution |
+| [`spec/`](../spec/) | Normative LayerX specifications (KVX first) |
+
+`402LXP` remains the only LayerX balance writer. There is no LayerX token. Paxeer is the custody domain; Ethereum and Solana mirrors in `interop/` are archives, not settlement venues.
+
+The Cosmos-style chain identifier used by node distribution is `hyperpax_125-1` (EVM chain ID `125`). See [`hpx/`](hpx/).
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `daemon/paxd/` | `paxd` node binary |
+| `node/` | Application wiring, genesis, upgrades |
+| `modules/` | Paxeer chain modules (`evm`, `epoch`, `mint`, `oracle`, `tokenfactory`) |
+| `rpc/` | EVM JSON-RPC compatibility |
+| `contracts/` | Paxeer-native Solidity (WPAX, pointers, precompile interfaces) — not the LayerX settlement contracts |
+| `consensus/`, `sdk/`, `storage/` | Consensus, Cosmos SDK fork, storage engines |
+| `docker/` | Local single-node and cluster compose |
+| `hpx/` | Native `paxd` distribution and peer registry tooling |
+| `docs/` | Subtree documentation (OpenAPI/Swagger, RPC notes) |
+
+Go module: `github.com/sidiora-labs/paxeer-network`.
+
+## Build and test
+
+Paxeer is a separate Go module. From the **monorepo root**:
+
+```sh
+make paxeer-build
+make paxeer-lint
+make paxeer-test
+make paxeer-ci
+```
+
+Those targets invoke this directory's Makefile. `make monorepo-ci` at the repository root composes the LayerX gate with `make paxeer-ci`. Paxeer releases use namespaced `paxeer-network/vX.Y.Z` tags.
+
+From **this directory**:
+
+```sh
+make build    # ./build/paxd
+make install  # go install ./daemon/paxd
+make lint
+make test
+make ci       # lint + test
+```
+
+Local Docker cluster targets (`docker-cluster-start`, `run-local-node`, and the rest) are documented in [`docker/README.md`](docker/README.md) and the Makefile. Paths in those files are relative to `paxeer-network/`.
+
+### Foundry
+
+Paxeer-native contracts use Foundry (`foundry.toml` in this directory). From here:
+
+```sh
+forge install
+forge build
+```
+
+See [`contracts/README.md`](contracts/README.md). LayerX settlement contracts at the repository root are a separate Solidity `0.8.27` tree.
+
+A successful local run is development evidence. It is not authorization to deploy validators, move custody, or handle real assets.
+
+## Documentation
+
+Start in [`docs/`](docs/):
+
+- [`docs/README.md`](docs/README.md) — subtree docs index and OpenAPI/Swagger generation
+- [`docs/evm_jsonrpc_unsupported.md`](docs/evm_jsonrpc_unsupported.md) — EVM JSON-RPC methods that return a documented error
+
+LayerX protocol behavior, including how checkpoints and custody bind to Paxeer, is specified under [`spec/layerx-protocol/`](../spec/layerx-protocol/).
+
+## License
+
+This subtree is published with the rest of the monorepo under the repository [`LICENSE`](../LICENSE): source-available for inspection and security review during qualification, with a broader license after that work completes.

--- a/paxeer-network/docs/README.md
+++ b/paxeer-network/docs/README.md
@@ -1,12 +1,36 @@
+# Paxeer Network documentation
+
+These files document the **Paxeer Network** subtree of [Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol). They are not a standalone repository. The node, modules, RPC, and chain contracts live in `paxeer-network/`; LayerX execution, settlement contracts, and specifications live beside it at the monorepo root.
+
+Paxeer is the EVM L1 (chain ID `125`) LayerX uses for custody and checkpoint settlement. Co-location in this monorepo does not merge the two trust boundaries.
+
+| Document | Contents |
+| --- | --- |
+| [`../README.md`](../README.md) | What this subtree is, how it sits next to LayerX, build and test entrypoints |
+| [`evm_jsonrpc_unsupported.md`](evm_jsonrpc_unsupported.md) | EVM JSON-RPC methods registered on Pax that return a documented error |
+| This page (below) | Regenerating the node's OpenAPI / Swagger UI |
+| [`../docker/README.md`](../docker/README.md) | Local Docker node and cluster |
+| [`../contracts/README.md`](../contracts/README.md) | Foundry / Hardhat for Paxeer-native contracts |
+| [`../modules/README.md`](../modules/README.md) | Chain modules under `modules/` |
+| [`../hpx/README.md`](../hpx/README.md) | `paxd` distribution and peer registry tooling |
+
+LayerX settlement contracts (custody, checkpoints, bonds, exits) are documented with the protocol at the repository root (`contracts/`, `spec/layerx-protocol/`). They are not this subtree's `contracts/` directory.
+
+Commands below are run from `paxeer-network/` unless noted.
+
+---
+
 # OpenAPI/Swagger docs generation
 
 > **Note:** Anytime we make changes to the APIs/proto files, we also need to update the Swagger/OpenAPI docs.
 
 Both Swagger and OpenAPI terms are used interchangeably in this document.
--  [OpenAPI](https://github.com/OAI/OpenAPI-Specification/) = specification
+
+- [OpenAPI](https://github.com/OAI/OpenAPI-Specification/) = specification
 - Swagger = Tools for implementing the specification.
 
 The process of Swagger docs generation involves running a script that does the following tasks:
+
 1. Generating the swagger yml file using the `ignite` tool.
 2. Updating the static assets for the Swagger UI.
 
@@ -15,39 +39,42 @@ The process of Swagger docs generation involves running a script that does the f
 The docs generation script uses the `ignite` tool to generate the OpenAPI docs.
 So, first install the `ignite` tool, if not installed already.
 We need version v0.23.0, which is outdated, but works with the current version of the codebase.
-Pull binaries from the [releases page](https://github.com/ignite/cli/releases/tag/v0.23.0) or install from source code 
+Pull binaries from the [releases page](https://github.com/ignite/cli/releases/tag/v0.23.0) or install from source code
 following instructions.
 
 Verify the installation by running `ignite version`:
 
 ```bash
-% ignite version          
+% ignite version
 ·
 · 🛸 Ignite CLI v28.2.0 is available!
 ·
 · To upgrade your Ignite CLI version, see the upgrade doc: https://docs.ignite.com/guide/install.html#upgrading-your-ignite-cli-installation
 ·
-··
+·
 
 Ignite CLI version:     v0.23.0
 ....
 
 ```
+
 ## Running the script
+
 Then run the following command to generate the OpenAPI docs and update static assets for Swagger UI:
 
 ```bash
 ./scripts/update-swagger-ui-statik.sh
 ```
-The script generates a new swagger/openapi yml and saves it as `docs/swagger-ui/swagger.yml`.
-It will then embed the yml file and static assets in `docs/swagger-ui/` directory into the `docs/swagger/statik.go` file.
 
-If swagger endpoint is configured, the app on startup will "read" `statik.go` and make it's content available at the 
+The script generates a new swagger/openapi yml and saves it as `docs/swagger-ui/swagger.yml` under this subtree.
+It will then embed the yml file and static assets in `docs/swagger-ui/` into the `docs/swagger/statik.go` file.
+
+If swagger endpoint is configured, `paxd` on startup will read `statik.go` and make its content available at the
 `/swagger/` endpoint.
 
 # Serving the OpenAPI docs on the node
 
-To start serving the docs, enable the swagger docs serving. 
+To start serving the docs, enable the swagger docs serving.
 To do that, update `api.swagger` value to `true` in the `app.toml` file.
 
 ```toml
@@ -63,4 +90,5 @@ enable = true
 # Swagger defines if swagger documentation should automatically be registered.
 swagger = true
 ```
-Once node is restarted, swagger docs will be available at `http://<node-ip>:<port>/swagger/`
+
+Once the node is restarted, swagger docs will be available at `http://<node-ip>:<port>/swagger/`.

--- a/paxeer-network/docs/evm_jsonrpc_unsupported.md
+++ b/paxeer-network/docs/evm_jsonrpc_unsupported.md
@@ -1,5 +1,7 @@
 # Pax EVM JSON-RPC: explicitly unsupported methods
 
+This page is Paxeer Network RPC documentation inside [Sidiora-Labs/LayerX-Protocol](https://github.com/Sidiora-Labs/LayerX-Protocol) (`paxeer-network/`). It is not a standalone repository.
+
 Some Ethereum JSON-RPC methods are **registered** on Pax’s EVM endpoint but return a **JSON-RPC error** instead of a result, so clients and tools get a stable, documented failure (code **`-32000`**) rather than “method not found” (`-32601`).
 
 ## Methods

--- a/spec/layerx-protocol/docs/migration.md
+++ b/spec/layerx-protocol/docs/migration.md
@@ -9,6 +9,17 @@ over. MUST, MUST NOT, SHOULD and MAY are normative; companion documents under
 `spec/layerx-protocol/docs/` are `economics.md` (reserve accounting),
 `data-availability.md`, `checkpointing.md` and `state-machine.md`.
 
+This document is the LayerX genesis / cutover procedure (prior Go system → C17).
+It is not Ethereum/Solana source-chain migration and not Paxeer EVM store
+migration. Those live elsewhere in this monorepo:
+
+| Surface | Location |
+|---|---|
+| Genesis SQL and projections | [`migrations/`](../../../migrations/README.md) |
+| Ethereum / Solana source verifiers | [`interop/crates/layerx-migrate`](../../../interop/crates/layerx-migrate/OPERATIONS.md) |
+| Paxeer EVM store migrations | `paxeer-network/modules/evm/migrations/` |
+| Paxeer Network (settlement L1) | [`paxeer-network/`](../../../paxeer-network/README.md) |
+
 ## 1. Posture
 
 The new protocol starts from an **explicit genesis manifest**. It does not


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only. Do not merge — Andrew will merge.

Monorepo finder docs after `paxeer-network/` landed in this repo. No protocol, fee table, or status scoreboard in this PR.

## Claim lock

- Limited beta opens September 7. Source-available during qualification.
- No public LayerX RPC. No LayerX token.
- Base fee, if stated elsewhere, is **5,000 µUSDX per activity** (~½¢). This PR does not write a Fees or Status wiki page.
- No invented qualification scoreboard, live metrics, or unpublished genesis numbers.

## Files

**Paxeer subtree**

- `paxeer-network/README.md` — new. Paxeer Network (EVM L1, chain ID 125) as LayerX settlement/custody; how it sits next to LayerX; `make paxeer-*`, Go, Foundry; pointer to `paxeer-network/docs/`.
- `paxeer-network/docs/README.md` — retitled as monorepo docs index; keeps Swagger/OpenAPI generation.
- `paxeer-network/docs/evm_jsonrpc_unsupported.md` — one-line Sidiora-Labs/LayerX-Protocol home, not a standalone repo.

**MCP / A2A / mirrors / migrations (where they live)**

- `interop/README.md` — new workspace index (gateway, x402 MCP/A2A transports, mirrors, migrate). No standalone A2A crate.
- `interop/crates/layerx-mirror/README.md`
- `interop/crates/layerx-migrate/README.md`
- `agent/README.md` — MCP pointer.
- `agent/crates/layerx-mcp/README.md` — daemon-bound MCP tools.
- `migrations/README.md` — LayerX genesis/projection SQL, distinguished from ETH/Solana migrate and Paxeer EVM store migrations.
- `spec/layerx-protocol/docs/migration.md` — related-surfaces box only.

**Wiki drafts** (no wiki PR flow; Andrew copies after merge to https://github.com/Sidiora-Labs/LayerX-Protocol/wiki)

- `docs/wiki-drafts/Developers.md`
- `docs/wiki-drafts/Security.md`

## Left alone

`CONTRIBUTING.md`, `QUALIFICATION.md`, `docs/MONOREPO.md`, `programs/` README, wiki Home / Protocol / Modules / Finality / Payments / Fees / Status drafts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16ab7bbe-21c2-453d-a456-4fecaabc2f73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16ab7bbe-21c2-453d-a456-4fecaabc2f73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

