### PR TITLE
docs(programs): README + wiki Protocol/Modules/Finality drafts

### DIFF
--- a/docs/wiki/Finality.md
+++ b/docs/wiki/Finality.md
@@ -1,0 +1,77 @@
+<!--
+Draft copy for the GitHub wiki page "Finality".
+The wiki has no PR flow, so this file is the reviewable source. After this PR
+merges, paste the body below (everything under the first `# Finality`) into the
+wiki page. Do not commit this note to the wiki.
+-->
+
+# Finality
+
+Ordered instantly in-channel. Anchored to Paxeer on the L0 → L4 ladder.
+
+An activity is not final all at once. Each step names who is on the hook if the claim turns out to be wrong. The guarantee behind a batch is not a validity proof. It is bonded re-execution, a challenge window, and withdrawal limits.
+
+LayerX and the Paxeer settlement stack now live in one monorepo, so the whole path — from the sequencer that orders an activity to the Paxeer contracts that register a checkpoint — is auditable in one place. Paxeer Network is EVM chain ID `125`, and its node and contracts live under `paxeer-network/`. Custody still only moves on the Paxeer side; co-location changes nothing about the trust boundary.
+
+---
+
+## The ladder
+
+| Step | Name | What it means | Who is on the hook |
+| --- | --- | --- | --- |
+| L0 | Accepted | The sequencer orders the activity into the current batch and issues a receipt chained to the state root | The sequencer, for inclusion and ordering in this batch |
+| L1 | Sealed | The batch is sealed. Ordering is now fixed. Empty-seal / liveness timers apply if the sequencer stalls | Sequencer liveness; replicas hold the sealed bytes |
+| L2 | Distributed | The sealed batch and DA bundle go to the guarantor quorum for independent re-execution | Data availability: anyone must be able to replay |
+| L3 | Attested | Bonded guarantors re-execute and attest byte-identical results | Guarantor bonds. Conflicting attestations slash |
+| L4 | Settled | The checkpoint lands on Paxeer L1. Custody never leaves Paxeer | Paxeer custody, challenge window, withdrawal limits, emergency exits |
+
+Fast path is L0–L1: agents get a receipt in-channel. Settlement path is L2–L4: the same history becomes something Paxeer will hold and an exit can prove against.
+
+---
+
+## What stands behind a batch
+
+Independent operators re-run every batch and check that they get the same result, byte for byte. They are guarantors. A signature is an attestation, not a SNARK.
+
+Before an activity is L4-settled, what stands behind it is:
+
+- guarantor bonds,
+- the challenge window,
+- limits on how fast anything can be withdrawn.
+
+Those put a price on what a dishonest quorum could cost you. The whitepaper and security model name the risks that remain.
+
+---
+
+## Everything in the batch replays — including programs
+
+A batch is not just payments. Program calls, program-owned account transfers, and storage-occupancy settlement all land in the same ordered history and are re-executed the same way. Program execution is deterministic for exactly this reason: guarantors must reach byte-identical results, and every monetary effect a program produces is a `402LXP` transfer set carried in the batch, never a private balance write. Occupancy charges — rent on namespace bytes held across batches — settle into the batch receipt as replay-checkable evidence, so a guarantor can reproduce them from the log alone.
+
+---
+
+## Sequencer stall (named, not silent)
+
+If the sequencer stops sealing, the protocol does not pretend otherwise. The security model specifies empty-seal and liveness timers and an exit path onto Paxeer. LayerX is designed so ordinary activity never requires a Paxeer transaction — and so an exit still exists when the fast path is stuck.
+
+---
+
+## Replay is the authority
+
+The append-only activity log is the record. Database indexes are disposable. Replicas serve full history. Guarantors replay before they attest. A node that cannot reproduce a state root from the log is not a source of truth.
+
+That is why consensus execution forbids floating point, local clocks, and unstable iteration: L3 only works if two honest machines get the same bytes.
+
+---
+
+## What LayerX is not claiming here
+
+This ladder is how LayerX qualifies a checkpoint onto Paxeer. It is not a public-mainnet RPC, and it is not "final on L0." Receipts at accept are evidence of ordering in-channel. Custody moves on the Paxeer side at L4. Limited beta opens September 7; source is open for inspection while the public lane is qualified, and there is no public RPC, faucet, or explorer for LayerX itself yet.
+
+---
+
+## Start here
+
+- Home
+- Protocol — LXC envelope and the three rules
+- Modules — the eight economic modules and the programs surface
+- Security

--- a/docs/wiki/Modules.md
+++ b/docs/wiki/Modules.md
@@ -1,0 +1,116 @@
+<!--
+Draft copy for the GitHub wiki page "Modules".
+The wiki has no PR flow, so this file is the reviewable source. After this PR
+merges, paste the body below (everything under the first `# Modules`) into the
+wiki page. Do not commit this note to the wiki.
+-->
+
+# Modules
+
+Eight economic modules on a kernel that owns identity and authority.
+
+Programs and oracle intake are separate surfaces — not extra module IDs.
+
+---
+
+## The registered set (0x01–0x08)
+
+| ID | Module | What it does |
+| --- | --- | --- |
+| `0x01` | asset | Transfer sets that move value. `402LXP` is the writer. |
+| `0x02` | escrow | Money held until the terms are met |
+| `0x03` | budget | A hard ceiling on what an agent may spend |
+| `0x04` | stream | Paying continuously, by the unit |
+| `0x05` | service | Agreeing work, proving it, delivering it |
+| `0x06` | perps | Leveraged positions and their margin accounts |
+| `0x07` | governance | Changing protocol settings, on a timelock |
+| `0x08` | bridge | Custody on Paxeer L1, and withdrawal claims |
+
+Module IDs are stable and never reused. They occupy the high 16 bits of `activity_type`. An unknown or epoch-disabled module is refused — not best-effort decoded.
+
+Runtime sources live under `src/modules/` (`asset`, `escrow`, `budget`, `stream`, `service`, `perps`, `governance`, `bridge`, plus `programs` as a separate surface). Since the monorepo integration, the Paxeer settlement stack these modules checkpoint to lives in the same repository under `paxeer-network/` (EVM chain ID `125`).
+
+---
+
+## One doorway for money
+
+`402LXP` is the sole balance writer. That is the feature, not a caveat.
+
+Modules never call `set_balance`. They emit transfer sets — one or more legs with a single authorization context, a single sequence, and a single receipt. All legs commit, or none do. Per asset, Σ debits = Σ credits.
+
+Locked funds are real accounts, not hidden columns:
+
+```
+agent:<did>:main
+agent:<did>:budget:<id>
+agent:<did>:escrow:<id>
+agent:<did>:stream:<id>
+agent:<did>:margin:<position>
+module:programs:value:<account-id>
+system:fees
+system:paxeer-reserve
+```
+
+Opening a position is a transfer into a margin account. Capturing escrow is a transfer out of an escrow account. Ordinary modules do not mint and do not burn.
+
+See Payments and Fees.
+
+---
+
+## Not modules
+
+| Surface | Where it lives | Why it is not `0x09` / `0x0A` |
+| --- | --- | --- |
+| Identity & authority | Kernel | DIDs, keys, grants, rotation, recovery — universal to every activity |
+| Oracle / Crossverse | Outside adapter | Signed oracle activities enter the ordered history; execution never dials out |
+| Programs | Separate runtime (`src/modules/programs`, `programs/`) | Guest execution and program-owned accounts — a first-class surface, not a ninth economic module ID on this table |
+
+---
+
+## What each module is for
+
+**asset.** SEND and RECEIVE compile to the same internal transfer. RECEIVE requires a payer grant: one recipient, one account, caps, purpose, expiry. No wildcards.
+
+**escrow.** Lock, capture, release. Terms are module state; money moves only as `402LXP` legs.
+
+**budget.** Fund a ceiling, spend from it, expire or revoke it. Delegation is a grant, not a second wallet.
+
+**stream.** Continuous, metered payment by the unit, drawn under the same conservation rules.
+
+**service.** Offers, commitments, delivery attestations, acceptance, disputes. Payment still walks through `402LXP`.
+
+**perps.** Positions, margin, funding, liquidation, insurance. Losses and fees are transfer legs, not shadow balances.
+
+**governance.** Parameter changes on a timelock. Emergency freezes are named, narrow, and themselves activities.
+
+**bridge.** Deposits and withdrawals against Paxeer custody. The reserve mirror is an ordinary account so conservation still holds.
+
+---
+
+## Programs: the first-class execution surface
+
+Programs run untrusted guest code on a deterministic WASM runtime under the authority of the activity that invoked them. A program is a first-class surface, not a ninth economic module, and it never gains balance-writing authority — every monetary effect it produces compiles to a `402LXP` transfer set the kernel applies. The runtime, registry, SDKs, and porting kits live under `programs/`.
+
+- **Program-owned accounts.** Derived deterministically from `(program_id, seed)` under a domain-separated hash that is disjoint from principal account ids. No principal can claim or sign for a program account; deriving one conveys no spending authority. A principal can fund a program account but can never authorize debits from it. Program value accounts appear on the money map as `module:programs:value:<account-id>`.
+- **Downward-only spending grants.** A program-to-program call can convey a bounded spending grant over the caller's own derived accounts. It narrows only — asset, destination, source, and amount may shrink, never grow. Any widening is refused with the same typed escalation error principal grants use, and no partial transfer set survives.
+- **Occupancy settlement.** State that persists is paid for as long as it persists. Occupancy meters namespace bytes held across protocol batches, priced by the fee schedule and charged to the account declared responsible for that namespace, settled as `402LXP` legs and bound into the batch receipt.
+- **Protocol-backed balances.** A program's balance is real protocol state, read from the account tree through Merkle proofs — not a registry counter. `402LXP` stays the only writer; programs emit transfer sets and never call `set_balance`.
+
+See `programs/README.md`.
+
+---
+
+## Kernel boundary
+
+The kernel understands identities, accounts, assets, authority, sequences, fees, receipts, checkpoints, and module dispatch. It does not understand funding rates or delivery acceptance.
+
+Each module implements `genesis`, `decode`, `validate` (read-only), `execute` (effects to a buffer only), epoch hooks, and `state_root`. The context handle is the complete capability set: namespaced KV, emit transfer set, emit event, batch timestamp, charge gas. There is no `now()`, no `random()`, no `http()`, and no `set_balance()`.
+
+---
+
+## Start here
+
+- Home
+- Protocol — LXC envelope and the three rules
+- Finality — L0 → L4
+- Design § modules

--- a/docs/wiki/Protocol.md
+++ b/docs/wiki/Protocol.md
@@ -114,6 +114,8 @@ Per activity the kernel, in fixed order:
 
 Receipts are evidence produced by the protocol. No receipt field is supplied by a client.
 
+You pay for the work an activity does — bytes, signatures, state — not a zero-fee line. The specified base fee is 5,000 µUSDX per activity (about half a cent). See Payments and Fees.
+
 ---
 
 ## Status

--- a/docs/wiki/Protocol.md
+++ b/docs/wiki/Protocol.md
@@ -1,0 +1,130 @@
+<!--
+Draft copy for the GitHub wiki page "Protocol".
+The wiki has no PR flow, so this file is the reviewable source. After this PR
+merges, paste the body below (everything under the first `# Protocol`) into the
+wiki page. Do not commit this note to the wiki.
+-->
+
+# Protocol
+
+One signed record per action. One doorway for money. One result anyone can replay.
+
+LayerX is the activity, execution, and accounting layer for autonomous agents. Paxeer Network (EVM chain ID `125`) holds custody, checkpoints, bonds, challenges, and exits. A normal payment or agent action does not require a Paxeer transaction.
+
+LayerX and the Paxeer settlement stack now live in one monorepo. Co-location keeps the protocol, the settlement network, the developer surfaces, and their automation auditable in one place while preserving their separate build, release, and trust boundaries — repository co-location grants neither side new authority over the other. LayerX settles on Paxeer; the settlement code lives under `paxeer-network/`.
+
+Normative behavior lives in `spec/` (KVX first). This page is the human read of that design.
+
+---
+
+## Execution vs settlement
+
+| LayerX owns | Paxeer owns |
+| --- | --- |
+| Agent identities and delegated authority | Asset custody |
+| Global activity ordering | Deposits and withdrawals |
+| Payments and balances (`402LXP`) | Checkpoint registration |
+| Holds, escrow, budgets, streams | Guarantor bonds |
+| Service agreements, deliveries, attestations | Checkpoint attestations |
+| Trading, positions, funding, liquidation | Slashing for conflicting attestations |
+| Programmable guest execution (programs) | Emergency exits and dispute settlement |
+| Deterministic state execution, receipts, replay | Final settlement to external assets |
+| Data availability and reconstruction | |
+
+Thousands of LayerX activities can collapse into one periodic checkpoint. Custody never leaves Paxeer.
+
+---
+
+## The activity (LXC/1)
+
+Every state-changing operation is one signed activity: a payment, an escrow capture, a budget spend, a stream draw, a service delivery, a perp fill, a governance change, a bridge claim, or a program call.
+
+The wire format is LXC/1 — a canonical binary envelope, not a convenience JSON. Integers are fixed-width and big-endian. There are no optional fields, no maps, and no floating point. Decoding is total: trailing bytes are an error. Re-encoding a valid activity must yield the same bytes.
+
+Typical envelope fields (illustrative names; see the design for encodings):
+
+| Field | Role |
+| --- | --- |
+| `protocol_version` | Must be enabled for the batch epoch |
+| `network_id` | Exact match; blocks cross-network replay |
+| `activity_type` | High 16 bits = module id, low 16 = type ordinal |
+| `actor_did` | Who is acting |
+| `authority` | Primary key, session, or scoped grant |
+| `account_sequence` | Must equal `next_sequence[actor]` exactly — gaps are rejected |
+| `timestamp_bound` | Window checked against the batch timestamp, never node wall-clock |
+| `idempotency_key` | A repeat returns the original receipt with zero new economic effect |
+| `fee_limit` | Must cover the deterministically computed fee |
+| `payload` / `payload_hash` | Module-specific body; hash checked before parse |
+| `signature` | Ed25519 over the canonical prefix |
+
+The protocol verifies the actor and its authority, consumes the sequence, orders the activity globally, applies a deterministic state transition, and returns a signed receipt tied to the resulting state root.
+
+Failed activities still consume sequence, still pay the fee, and still occupy a global sequence number. Effects from the module roll back; bookkeeping does not.
+
+---
+
+## Three design rules
+
+1. **One canonical history.** Every accepted or failed activity receives a global sequence. State roots chain per activity, not only per batch. The append-only activity log is authoritative. Indexes are disposable projections and can be rebuilt by replay.
+2. **One financial doorway.** `402LXP` is the only component allowed to write balances. Modules — and programs — emit validated transfer sets; they do not mutate funds themselves. See Payments and Fees.
+3. **One reproducible result.** Consensus-critical execution excludes floating point, local clocks, database iteration order, pointer-derived hashes, and other sources of nondeterminism. Replicas and bonded guarantors independently replay batches before a checkpoint is attested to Paxeer.
+
+---
+
+## Identity and authority (kernel)
+
+Identity is kernel, not a module. Agent DIDs are native accounts. Authorization is part of the state machine: primary keys, session keys, scoped capability grants, rotation, recovery, revocation, and expiry.
+
+A grant can be narrowed but not silently widened. Bumping `revocation_sequence` invalidates grants that still reference the old value. Retirement requires a zero balance sheet so value cannot be stranded.
+
+Oracle prices enter as signed activities through a Crossverse adapter — outside the kernel, inside the ordered history. There is no HTTP call from inside a state transition.
+
+---
+
+## Programs: a first-class execution surface
+
+Programs are where untrusted guest code runs. They are a first-class surface alongside the eight economic modules — not a ninth economic module ID. A program executes inside the authority of the activity that invoked it, on a deterministic WASM runtime, and it never gains balance-writing authority: every monetary effect it produces compiles to a `402LXP` transfer set applied by the kernel. The runtime, registry, SDKs, and porting kits live under `programs/`.
+
+Four rules define the programs money story:
+
+- **Program-owned accounts.** A program can own accounts derived deterministically from `(program_id, seed)` under a domain-separated hash. Derivation is a pure function of public inputs, and the domain is disjoint from principal account ids — so no principal can claim or sign for a program account. Deriving an account conveys no spending authority; a principal can fund one but can never authorize debits from it.
+- **Downward-only spending grants.** A program-to-program call can convey a bounded spending grant over the caller's own derived accounts. It narrows only: asset, destination, source, and amount can shrink, never grow. Any attempted widening fails with the same typed escalation refusal principal grants use, and no partial transfer set survives.
+- **Occupancy settlement.** Storage that persists is paid for as long as it persists. Occupancy meters namespace bytes held across protocol batches, priced by the fee schedule and charged to the account declared responsible for that namespace — settled as ordinary `402LXP` legs and bound into the batch receipt as replay-checkable evidence.
+- **Protocol-backed balances.** A program's balance is real protocol state read from the account tree through Merkle proofs, not a bookkeeping column. `402LXP` remains the sole balance writer; programs emit transfer sets and never call `set_balance`.
+
+See Modules and `programs/README.md`.
+
+---
+
+## From activity to receipt
+
+Per activity the kernel, in fixed order:
+
+1. Decode the envelope.
+2. Check `network_id`, `protocol_version`, module enablement.
+3. Resolve `actor_did` and `authority`; verify the signature.
+4. Check `account_sequence == next_sequence[actor]`.
+5. Check `timestamp_bound` against the batch timestamp.
+6. Check idempotency (hit → original receipt, no new effect).
+7. Compute the fee against `fee_limit`.
+8. Open a state journal; `validate` then `execute`.
+9. Commit on success, roll back on failure.
+10. Charge the fee as a `402LXP` transfer, consume the sequence, record the idempotency key, emit the receipt — all four on both success and failure.
+11. Recompute the state root and chain it into the receipt.
+
+Receipts are evidence produced by the protocol. No receipt field is supplied by a client.
+
+---
+
+## Status
+
+Limited beta opens September 7. Source is open for inspection while the public lane is qualified. There is no public RPC, faucet, or explorer for LayerX itself yet, and no public LayerX mainnet — custody and settlement live on Paxeer.
+
+---
+
+## Start here
+
+- Home
+- Modules — the eight economic modules and the programs surface
+- Finality — L0 → L4
+- Design § protocol

--- a/programs/README.md
+++ b/programs/README.md
@@ -1,0 +1,255 @@
+# LayerX Programs
+
+**The programmable runtime for LayerX — deterministic guest execution with no balance-writing authority.**
+
+This workspace holds the LayerX programs surface: a deterministic WASM runtime, the
+registry that proves what a program deployed and what it holds, the C↔Rust bridge into
+the protocol kernel, developer SDKs, porting kits, and the adversarial test corpus.
+
+Programs are a **first-class execution surface**, not one of the protocol's economic
+modules. The eight economic modules (`0x01`–`0x08`) are documented in
+[`src/modules`](../src/modules) and the project wiki; programs sit alongside them as the
+place where untrusted guest code runs. Guest execution is dispatched under the programs
+module inside the runtime module registry (`LXP_MODULE_PROGRAMS = 9` in
+[`include/layerx/lxp_module.h`](../include/layerx/lxp_module.h)), but a program is not a
+ninth economic module and writes no balances of its own. Every monetary effect a program
+produces compiles to an authenticated `402LXP` transfer set applied by the kernel — the
+same single money doorway every module uses.
+
+Where the rest of the system fits:
+
+- **Identity and authority are kernel**, not a program concern. A program executes inside
+  the authority of the activity that invoked it and can never widen it.
+- **`402LXP` is the sole balance writer.** Programs emit transfer sets; they do not call
+  `set_balance` (no such function exists).
+- **Oracle prices** enter through the Crossverse adapter as signed activities, outside
+  execution. A state transition never dials out.
+- **Settlement** happens on Paxeer Network (EVM chain ID `125`). LayerX orders and
+  executes activity; periodic checkpoints settle on Paxeer. Since the monorepo
+  integration, the Paxeer settlement stack lives in this same repository under
+  [`paxeer-network/`](../paxeer-network) — co-located, but with its own trust and build
+  boundary (see [`docs/MONOREPO.md`](../docs/MONOREPO.md) once published, and the root
+  [`README.md`](../README.md)).
+
+Normative behavior lives in [`spec/`](../spec) (KVX first). This document is the human
+read of the programs workspace and is not a substitute for the spec.
+
+---
+
+## Workspace layout
+
+The programs workspace is a Cargo workspace (`programs/Cargo.toml`) with a strict lint
+profile: `unsafe_code` is denied by default, and `unwrap_used`, `expect_used`, and float
+arithmetic are denied across the tree.
+
+| Path | Purpose |
+| --- | --- |
+| `crates/layerx-programs-runtime` | Deterministic WASM runtime: validation, metering, the ABI/capability boundary, cross-program calls, transfers, occupancy accounting, and the FFI bridge into the C kernel |
+| `crates/layerx-programs-registry` | Receipt-bound registry: deployment journal, program value-account bindings, real-balance proofs, and wind-down/deprecation |
+| `crates/layerx-programs-protocol-adapter` | Thin C↔Rust adapter exposing receipt-verified program state reads to the rest of the protocol |
+| `sdk/rust`, `sdk/c`, `sdk/assemblyscript` | Guest program SDKs for the version-one programs ABI, each with a `paid-counter` example |
+| `porting/evm`, `porting/solana`, `porting/cosmwasm` | Migration crates and `MIGRATION.md` guides mapping Solidity / Anchor / CosmWasm vocabulary onto the programs ABI |
+| `fuzz` | Structure-aware fuzz target and corpus for the runtime |
+| `tools` | Boundary scripts: `dependency-policy.sh`, `runtime-module-boundaries.sh` |
+| `tests` | Cross-implementation vectors, the hostile-program `gauntlet`, and calldata fixtures |
+| `vendor` | Vendored, pinned dependencies for a hermetic build |
+
+### The three crates
+
+**`layerx-programs-runtime`** is the deterministic WASM foundation for guest programs.
+It runs on a pinned `wasmi` interpreter with floating point and other nondeterminism
+removed. The module map (see `src/lib.rs`) separates concerns deliberately:
+
+- `validate.rs`, `limits.rs` — static module validation and structural bounds (module
+  bytes, function count, stack height, call depth).
+- `budget.rs`, `meter.rs` — caller-declared activity ceilings, the admitted budget token,
+  and per-execution resource metering (CPU fuel, memory, storage read/write, output).
+- `abi/` — the transaction boundary. `abi/capability.rs` owns capability grants, their
+  canonical encoding, and downward-only narrowing; `abi/response.rs` owns response and
+  refusal transport; `abi/storage_ops.rs` owns namespaced storage.
+- `accounts.rs` — deterministic derivation of program-owned accounts.
+- `transfer.rs`, `ffi_transfer.rs` — the sole monetary exit: typed `402LXP` requests
+  bound to invocation authority and submitted as one atomic set to the kernel primitive.
+- `occupancy.rs` — deterministic, receipt-bound storage-occupancy accounting.
+- `calls.rs`, `engine.rs`, `execute.rs`, `entrypoint.rs`, `lifecycle.rs` — cross-program
+  calls, execution, and program lifecycle.
+- `host/` — linker orchestration; each host-function family (storage, events, calls,
+  transfer) is registered in exactly one unit and reaches execution state only through
+  `RuntimeState`.
+- `ffi.rs`, `ffi_call.rs` — the FFI bridge the C protocol module calls into.
+
+**`layerx-programs-registry`** (`#![forbid(unsafe_code)]`) turns protocol receipts into
+answers about programs: the append-only `DeploymentJournal`, `ProgramValueAccountBinding`
+records, and `VerifiedAccountSnapshot`/`ValueAccount` types that resolve a program's real
+balance from account-tree Merkle proofs rather than a declared bookkeeping column. It also
+owns deprecation and wind-down (`AuthorizedExit`, `ExitRoute`, `WindDownView`).
+
+**`layerx-programs-protocol-adapter`** is the narrow read bridge: `read_program_state`
+exposes receipt-verified program state (`ProtocolProgramStateRead`) to the C protocol and
+the hosted read surfaces without granting any write authority.
+
+---
+
+## Protocol surfaces
+
+Four surfaces landed with and around the monorepo integration. Each is described here as
+it is actually implemented; the authoritative source is the code and
+[`spec/layerx-platform`](../spec/layerx-platform) (requirement `37`, tasks `30.1`–`30.5`,
+and requirement `36.5` for occupancy).
+
+### Program-owned accounts
+
+A program can own accounts that no principal can claim. An account id is derived
+deterministically from the program and a seed — a pure function of public inputs, with no
+host state, clock, or entropy involved:
+
+```
+account_id = SHA-256(
+    "LayerX/programs/program-account/v1\0"   // domain tag, distinct from principal ids
+    || program_id                            // 32 bytes, bound before the seed
+    || u32_be(seed_len)                      // length prefix removes concatenation ambiguity
+    || seed                                  // up to 128 bytes
+)
+```
+
+The construction is domain-separated: the tag is disjoint from the `LX:ACCOUNT:v1` domain
+used for principal/named account ids, so a principal cannot present a public key whose
+identifier collides with a derived program account without breaking SHA-256 preimage
+resistance. The C kernel (`src/modules/programs/accounts.c`) and the Rust runtime
+(`accounts.rs`) agree byte-for-byte, and frozen golden vectors pin the digests.
+
+Deriving an account conveys **no authority**. Program value accounts are registered as
+`LX_ACCOUNT_MODULE_VALUE` accounts that carry no authority key, so:
+
+- the ordinary account-open path refuses the `module:programs:value:…` namespace;
+- registration is gated on the program owner, not first-caller squatting;
+- debits require program authority bound to the deriving program's own frame and exact
+  seed (re-derived and checked at transfer time), never a principal signature.
+
+A principal can **fund** a program account (an ordinary `402LXP` credit leg) but can never
+**authorize debits** as if it owned the account.
+
+### Downward-only spending grants
+
+Spending authority narrows, never widens. The `ProgramSpend` capability
+(`abi/capability.rs`) conveys a bounded grant over accounts the granting program itself
+derives — distinct from the `Transfer402` grant over the invoking principal's balance. It
+binds `owner_program`, `seed`, `source_account`, `asset`, `to`, and a `maximum_amount`.
+
+Across a program-to-program call edge the grant may only be narrowed:
+
+- any change to identity fields (`owner_program`, `seed`, `source_account`, `asset`, `to`)
+  produces a different capability key, so the parent lookup fails and the edge is refused
+  with the same typed capability-escalation error principal grants already use;
+- an attempt to raise `maximum_amount` above the parent's is refused; a child amount must
+  be less than or equal to the parent's;
+- only the **owner program** may originate a fresh `ProgramSpend` over its own account on
+  an edge; a callee cannot mint authority it was not given.
+
+At transfer time the grant is checked cumulatively against the actual legs, and the
+deriving program's frame is the only frame that may stage a program-account debit. There
+is no silent widen and no partial transfer set survives a refused escalation.
+
+### Occupancy settlement
+
+State that persists is paid for as long as it persists. Occupancy is deterministic,
+batch-indexed rent for persistent program storage — it meters **namespace bytes held
+across protocol batches**, priced by the fee schedule. There is no wall-clock component:
+"time" here is the protocol batch sequence.
+
+For each occupied storage namespace over a batch interval:
+
+```
+byte_batches = recorded_bytes × (to_batch − from_batch)
+accrued_fee  = byte_batches × occupancy_byte_batch_price
+amount_due   = prior_arrears + accrued_fee
+```
+
+Before writing storage a call must establish a signed responsibility mandate that names
+the payer and caps both the bytes and the lifetime charge; the occupancy fee budget is
+carved out of the activity's signed fee limit, separate from the execution meter. Each
+charge resolves to a disposition — `Paid`, `ChargeCeilingExceeded` (namespace frozen),
+`ScheduleCeilingExceeded`, `InsufficientFunds`, or `MigrationRequired` (pre-upgrade legacy
+bytes, frozen at price zero until the owner migrates). Settlement is charged to the
+declared responsible account through ordinary `402LXP` transfer legs and bound into the
+batch receipt as canonical, replay-checkable evidence. The principal-scoped namespace is
+charged to its principal; a shared namespace is charged to the program owner.
+
+### Protocol-backed program balances
+
+A program's balance is real protocol state, not a registry counter. Registry value
+accounts are the same `LX_ACCOUNT_MODULE_VALUE` accounts that live in the kernel account
+tree; the registry reads a balance by verifying the account leaf through the account root,
+the universal subtree root, and the receipt state root before surfacing it. Wind-down
+refuses to strand value: a deprecation cannot complete while a bound account still carries
+a non-zero balance without an authorized exit route.
+
+The invariant that ties all of this together: **`402LXP` remains the sole balance
+writer.** Programs emit transfer sets — they never set a balance directly. As the platform
+spec puts it, *"No program ever receives balance-writing authority. Every monetary effect
+a program produces is expressed as authenticated 402LXP transfers applied by the kernel
+transfer primitive… a balance change outside a 402LXP transfer aborts the transition."*
+
+---
+
+## SDKs and porting kits
+
+Guest program SDKs target the version-one programs ABI:
+
+- **`sdk/rust`** (`layerx-program-sdk`) — the Rust guest SDK.
+- **`sdk/c`** — a C guest SDK with headers, sources, and a toolchain manifest.
+- **`sdk/assemblyscript`** — an AssemblyScript SDK (`abi`, `capability`, `transfer`,
+  `storage`, `event`, `call`, `receipt` bindings) with a determinism lint.
+
+Each SDK ships a `paid-counter` example: the smallest program that charges for the work it
+does and returns a receipt. Note that the newer program-spend capability tag is a
+candidate-ABI addition and is not yet mirrored into every SDK; the runtime crate is the
+authoritative implementation.
+
+The porting kits map familiar contract vocabularies onto the programs ABI and are explicit
+about what does not carry over:
+
+- **`porting/evm`** — porting a Solidity contract.
+- **`porting/solana`** — porting a Solana / Anchor program.
+- **`porting/cosmwasm`** — porting a CosmWasm contract.
+
+Each has a `MIGRATION.md` written for a developer who already knows the source chain.
+
+---
+
+## Fuzzing, tools, and tests
+
+- **`fuzz/`** — a structure-aware fuzz target (`src/main.rs`) with a checked-in corpus.
+- **`tools/dependency-policy.sh`** — enforces the vendored-dependency policy (`deny.toml`).
+- **`tools/runtime-module-boundaries.sh`** — enforces the runtime's module-boundary rules.
+- **`tests/gauntlet/`** — the hostile-program gauntlet (cross-program derivation, callee
+  spend attempts, escalation across depth/fan-out/repeated visits) with an
+  `attack-inventory.tsv`.
+- **`tests/vectors/`** — cross-implementation vectors, including calldata fixtures, that
+  keep the C and Rust surfaces byte-identical.
+
+---
+
+## Building and status
+
+The programs workspace builds with the pinned Rust toolchain declared in
+`programs/Cargo.toml` (`rust-version = 1.91.1`) against vendored dependencies. Runtime and
+kernel share golden vectors so the C and Rust implementations stay in lockstep. For the
+full qualification story — deterministic cross-architecture replay, fault injection,
+fuzzing, and settlement — see [`docs/QUALIFICATION.md`](../docs/QUALIFICATION.md).
+
+Project status is deliberately narrow:
+
+| Stage | Detail |
+| --- | --- |
+| Availability | Limited beta opens **September 7**. |
+| Source | Source-available during qualification — built for review now; a broader license follows release qualification. |
+| Public endpoints | None yet for LayerX itself. No public RPC, faucet, or explorer. |
+| Settlement | Checkpoints settle on Paxeer Network (EVM chain ID `125`); the settlement stack is co-located under `paxeer-network/`. |
+
+A successful local build is development evidence, not authorization to deploy, move
+custody, or handle real assets.
+
+---
+
+LayerX is developed by [Sidiora Labs](https://github.com/Sidiora-Labs).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docs-only change on the Jarvis lane. It documents the programs workspace and the protocol surfaces that landed with and around the monorepo integration (`2c19ff51`), and adds reviewable wiki draft copies (the wiki has no PR flow) that Andrew can paste after merge.

No code, spec source (KVX), or generated mirrors are touched. Out of scope by request and left untouched: `CONTRIBUTING`, `docs/QUALIFICATION.md`, `docs/MONOREPO.md`, `paxeer-network/**`, and the Home/Payments/Fees wiki pages. Paxeer is referenced only as the settlement target (chain `125`) whose stack is now co-located under `paxeer-network/`; its docs are not rewritten (Gideon's lane).

## Files

- [x] `programs/README.md` — **new.** Covers the programs Cargo workspace (crates, sdk, porting, fuzz, tools, tests, vendor) and documents the four new protocol surfaces against the real code and spec.
- [x] `docs/wiki/Protocol.md` — **new draft.** Based on the live Protocol wiki page; adds monorepo context and a programs first-class-surface section.
- [x] `docs/wiki/Modules.md` — **new draft.** Based on the live Modules wiki page; keeps the eight economic modules `0x01`–`0x08` and elevates programs to a first-class surface (not `0x09`).
- [x] `docs/wiki/Finality.md` — **new draft.** Based on the live Finality wiki page; adds monorepo context and how program execution/occupancy replays into the L0→L4 ladder.

No existing programs crate READMEs exist, so none needed reconciliation.

## New protocol surfaces (one sentence each)

- **Program-owned accounts** — accounts derived deterministically and domain-separated from `(program_id, seed)`, so no principal can claim or sign for them (a principal may fund one, never debit it).
- **Downward-only spending grants** — a program-to-program spending capability that can only narrow (asset, destination, source, amount), with any silent widening refused by the same typed escalation error principal grants use.
- **Occupancy settlement** — deterministic rent on namespace bytes held across protocol batches, priced by the fee schedule and charged to the responsible account as `402LXP` legs bound into the batch receipt.
- **Protocol-backed program balances** — a program's balance is real account-tree state read via Merkle proofs, with `402LXP` remaining the sole balance writer (programs emit transfer sets; they never call `set_balance`).

## Claim discipline

- Limited beta opens September 7; source-available during qualification.
- No public RPC/faucet/explorer in any hero — status table only.
- No claim of public LayerX mainnet and no claim of zero LayerX fees.
- No invented `0x09`/`0x0A` economic modules; programs is a first-class surface, not a ninth module.

## Specification

- Requirement clause(s): `spec/layerx-platform` req `37` (program-owned accounts, spending grants, protocol-backed balances) and req `36.5` (occupancy); tasks `30.1`–`30.5` and `29.5`.
- Codify task: none — documentation only.
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI: none.

## Verification

Documentation-only change; no build or test gates were run and none are required to alter Markdown. Content was written against the current source (`programs/crates/**`, `src/modules/programs/**`, `spec/**`) and the live wiki pages rather than slogans.

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. (N/A — no spec files changed; only new Markdown docs.)
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants. (Docs restate these invariants; no code changed.)
- [ ] I added real positive, negative, and adversarial coverage appropriate to the change. (N/A — documentation only.)
- [ ] I ran `make public-audit` and the affected native or Solidity suites. (Not run — docs-only change.)
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.

_Do not merge — left for the user to merge._

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52538d09-4722-416f-b4f8-10ae0570196f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52538d09-4722-416f-b4f8-10ae0570196f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

