### PR TITLE
[superseded] docs(paxeer): core markdown — do not merge

### DIFF
--- a/paxeer-docs/content/core/consensus.md
+++ b/paxeer-docs/content/core/consensus.md
@@ -1,0 +1,170 @@
+# Consensus
+
+Paxeer's consensus layer implements a Byzantine Fault Tolerant state machine based on Tendermint BFT. The implementation lives in `paxeer-network/consensus/` and coordinates block proposal, voting, and finality across the validator set.
+
+## Architecture
+
+The consensus engine operates as a state machine progressing through distinct round steps for each block height. The core state machine is implemented in `consensus/internal/consensus/state.go`, which handles:
+
+- Proposal reception and validation
+- Prevote and precommit voting rounds
+- Block locking and commit finalization
+- Vote aggregation and supermajority detection
+- Timeout management for each consensus step
+
+### Round Steps
+
+Each consensus round progresses through these steps (`consensus/internal/consensus/types/round_state.go`):
+
+1. **NewHeight** — height increment, validator set loaded
+2. **NewRound** — round counter incremented, proposer selected
+3. **Propose** — designated proposer broadcasts block proposal
+4. **Prevote** — validators cast prevote for proposed block or nil
+5. **PrevoteWait** — wait for +2/3 prevotes
+6. **Precommit** — validators lock on block with polka (supermajority prevotes) and precommit
+7. **PrecommitWait** — wait for +2/3 precommits
+8. **Commit** — block executed and finalized
+
+The round step type is defined as:
+
+```go
+type RoundStepType uint8
+
+const (
+    RoundStepNewHeight     RoundStepType = 0x01
+    RoundStepNewRound      RoundStepType = 0x02
+    RoundStepPropose       RoundStepType = 0x03
+    RoundStepPrevote       RoundStepType = 0x04
+    RoundStepPrevoteWait   RoundStepType = 0x05
+    RoundStepPrecommit     RoundStepType = 0x06
+    RoundStepPrecommitWait RoundStepType = 0x07
+    RoundStepCommit        RoundStepType = 0x08
+)
+```
+
+### Voting and Locking
+
+When +2/3 of voting power prevotes for a block, the consensus forms a polka (proof of lock). Validators then lock on that block and issue precommits. The locking mechanism (`enterPrecommit` in `consensus/internal/consensus/state.go`) ensures:
+
+- Once locked, validators will only prevote/precommit for the locked block or nil
+- A lock can be updated only with a polka from a later round
+- This prevents safety violations while allowing liveness through round progression
+
+The precommit logic validates:
+
+```go
+// From consensus/internal/consensus/state.go
+if cs.roundState.ProposalBlock().HashesTo(blockID.Hash) {
+    if err := cs.blockExec.ValidateBlock(ctx, cs.state, cs.roundState.ProposalBlock()); err != nil {
+        panic(fmt.Sprintf("precommit step: +2/3 prevoted for an invalid block %v", err))
+    }
+    cs.roundState.SetLockedRound(round)
+    cs.roundState.SetLockedBlock(cs.roundState.ProposalBlock())
+    cs.signAddVote(ctx, tmproto.PrecommitType, blockID.Hash, blockID.PartSetHeader)
+}
+```
+
+### Block Execution and Commit
+
+When +2/3 precommits arrive for a block, the consensus engine calls `finalizeCommit` which:
+
+1. Executes the block via ABCI `FinalizeBlock` (app state transition)
+2. Persists the block to `store.BlockStore` (`consensus/internal/store/store.go`)
+3. Updates the validator set for the next height
+4. Advances to `NewHeight` step
+
+The block store (`consensus/internal/store/store.go`) provides:
+
+- `SaveBlock` — writes block and commit to disk
+- `LoadBlock` — retrieves block by height
+- Pruning of old blocks based on retention config
+
+## ABCI Integration
+
+The Application Blockchain Interface connects consensus to the application layer. Paxeer's ABCI types are defined in `consensus/abci/types/` and include:
+
+- `CheckTx` — mempool admission (gas validation, signature verification)
+- `FinalizeBlock` — execute all transactions in a committed block
+- `Commit` — finalize state and return app hash
+
+The `consensus/internal/proxy/` package wraps the ABCI client and provides:
+
+```go
+// consensus/internal/proxy/app_conn.go
+type AppConnConsensus interface {
+    FinalizeBlock(context.Context, *abci.FinalizeBlockRequest) (*abci.FinalizeBlockResponse, error)
+    Commit(context.Context, *abci.CommitRequest) (*abci.CommitResponse, error)
+}
+```
+
+State synchronization between consensus and application state is managed by `consensus/internal/state/` which persists validator sets, consensus parameters, and the last committed height.
+
+## Node Initialization
+
+Consensus nodes are constructed in `consensus/node/node.go`. The `makeNode` function initializes:
+
+- Block and state databases (`initDBs`)
+- Genesis document loading and validation
+- Event bus for consensus events
+- Mempool for transaction ordering
+- Evidence pool for Byzantine fault detection
+- P2P router for validator communication
+- RPC endpoints
+
+A node's consensus policy (defined in `consensus/types/consensus_policy.go`) determines whether it participates in proposals, voting, and commit.
+
+## Mempool
+
+The mempool (`consensus/internal/mempool/`) orders transactions before they enter a block. Transactions are:
+
+1. Received via `CheckTx` ABCI call
+2. Validated for signatures, nonces, gas limits
+3. Stored in a priority queue (currently FIFO)
+4. Broadcast to peers via `mempool/reactor/`
+5. Removed after inclusion in a committed block
+
+Mempool configuration (`consensus/config/config.go`) controls max transaction size, cache size, and broadcast behavior.
+
+## Light Client Verification
+
+Light clients can verify block headers without full block data by checking validator signatures on commits. The light client protocol is implemented in `consensus/light/` and verifies:
+
+- Validator set continuity (unbonding period constraints)
+- 2/3+ voting power signed the commit
+- Block header hash matches the commit
+
+Light clients track validator set changes and can detect forks through evidence of conflicting commits.
+
+## Failure Handling
+
+The consensus engine handles failures through:
+
+- **Timeouts** — each step has a timeout triggering progression to next step
+- **Evidence** — conflicting votes are reported to the evidence pool (`consensus/internal/evidence/`)
+- **Peer gossip** — missing proposals or votes are requested from peers
+- **Round advancement** — if proposal fails, advance to next round with new proposer
+
+Byzantine validators submitting conflicting votes are detected via `ReportConflictingVotes` and subject to slashing.
+
+## Configuration
+
+Consensus behavior is configured in `consensus/config/config.go`:
+
+- `TimeoutPropose`, `TimeoutPrevote`, `TimeoutPrecommit` — step timeouts
+- `SkipTimeoutCommit` — skip commit timeout for faster blocks
+- `CreateEmptyBlocks` — produce blocks even without transactions
+- `PeerGossipSleepDuration` — P2P broadcast throttling
+
+The config is loaded from `config.toml` and can be overridden per-node.
+
+## Observability
+
+Consensus metrics are exposed via Prometheus (`consensus/internal/consensus/metrics.go`):
+
+- Block height and round progression
+- Vote collection latency
+- Proposal broadcast time
+- Peer connectivity status
+- Evidence pool size
+
+Events are published to the event bus (`consensus/internal/eventbus/`) for external subscribers.

--- a/paxeer-docs/content/core/engine.md
+++ b/paxeer-docs/content/core/engine.md
@@ -1,0 +1,197 @@
+# Engine
+
+The Paxeer engine executes transactions within blocks, bridging consensus output to EVM state transitions. The executor package (`paxeer-network/engine/executor/`) provides the core transaction execution interface.
+
+## Executor
+
+The executor wraps a go-ethereum EVM instance and manages transaction execution lifecycle. It is defined in `engine/executor/executor.go`:
+
+```go
+type Executor struct {
+    evm *vm.EVM
+}
+```
+
+### Executor Variants
+
+Paxeer supports two execution backends:
+
+**1. Evmone Executor** — uses the evmone C++ interpreter via EVMC bindings for performance:
+
+```go
+func NewEvmoneExecutor(
+    evmoneVM *evmc.VM,
+    blockCtx vm.BlockContext,
+    stateDB vm.StateDB,
+    chainConfig *params.ChainConfig,
+    config vm.Config,
+    customPrecompiles map[common.Address]vm.PrecompiledContract,
+) *Executor
+```
+
+The evmone path pre-computes host context configuration from chain config to avoid per-SSTORE overhead. The evmone VM is wrapped in `internal/HostContext` which adapts EVMC callbacks to geth's StateDB interface.
+
+**2. Geth Executor** — pure Go implementation using go-ethereum's interpreter:
+
+```go
+func NewGethExecutor(
+    blockCtx vm.BlockContext,
+    stateDB vm.StateDB,
+    chainConfig *params.ChainConfig,
+    config vm.Config,
+    customPrecompiles map[common.Address]vm.PrecompiledContract,
+) *Executor
+```
+
+Both executors expose the same execution interface, allowing runtime selection based on build configuration.
+
+## Transaction Execution
+
+The executor provides two execution modes:
+
+### Standard Execution
+
+`ExecuteTransaction` performs full gas metering including fee deduction:
+
+```go
+func (e *Executor) ExecuteTransaction(
+    tx *types.Transaction,
+    sender common.Address,
+    baseFee *big.Int,
+    gasPool *core.GasPool,
+) (*core.ExecutionResult, error)
+```
+
+This path:
+1. Converts the Ethereum transaction to a geth `Message`
+2. Applies gas fee purchase from sender balance
+3. Executes the EVM state transition
+4. Refunds unused gas to sender
+5. Returns execution result with gas used, logs, and return data
+
+### Fee-Charged Execution
+
+`ExecuteTransactionFeeCharged` executes transactions where fees have been charged separately (e.g., via Cosmos ante handler):
+
+```go
+func (e *Executor) ExecuteTransactionFeeCharged(
+    tx *types.Transaction,
+    sender common.Address,
+    baseFee *big.Int,
+    gasPool *core.GasPool,
+) (*core.ExecutionResult, error)
+```
+
+This matches the behavior of the EVM module's msg_server path where the ante handler charges fees before execution. The executor:
+- Sets `feeAlreadyCharged=true` to skip gas purchase/refund
+- Sets `shouldIncrementNonce=true` to increment nonce during execution
+- Calls `core.NewStateTransition(...).Execute()` directly
+
+This is defined in `engine/executor/executor.go`:
+
+```go
+e.evm.SetTxContext(core.NewEVMTxContext(message))
+return core.NewStateTransition(e.evm, message, gasPool, true, true).Execute()
+```
+
+## StateDB Bridge
+
+The executor operates on a `vm.StateDB` interface implemented by the EVM module's state package (`modules/evm/state/`). This bridges Cosmos SDK key-value stores to Ethereum's account-based model.
+
+The StateDB implementation (`modules/evm/state/statedb.go`) provides:
+
+- Balance management with 6-decimal µhpx to 18-decimal wei conversion
+- Contract code and storage access
+- Nonce tracking
+- Snapshot/revert for failed transactions
+- Journal for tracking all state mutations
+
+All state changes are isolated within a `CacheMultiStore` during execution and only committed if the transaction succeeds.
+
+## Block Context
+
+The executor requires a `vm.BlockContext` providing block-level parameters:
+
+```go
+type BlockContext struct {
+    Coinbase     common.Address   // fee collector for this tx
+    GasLimit     uint64            // block gas limit
+    BlockNumber  *big.Int          // current height
+    Time         uint64            // block timestamp
+    Difficulty   *big.Int          // always 0 (no PoW)
+    BaseFee      *big.Int          // EIP-1559 base fee
+    Random       common.Hash       // PREVRANDAO (from consensus)
+}
+```
+
+The block context is constructed by the EVM keeper before execution using consensus block metadata.
+
+## Gas Metering
+
+Gas conversion between Cosmos SDK (integer gas units) and EVM (uint64 gas units) is handled by the EVM keeper. The conversion factor is configurable but typically 1:1.
+
+The executor receives a `core.GasPool` limiting total gas available for the transaction:
+
+```go
+gasPool := new(core.GasPool).AddGas(gasLimit)
+result, err := executor.ExecuteTransaction(tx, sender, baseFee, gasPool)
+```
+
+After execution, the remaining gas in the pool indicates unused gas.
+
+## Custom Precompiles
+
+Paxeer extends Ethereum's precompile set with custom contracts exposing Cosmos functionality. These are passed to the executor during construction:
+
+```go
+customPrecompiles := map[common.Address]vm.PrecompiledContract{
+    common.HexToAddress("0x0000000000000000000000000000000000001001"): bankPrecompile,
+    common.HexToAddress("0x0000000000000000000000000000000000001002"): stakingPrecompile,
+    // ...
+}
+```
+
+The executor registers these in the EVM config, making them callable at their designated addresses.
+
+## Execution Isolation
+
+Each transaction executes in isolation with its own:
+
+- Gas meter (from the gas pool)
+- Snapshot of state (revertible)
+- Log accumulator (cleared on revert)
+- Transient storage (EIP-1153, cleared between transactions)
+- Access list (EIP-2930, reset per transaction)
+
+Failed transactions revert all state changes but still consume gas and increment the sender's nonce (if the transaction passed ante validation).
+
+## Testing and Replay
+
+The engine includes test harnesses in `engine/tests/`:
+
+- `state_test.go` — Ethereum state test JSON compatibility
+- `giga_test.go` — large-scale stress tests
+- `harness/` — test builder for constructing block execution scenarios
+
+The EVM keeper also supports Ethereum replay mode for validating historical Ethereum blocks against the executor, useful for verifying compatibility.
+
+## Parallelization Hooks
+
+The `engine/` package defines interfaces for future optimistic concurrency control (OCC) and parallel execution. Actual parallelization implementation lives in `paxeer-network/parallelization/` but is not yet enabled in production.
+
+Planned parallel execution will use:
+- Read/write set tracking during execution
+- Conflict detection across concurrent transactions
+- Deterministic re-execution on conflicts
+
+Current executor API is designed to be compatible with parallel execution once enabled.
+
+## Dependencies
+
+The engine depends on:
+
+- **xevm** (`engine/deps/xevm/`) — EVM keeper types and state access
+- **xbank** (`engine/deps/xbank/`) — deferred bank operations for gas refunds
+- **testutil** (`engine/deps/testutil/`) — test fixtures and block processing utilities
+
+These dependencies are isolated under `engine/deps/` to maintain clear boundaries between executor and higher-level chain logic.

--- a/paxeer-docs/content/core/evm.md
+++ b/paxeer-docs/content/core/evm.md
@@ -1,0 +1,303 @@
+# EVM Module
+
+The EVM module (`paxeer-network/modules/evm/`) integrates a full Ethereum Virtual Machine into Paxeer as chain ID **125**. It enables native EVM transaction execution, bidirectional address mapping between Pax and Ethereum, and interoperability between CosmWasm and EVM via pointer contracts.
+
+## Chain ID
+
+Paxeer operates as Ethereum chain ID **125**. All EVM transactions must sign with this chain ID to be accepted. This is enforced during signature recovery in the ante handler.
+
+## Dual Address Model
+
+Every account can have both a Pax (bech32) address and an EVM (hex) address. The module maintains bidirectional mappings in `modules/evm/keeper/address.go`:
+
+### Explicit Association
+
+Users link addresses via:
+
+1. **Associate transaction** — a dedicated Paxeer transaction type that binds addresses
+2. **Implicit derivation** — signing any Cosmos or EVM transaction automatically derives and associates the EVM address from the secp256k1 public key
+
+The keeper stores mappings:
+
+```go
+// modules/evm/keeper/address.go
+func (k *Keeper) SetAddressMapping(ctx sdk.Context, paxAddr sdk.AccAddress, evmAddr common.Address)
+func (k *Keeper) GetPaxAddress(ctx sdk.Context, evmAddr common.Address) (sdk.AccAddress, bool)
+func (k *Keeper) GetEVMAddress(ctx sdk.Context, paxAddr sdk.AccAddress) (common.Address, bool)
+```
+
+### Cast Addresses
+
+When no explicit association exists, the module falls back to deterministic byte-cast between address formats. Cast addresses have limitations:
+
+- **Two views of the same account** — balances and state appear different from Pax and EVM perspectives
+- **Limited interoperability** — pointer contracts and cross-VM calls require explicit association
+
+Cast addresses are used only as a fallback and are not recommended for production use.
+
+## Transaction Execution
+
+EVM transactions arrive as `MsgEVMTransaction` and are unpacked into native Ethereum transaction types:
+
+- **Type 0** — Legacy transactions
+- **Type 1** — EIP-2930 access list transactions
+- **Type 2** — EIP-1559 dynamic fee transactions
+- **Type 4** — EIP-7702 set-code transactions (code delegation)
+
+The execution flow (`modules/evm/keeper/keeper.go`):
+
+1. Ante handler validates signature, nonce, gas, fees
+2. EVM keeper constructs block context from consensus data
+3. Executor (from `engine/executor/`) runs the transaction
+4. State changes are committed to the Cosmos store
+5. Receipt is written to receipt store (`storage/ledger_db/receipt/`)
+
+Gas is charged in Cosmos SDK units and converted to EVM units via a configurable normalizer (default 1:1).
+
+## Ante Handler
+
+EVM transactions bypass the standard Cosmos ante chain and use a dedicated EVM ante handler (`modules/evm/keeper/ante.go`). The pipeline enforces:
+
+1. **Cosmos field rejection** — EVM txs must not use memo, timeout, or Cosmos-style fees
+2. **Preprocessing** — unpack inner Ethereum tx, recover sender via ECDSA
+3. **Address derivation** — for Cosmos-signed txs, derive EVM address from pubkey
+4. **Basic validation** — init code size limits, non-negative value, intrinsic gas calculation
+5. **Signature/nonce verification** — validate chain ID and nonce ordering
+6. **Fee validation** — check base fee and minimum fee, execute gas purchase
+7. **Gas metering** — set Cosmos gas meter to converted EVM gas limit
+
+Nonce handling differs between CheckTx and DeliverTx:
+
+- **CheckTx** — uses pending nonce logic for mempool ordering (allows gaps)
+- **DeliverTx** — requires exact nonce match (must be `account.nonce + 1`)
+
+## StateDB Implementation
+
+The `state` package (`modules/evm/state/statedb.go`) implements go-ethereum's `vm.StateDB` interface on top of Cosmos SDK stores. This is the core bridge enabling EVM execution within the Cosmos framework.
+
+### Balance Representation
+
+Paxeer uses 6-decimal **µhpx** as the native unit, while EVM expects 18-decimal **wei**. The StateDB handles conversion:
+
+- EVM operations work in wei (18 decimals)
+- Cosmos stores balances in µhpx (6 decimals)
+- Sub-µhpx remainder (the lower 12 decimal places) is tracked separately in a `wei` store
+
+When an EVM transaction sends `1.5 * 10^12 wei`, the StateDB:
+1. Converts to µhpx: `1.5 * 10^12 / 10^12 = 1.5 µhpx` → stores `1 µhpx`
+2. Stores remainder: `0.5 * 10^12 wei` in the `wei` store
+
+This ensures sub-µhpx precision is preserved across EVM operations without modifying the bank module.
+
+### Snapshots and Reverts
+
+The StateDB uses `CacheMultiStore` for snapshotting:
+
+```go
+func (s *StateDB) Snapshot() int {
+    id := s.snapCounter
+    s.snapshots[id] = s.ctx.MultiStore().CacheMultiStore()
+    s.snapCounter++
+    return id
+}
+
+func (s *StateDB) RevertToSnapshot(snapID int) {
+    cachedStore := s.snapshots[snapID]
+    s.ctx = s.ctx.WithMultiStore(cachedStore)
+    s.journal.Revert(snapID)
+}
+```
+
+A journal records every state mutation (balance change, storage write, code update) so it can be rolled back on revert. The journal is cleared at transaction boundaries.
+
+### Transient State
+
+The following state is held in memory per-transaction and not persisted:
+
+- **Logs** — EVM event logs
+- **Transient storage** — EIP-1153 TLOAD/TSTORE
+- **Access lists** — EIP-2929/2930 accessed addresses and storage keys
+- **Gas refunds** — gas refund counter
+
+These are finalized only when the transaction commits successfully.
+
+## Receipts and Logs
+
+### Receipt Structure
+
+Receipts are built after execution and contain:
+
+- Transaction hash
+- Block number and transaction index
+- Gas used
+- Cumulative gas used in block
+- Contract address (if contract creation)
+- Status (1 = success, 0 = failure)
+- Logs (event emissions)
+- Logs bloom filter
+
+Receipts are stored in `storage/ledger_db/receipt/receipt_store.go` indexed by transaction hash and block height.
+
+### Synthetic Receipts
+
+Paxeer creates synthetic receipts for cross-VM interactions:
+
+**CW→EVM** — if a Cosmos transaction calls an EVM contract, a synthetic receipt carries EVM-side logs
+
+**CW Pointee** — if a Cosmos transaction calls a CosmWasm contract with an EVM pointer, synthetic logs are emitted to represent activity from the EVM perspective
+
+**EVM→CW** — if an EVM transaction calls a CosmWasm contract via pointer, synthetic logs are added to the EVM transaction's receipt
+
+### Failure Receipts
+
+Unlike Ethereum, EVM transactions on Paxeer can fail before reaching the EVM:
+
+- **Nonce mismatch** — no receipt (no state change)
+- **Other ante failures** — status-0 receipt (nonce incremented, gas consumed)
+
+This ensures receipts exist for all state-changing failures.
+
+### Block Bloom Filters
+
+The EVM keeper aggregates bloom filters from all receipts in a block to create:
+
+- **Block bloom** — includes all logs (EVM + CW synthetic)
+- **EVM-only bloom** — excludes CW-originated logs
+
+These are stored per-height for efficient log filtering.
+
+## Deferred Processing
+
+Rather than finalizing during execution, some work is deferred to EndBlock (`modules/evm/keeper/keeper.go`):
+
+1. **Fee surplus collection** — the difference between paid and required fees is swept to the fee collector
+2. **Failed receipts** — written for transactions that failed during execution
+3. **Block bloom aggregation** — composed from all transaction blooms
+
+Deferred info is stored in transient storage during the block and processed in `EndBlock`.
+
+### Coinbase Addresses
+
+Each transaction receives a deterministic coinbase address for collecting fee surplus. At EndBlock, all coinbase balances are swept to the module's fee collector account.
+
+## Dynamic Base Fee (EIP-1559)
+
+The module implements EIP-1559 dynamic fee adjustment (`modules/evm/keeper/fee.go`):
+
+```go
+func (k *Keeper) EndBlock(ctx sdk.Context) {
+    // ... other end-block logic
+    k.UpdateBaseFeePerGas(ctx)
+}
+```
+
+After each block:
+- If gas usage > target, base fee increases (up to max cap)
+- If gas usage < target, base fee decreases (down to min floor)
+
+Fee bounds are configurable via module params. The new base fee applies to the next block.
+
+## Pointer Contracts
+
+Pointer contracts enable tokens on one VM to be accessed from the other. This is the primary interoperability mechanism between CosmWasm and EVM.
+
+### EVM Pointers for CW/Native Tokens
+
+- **Native Cosmos denoms** → ERC20 pointer
+- **CW20 tokens** → ERC20 pointer
+- **CW721 NFTs** → ERC721 pointer
+- **CW1155 multi-tokens** → ERC1155 pointer
+
+### CW Wrappers for ERC Tokens
+
+- **ERC20 tokens** → CW20 wrapper
+- **ERC721 NFTs** → CW721 wrapper
+- **ERC1155 multi-tokens** → CW1155 wrapper
+
+Pointers are created via the `pointer` precompile (address `0x100b`, see [Precompiles](precompiles.md)). Precompiled bytecode for pointer contracts is embedded in the binary under `artifacts/`.
+
+A reverse registry allows looking up the original token from its pointer address. Pointers are versioned and can be upgraded.
+
+## Precompiled Contracts
+
+The module supports custom precompiled contracts exposing Cosmos functionality to EVM callers. Precompiles are registered at fixed addresses (see [Precompiles](precompiles.md)) and are versioned by block height.
+
+Payable precompiles suppress transfer events to avoid double-counting when value is forwarded.
+
+## WASM Integration
+
+CosmWasm contracts interact with the EVM through:
+
+### Queries (Read-Only)
+
+- Static EVM calls
+- ERC20/721/1155 token queries
+- Address association lookups
+
+### Messages (State-Changing)
+
+- `MsgInternalEVMCall` — regular EVM calls from CW contracts
+- `MsgInternalEVMDelegateCall` — delegate calls (restricted to whitelisted pointer contracts)
+
+These are implemented in `modules/evm/types/` and processed by the EVM keeper.
+
+## ABCI Lifecycle
+
+### BeginBlock
+
+```go
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+    k.txResults = nil
+    k.msgs = nil
+}
+```
+
+Resets per-block transaction tracking.
+
+### EndBlock
+
+```go
+func (k Keeper) EndBlock(ctx sdk.Context) {
+    k.CleanTxHashIndex(ctx)
+    k.MigrateLegacyReceipts(ctx)
+    k.PruneZeroValueStorageSlots(ctx)
+    k.UpdateBaseFeePerGas(ctx)
+    k.CollectCoinbaseSurplus(ctx)
+    k.ProcessDeferredInfo(ctx)
+}
+```
+
+1. Cleans old transaction hash indices
+2. Migrates legacy receipts (one-time migration)
+3. Prunes zero-value storage slots (resumable, batched)
+4. Adjusts dynamic base fee for next block
+5. Sweeps coinbase balances to fee collector
+6. Aggregates deferred info (surplus, receipts, blooms)
+
+## Configuration
+
+Module params (`modules/evm/types/params.go`):
+
+- `MinimumFeePerGas` — floor for base fee
+- `BaseFeePerGas` — current base fee (updated each block)
+- `PriorityNormalizer` — scales priority fee for mempool ordering
+- `BaseFeeChangeDenominator` — EIP-1559 adjustment rate
+- `ElasticityMultiplier` — gas target vs limit ratio
+
+Configuration is stored in module state and governable via governance proposals.
+
+## Observability
+
+Metrics exposed via Prometheus:
+
+- Transaction throughput (EVM vs total)
+- Gas used per block
+- Base fee evolution
+- Receipt storage latency
+- Pointer contract invocations
+
+Events emitted to event bus:
+
+- `EventTypeEthereumTx` — EVM transaction executed
+- `EventTypeEVMCallFailed` — execution reverted
+- `EventTypeAddressAssociation` — new address link

--- a/paxeer-docs/content/core/modules.md
+++ b/paxeer-docs/content/core/modules.md
@@ -1,0 +1,332 @@
+# Modules
+
+Paxeer-specific chain modules live under `paxeer-network/modules/`. These extend the Cosmos SDK framework with Paxeer-native functionality. Framework-provided modules remain under `sdk/x/`; interchain applications live under `interchain/modules/`.
+
+## EVM Module
+
+The `evm` module integrates the Ethereum Virtual Machine. See the dedicated [EVM](evm.md) page for complete documentation.
+
+Summary:
+- Native EVM execution on chain ID 125
+- Address association between Pax and EVM
+- Receipts and logs
+- Pointer contracts for CW↔EVM interoperability
+- EIP-1559 dynamic fees
+
+## Epoch Module
+
+**Path:** `modules/epoch/`
+
+The epoch module manages time-based epochs that trigger periodic chain actions. Epochs are defined by a fixed duration and advance automatically when the block time exceeds the current epoch's start time plus duration.
+
+### Lifecycle
+
+Epochs progress in `BeginBlock` (`modules/epoch/keeper/abci.go`):
+
+```go
+func (k Keeper) BeginBlock(ctx sdk.Context) {
+    lastEpoch := k.GetEpoch(ctx)
+    if ctx.BlockTime().Sub(lastEpoch.CurrentEpochStartTime) > lastEpoch.EpochDuration {
+        k.AfterEpochEnd(ctx, lastEpoch)
+        
+        newEpoch := types.Epoch{
+            GenesisTime:           lastEpoch.GenesisTime,
+            EpochDuration:         lastEpoch.EpochDuration,
+            CurrentEpoch:          lastEpoch.CurrentEpoch + 1,
+            CurrentEpochStartTime: ctx.BlockTime(),
+            CurrentEpochHeight:    ctx.BlockHeight(),
+        }
+        k.SetEpoch(ctx, newEpoch)
+        k.BeforeEpochStart(ctx, newEpoch)
+    }
+}
+```
+
+When an epoch boundary is crossed:
+1. `AfterEpochEnd` hooks fire (previous epoch cleanup)
+2. Epoch counter increments
+3. `BeforeEpochStart` hooks fire (new epoch initialization)
+4. `EventTypeNewEpoch` event is emitted
+
+### Hooks
+
+Other modules register epoch hooks to run logic at epoch boundaries. Hooks are defined in `modules/epoch/types/hooks.go`:
+
+```go
+type EpochHooks interface {
+    BeforeEpochStart(ctx sdk.Context, epoch Epoch)
+    AfterEpochEnd(ctx sdk.Context, epoch Epoch)
+}
+```
+
+The mint module uses `BeforeEpochStart` to issue inflation rewards. The oracle module uses `AfterEpochEnd` to tally exchange rate votes.
+
+### State
+
+The epoch keeper stores:
+
+```go
+type Epoch struct {
+    GenesisTime           time.Time
+    EpochDuration         time.Duration
+    CurrentEpoch          uint64
+    CurrentEpochStartTime time.Time
+    CurrentEpochHeight    int64
+}
+```
+
+Epochs are persisted in `modules/epoch/keeper/epoch.go` and queryable via gRPC.
+
+### Messages and Queries
+
+The module does not expose user-facing messages (epochs advance automatically). Available queries:
+
+- `Epoch` — returns current epoch number, start time, and height
+- `Params` — returns epoch duration
+
+### Configuration
+
+Epoch duration is set at genesis and governable via params. Typical production epochs are 1 day.
+
+## Mint Module
+
+**Path:** `modules/mint/`
+
+The mint module issues new native tokens according to an inflation schedule. It runs during epoch transitions to mint and distribute rewards.
+
+### ABCI
+
+Minting occurs in `BeginBlock` via the epoch hook:
+
+```go
+func (k Keeper) BeforeEpochStart(ctx sdk.Context, epoch epochtypes.Epoch) {
+    // Calculate inflation amount based on params
+    mintedCoin := k.CalculateInflation(ctx, epoch)
+    
+    // Mint to module account
+    k.MintCoins(ctx, mintedCoin)
+    
+    // Distribute to staking rewards pool
+    k.DistributeInflation(ctx, mintedCoin)
+}
+```
+
+The minted tokens flow to the distribution module, which allocates them to validators and delegators as staking rewards.
+
+### Inflation Schedule
+
+Inflation parameters define:
+
+- `InflationRate` — annual inflation percentage
+- `MintDenom` — the native token denom (e.g., `uhpx`)
+- `BlocksPerYear` — expected blocks per year for rate calculation
+
+Inflation can be constant or dynamic based on staking ratio (bonded vs total supply). The schedule is implemented in the keeper and configurable via governance.
+
+### State
+
+The mint module maintains:
+- Current inflation rate
+- Annual provisions (expected yearly mint amount)
+- Last mint block
+
+These are queryable via gRPC.
+
+### Messages and Queries
+
+No user-facing messages (minting is automatic). Queries:
+
+- `InflationRate` — current annual inflation percentage
+- `AnnualProvisions` — expected yearly mint amount
+- `Params` — mint parameters
+
+## Oracle Module
+
+**Path:** `modules/oracle/`
+
+The oracle module aggregates exchange rate data from validators via a vote-reveal scheme. It provides price feeds for other modules (e.g., for fee conversion or stablecoin operations).
+
+### Architecture
+
+The oracle keeper (`modules/oracle/keeper/keeper.go`) maintains:
+
+```go
+type Keeper struct {
+    cdc                         codec.BinaryCodec
+    storeKey                    sdk.StoreKey
+    accountKeeper               types.AccountKeeper
+    bankKeeper                  types.BankKeeper
+    distrKeeper                 types.DistributionKeeper
+    StakingKeeper               types.StakingKeeper
+    spamPreventionCounterMtxMap *datastructures.TypedSyncMap[string, *sync.Mutex]
+    distrName                   string
+}
+```
+
+### Exchange Rate Voting
+
+Validators submit exchange rates via a commit-reveal scheme:
+
+1. **Prevote** — validator submits hash of their exchange rate (concealed)
+2. **Vote** — validator reveals actual exchange rate
+3. **Tally** — at epoch end, median is computed from all reveals weighted by voting power
+
+Exchange rates are stored in `modules/oracle/keeper/keeper.go`:
+
+```go
+type OracleExchangeRate struct {
+    ExchangeRate         sdk.Dec
+    LastUpdate           sdk.Int   // block height of last update
+    LastUpdateTimestamp  int64     // unix timestamp of last update
+}
+
+func (k Keeper) SetBaseExchangeRate(ctx sdk.Context, denom string, exchangeRate sdk.Dec)
+func (k Keeper) GetBaseExchangeRate(ctx sdk.Context, denom string) (sdk.Dec, sdk.Int, int64, error)
+```
+
+### Rewards and Penalties
+
+Validators who participate in voting earn oracle rewards (distributed from a reward pool). Validators who miss votes or submit outliers are penalized via slashing.
+
+Participation is tracked per validator and used to compute reward allocation.
+
+### TWAP (Time-Weighted Average Price)
+
+The oracle maintains TWAP windows for smoothing price volatility. TWAP data is computed by averaging exchange rates over a sliding window.
+
+### State
+
+The oracle keeper stores:
+- Exchange rates per denom
+- Validator prevotes and votes (ephemeral, cleared each epoch)
+- Miss counters per validator
+- TWAP history
+
+### Messages
+
+- `MsgAggregateExchangeRatePrevote` — commit hash of exchange rates
+- `MsgAggregateExchangeRateVote` — reveal actual exchange rates
+- `MsgDelegateFeedConsent` — delegate voting rights to a feeder address
+
+### Queries
+
+- `ExchangeRates` — all current exchange rates
+- `OracleTwaps` — TWAP data for specified denoms and lookback
+- `VotePenaltyCounter` — miss count for a validator
+
+### Configuration
+
+Oracle params:
+- `VotePeriod` — blocks per vote window
+- `VoteThreshold` — minimum voting power required for valid rate
+- `RewardBand` — acceptable deviation from median (outside = penalty)
+- `SlashFraction` — penalty for missing votes
+- `MinValidPerWindow` — minimum valid votes in slash window
+
+## TokenFactory Module
+
+**Path:** `modules/tokenfactory/`
+
+The tokenfactory module allows permissioned creation and management of native token denominations. Tokens created via tokenfactory are indistinguishable from genesis denoms and fully integrated with the bank module.
+
+### Architecture
+
+The keeper (`modules/tokenfactory/keeper/keeper.go`) manages:
+
+```go
+type Keeper struct {
+    storeKey      sdk.StoreKey
+    paramSpace    paramtypes.Subspace
+    accountKeeper types.AccountKeeper
+    bankKeeper    types.BankKeeper
+    distrKeeper   types.DistrKeeper
+}
+```
+
+### Denom Creation
+
+Users create denoms via `MsgCreateDenom`:
+
+```go
+// modules/tokenfactory/keeper/createdenom.go
+func (k Keeper) CreateDenom(ctx sdk.Context, creatorAddr string, subdenom string) (string, error) {
+    denom := fmt.Sprintf("factory/%s/%s", creatorAddr, subdenom)
+    // ... store denom metadata
+    return denom, nil
+}
+```
+
+The resulting denom format is `factory/{creator_address}/{subdenom}`. The creator becomes the denom admin.
+
+### Admin Actions
+
+The denom admin can:
+
+- **Mint** — create new tokens of the denom
+- **Burn** — destroy tokens from their own balance
+- **ChangeAdmin** — transfer admin rights to another address
+- **SetDenomMetadata** — update display name, symbol, decimals
+
+Admin actions are implemented in `modules/tokenfactory/keeper/bankactions.go`:
+
+```go
+func (k Keeper) MintTo(ctx sdk.Context, admin string, denom string, amount sdk.Coin, recipient string) error
+func (k Keeper) BurnFrom(ctx sdk.Context, admin string, denom string, amount sdk.Coin, sender string) error
+```
+
+Minting/burning is executed via the bank module after admin verification.
+
+### Allow Lists (Optional)
+
+Denoms can optionally restrict minting/burning to an allow list of addresses:
+
+```go
+func (k Keeper) SetDenomAllowList(ctx sdk.Context, denom string, allowList []string) error
+```
+
+When an allow list is set, only addresses on the list can mint or burn that denom.
+
+### State
+
+The keeper stores:
+- Creator → denoms mapping (`GetCreatorPrefixStore`)
+- Denom → admin mapping
+- Denom → allow list mapping
+- List of all creators (`GetCreatorsPrefixStore`)
+
+### Messages
+
+- `MsgCreateDenom` — create a new tokenfactory denom
+- `MsgMint` — mint tokens (admin only)
+- `MsgBurn` — burn tokens from sender
+- `MsgChangeAdmin` — transfer admin rights
+- `MsgSetDenomMetadata` — update metadata
+- `MsgUpdateAllowList` — modify allow list
+
+### Queries
+
+- `DenomAuthorityMetadata` — admin and creation metadata for a denom
+- `DenomsFromCreator` — all denoms created by an address
+- `Params` — tokenfactory parameters
+
+### Configuration
+
+Tokenfactory params:
+- `DenomCreationFee` — cost to create a new denom (paid to community pool)
+- `DenomAllowListMaxSize` — maximum allow list size
+
+### Use Cases
+
+Tokenfactory enables:
+- **Stablecoins** — admin mints/burns to maintain peg
+- **Wrapped assets** — bridged tokens from other chains
+- **Protocol tokens** — governance or utility tokens for dApps
+- **Gaming tokens** — in-game currencies
+
+## Store Module
+
+**Path:** `modules/store/`
+
+The store module is a thin helper providing module-level store integration. It does not implement business logic but offers utilities for accessing stores from other modules.
+
+This module is primarily internal scaffolding and not directly exposed to users or external developers.

--- a/paxeer-docs/content/core/precompiles.md
+++ b/paxeer-docs/content/core/precompiles.md
@@ -1,0 +1,309 @@
+# Precompiles
+
+Paxeer extends Ethereum's precompiled contracts with custom contracts that expose Cosmos SDK functionality to EVM callers. These are registered at fixed addresses and callable from any EVM transaction or contract.
+
+Precompile addresses and registration are defined in `paxeer-network/precompiles/setup.go`. All precompiles are versioned by upgrade name to support historical queries and tracing.
+
+## Precompile Addresses
+
+All Paxeer precompiles are registered in the reserved address space below `0x100`:
+
+| Precompile | Address | Description |
+|------------|---------|-------------|
+| [Bank](#bank) | `0x0000000000000000000000000000000000001001` | Native token transfers and queries |
+| [Wasmd](#wasmd) | `0x0000000000000000000000000000000000001002` | CosmWasm contract instantiation and execution |
+| [JSON](#json) | `0x0000000000000000000000000000000000001003` | JSON parsing utilities |
+| [Addr](#addr) | `0x0000000000000000000000000000000000001004` | Address association and lookup |
+| [Staking](#staking) | `0x0000000000000000000000000000000000001005` | Validator delegation and staking operations |
+| [Gov](#gov) | `0x0000000000000000000000000000000000001006` | Governance proposal submission and voting |
+| [Distribution](#distribution) | `0x0000000000000000000000000000000000001007` | Staking rewards withdrawal |
+| [Oracle](#oracle) | `0x0000000000000000000000000000000000001008` | Exchange rate queries (retired) |
+| [IBC](#ibc) | `0x0000000000000000000000000000000000001009` | IBC token transfers |
+| [PointerView](#pointerview) | `0x000000000000000000000000000000000000100A` | Query pointer contract addresses (read-only) |
+| [Pointer](#pointer) | `0x000000000000000000000000000000000000100B` | Create pointer contracts for CW/EVM interop |
+| [Solo](#solo) | `0x000000000000000000000000000000000000100C` | Solo machine integration (permissioned) |
+| [P256](#p256) | `0x0000000000000000000000000000000000001011` | P256 signature verification |
+
+Precompiles are initialized in `setup.go`:
+
+```go
+func GetCustomPrecompiles(
+    latestUpgrade string,
+    keepers utils.Keepers,
+) map[ecommon.Address]utils.VersionedPrecompiles {
+    return map[ecommon.Address]utils.VersionedPrecompiles{
+        ecommon.HexToAddress(bank.BankAddress):               bank.GetVersioned(...),
+        ecommon.HexToAddress(wasmd.WasmdAddress):             wasmd.GetVersioned(...),
+        // ... all precompiles registered
+    }
+}
+```
+
+## Bank
+
+**Address:** `0x0000000000000000000000000000000000001001`  
+**Source:** `precompiles/bank/bank.go`
+
+The bank precompile exposes Cosmos SDK bank module functionality for native token operations.
+
+### Methods
+
+- **`send(string toAddress, string denom, uint256 amount)`** — send native tokens to a Pax address
+- **`sendNative(address recipient, string denom, uint256 amount)`** — send native tokens to an EVM address
+- **`balance(address account, string denom) returns (uint256)`** — query balance of a denom
+- **`all_balances(address account) returns (Coin[])`** — query all balances for an account
+- **`name(string denom) returns (string)`** — query denom display name
+- **`symbol(string denom) returns (string)`** — query denom symbol
+- **`decimals(string denom) returns (uint8)`** — query denom decimals
+- **`supply(string denom) returns (uint256)`** — query total supply of a denom
+
+Tokens are specified using native Cosmos denoms (e.g., `uhpx`, `factory/pax1.../subdenom`). Amounts are 18-decimal wei values, converted internally to 6-decimal µhpx.
+
+## Wasmd
+
+**Address:** `0x0000000000000000000000000000000000001002`  
+**Source:** `precompiles/wasmd/wasmd.go`
+
+The wasmd precompile enables EVM contracts to instantiate and execute CosmWasm contracts.
+
+### Methods
+
+- **`instantiate(uint64 codeID, string admin, bytes msg, string label) returns (string)`** — instantiate a CW contract, returns contract address
+- **`execute(string contractAddress, bytes msg) payable`** — execute a CW contract with optional native token transfer
+- **`execute_batch(string[] contractAddresses, bytes[] msgs, Coin[][] coins)`** — batch execute multiple CW contracts
+- **`query(string contractAddress, bytes request) returns (bytes)`** — static query to CW contract
+
+The `msg` and `request` parameters are JSON-encoded CosmWasm messages. The precompile handles conversion between EVM and Cosmos types.
+
+### Payable Behavior
+
+The `execute` method is payable. Value sent to the contract is converted to native Cosmos coins and passed to the CW contract as funds.
+
+## JSON
+
+**Address:** `0x0000000000000000000000000000000000001003`  
+**Source:** `precompiles/json/json.go`
+
+The JSON precompile provides utilities for parsing JSON data within EVM contracts. Useful for working with CosmWasm query responses.
+
+### Methods
+
+- **`extractAsBytes(bytes json, string key) returns (bytes)`** — extract a field as bytes
+- **`extractAsBytesList(bytes json, string key) returns (bytes[])`** — extract an array field
+- **`extractAsUint256(bytes json, string key) returns (uint256)`** — extract a numeric field
+- **`extractAsBytesFromArray(bytes json, string key, uint256 index) returns (bytes)`** — extract from array by index
+
+Gas cost scales with input size (100 gas per byte).
+
+## Addr
+
+**Address:** `0x0000000000000000000000000000000000001004`  
+**Source:** `precompiles/addr/addr.go`
+
+The addr precompile manages bidirectional address association between Pax (bech32) and EVM (hex) addresses.
+
+### Methods
+
+- **`getPaxAddr(address evmAddr) returns (string)`** — get Pax address for an EVM address
+- **`getEvmAddr(string paxAddr) returns (address)`** — get EVM address for a Pax address
+- **`associate(string paxAddr, bytes pubkey)`** — associate addresses using a public key
+- **`associatePubKey(string paxAddr, bytes pubkey)`** — alternative association method
+
+Association is typically automatic when signing transactions, but these methods allow explicit linking.
+
+## Staking
+
+**Address:** `0x0000000000000000000000000000000000001005`  
+**Source:** `precompiles/staking/staking.go`
+
+The staking precompile exposes validator delegation, undelegation, and redelegation functionality to EVM contracts.
+
+### Methods
+
+#### State-Changing
+
+- **`delegate(string validator, uint256 amount)`** — delegate tokens to a validator
+- **`redelegate(string srcValidator, string dstValidator, uint256 amount)`** — redelegate between validators
+- **`undelegate(string validator, uint256 amount)`** — begin unbonding tokens from a validator
+- **`createValidator(ValidatorParams params)`** — create a new validator (requires validator pubkey)
+- **`editValidator(ValidatorParams params)`** — update validator metadata
+
+#### Queries
+
+- **`delegation(address delegator, string validator) returns (uint256)`** — query delegation amount
+- **`validators() returns (Validator[])`** — list all validators
+- **`validator(string valAddr) returns (Validator)`** — get validator details
+- **`validatorDelegations(string valAddr) returns (Delegation[])`** — all delegations to a validator
+- **`validatorUnbondingDelegations(string valAddr) returns (UnbondingDelegation[])`** — unbonding delegations for validator
+- **`unbondingDelegation(address delegator, string validator) returns (UnbondingDelegation)`** — query unbonding progress
+- **`delegatorDelegations(address delegator) returns (Delegation[])`** — all delegations by a delegator
+- **`delegatorValidator(address delegator, string validator) returns (Validator)`** — validator delegated to
+- **`delegatorUnbondingDelegations(address delegator) returns (UnbondingDelegation[])`** — all unbonding for delegator
+- **`redelegations(address delegator, string srcVal, string dstVal) returns (Redelegation[])`** — query redelegations
+- **`delegatorValidators(address delegator) returns (Validator[])`** — validators a delegator has staked with
+- **`historicalInfo(uint64 height) returns (HistoricalInfo)`** — historical validator set at height
+- **`pool() returns (uint256 bonded, uint256 notBonded)`** — total staked vs unbonded tokens
+- **`params() returns (StakingParams)`** — staking module parameters
+
+Validator addresses are bech32-encoded (e.g., `paxvaloper1...`). Amounts are in wei (18 decimals), converted to µhpx internally.
+
+## Gov
+
+**Address:** `0x0000000000000000000000000000000000001006`  
+**Source:** `precompiles/gov/gov.go`
+
+The gov precompile allows EVM contracts to submit governance proposals and vote.
+
+### Methods
+
+- **`submitProposal(bytes content, string proposalType) returns (uint64)`** — submit a governance proposal, returns proposal ID
+- **`vote(uint64 proposalId, uint32 option)`** — vote on a proposal (Yes=1, No=3, NoWithVeto=4, Abstain=2)
+- **`deposit(uint64 proposalId, uint256 amount)`** — deposit tokens to a proposal
+- **`proposal(uint64 proposalId) returns (Proposal)`** — query proposal details
+- **`proposals(uint32 status) returns (Proposal[])`** — list proposals by status
+
+The `content` parameter is JSON-encoded proposal content. Voting options are integers matching Cosmos SDK vote options.
+
+## Distribution
+
+**Address:** `0x0000000000000000000000000000000000001007`  
+**Source:** `precompiles/distribution/distribution.go`
+
+The distribution precompile handles staking rewards withdrawal.
+
+### Methods
+
+- **`setWithdrawAddress(address withdrawAddr)`** — set address to receive rewards
+- **`withdrawDelegationRewards(string validator)`** — withdraw rewards from one validator
+- **`withdrawMultipleDelegationRewards(string[] validators)`** — withdraw from multiple validators in one tx
+- **`withdrawValidatorCommission(string validator)`** — withdraw validator commission (validator only)
+- **`rewards(address delegator, string validator) returns (Coin[])`** — query pending rewards
+
+Rewards accumulate per block and can be withdrawn at any time. Multiple withdrawals can be batched for gas efficiency.
+
+## Oracle
+
+**Address:** `0x0000000000000000000000000000000000001008`  
+**Source:** `precompiles/oracle/oracle.go`
+
+**Status:** Retired. Oracle data queries are disabled.
+
+The oracle precompile previously provided exchange rate data from validator voting. It now returns an error (`ErrOraclePrecompileRetired`) on all calls.
+
+Historical methods (now disabled):
+
+- `getExchangeRates() returns (ExchangeRate[])`
+- `getOracleTwaps(string[] denoms, uint64 lookback) returns (OracleTwap[])`
+
+## IBC
+
+**Address:** `0x0000000000000000000000000000000000001009`  
+**Source:** `precompiles/ibc/ibc.go`
+
+The IBC precompile enables cross-chain token transfers via IBC.
+
+### Methods
+
+- **`transfer(string sourcePort, string sourceChannel, string denom, uint256 amount, address sender, string receiver, string timeoutHeight, uint64 timeoutTimestamp)`** — IBC transfer with explicit timeout
+- **`transferWithDefaultTimeout(string sourcePort, string sourceChannel, string denom, uint256 amount, address sender, string receiver)`** — IBC transfer with default 10-minute timeout
+
+Transfers send tokens to another IBC-connected chain. The `receiver` is a bech32 address on the destination chain.
+
+Typical usage:
+
+```solidity
+ibc.transferWithDefaultTimeout(
+    "transfer",           // source port
+    "channel-0",          // source channel
+    "uhpx",               // denom
+    1000000000000000000,  // amount (1 HPX in wei)
+    msg.sender,           // sender
+    "osmo1..."            // receiver on destination
+);
+```
+
+## PointerView
+
+**Address:** `0x000000000000000000000000000000000000100A`  
+**Source:** `precompiles/pointerview/pointerview.go`
+
+The pointerview precompile queries existing pointer contract addresses (read-only). It does NOT create pointers; use the `pointer` precompile for creation.
+
+### Methods
+
+- **`getNativePointer(string denom) returns (address)`** — get ERC20 pointer for a native denom
+- **`getCW20Pointer(string cwAddr) returns (address)`** — get ERC20 pointer for a CW20 token
+- **`getCW721Pointer(string cwAddr) returns (address)`** — get ERC721 pointer for a CW721 NFT
+- **`getCW1155Pointer(string cwAddr) returns (address)`** — get ERC1155 pointer for a CW1155 token
+
+Returns `address(0)` if no pointer exists.
+
+## Pointer
+
+**Address:** `0x000000000000000000000000000000000000100B`  
+**Source:** `precompiles/pointer/pointer.go`
+
+The pointer precompile creates EVM pointer contracts for CosmWasm and native tokens, enabling cross-VM token access.
+
+### Methods
+
+- **`addNativePointer(string denom) returns (address)`** — create ERC20 pointer for a native denom
+- **`addCW20Pointer(string cwAddr) returns (address)`** — create ERC20 pointer for a CW20 token
+- **`addCW721Pointer(string cwAddr) returns (address)`** — create ERC721 pointer for a CW721 NFT
+- **`addCW1155Pointer(string cwAddr) returns (address)`** — create ERC1155 pointer for a CW1155 token
+
+Pointer creation is idempotent; calling again returns the existing pointer address. Pointers are deployed as minimal proxy contracts with embedded logic.
+
+See [EVM Module - Pointer Contracts](evm.md#pointer-contracts) for architectural details.
+
+## Solo
+
+**Address:** `0x000000000000000000000000000000000000100C`  
+**Source:** `precompiles/solo/solo.go`
+
+The solo precompile integrates with solo machine workflows for permissioned claim operations.
+
+### Methods
+
+- **`claim()`** — claim assets from solo machine
+- **`claimSpecific(address token, uint256 amount)`** — claim specific token and amount
+
+This precompile is restricted to authorized addresses and used for internal infrastructure. General users should not call it directly.
+
+## P256
+
+**Address:** `0x0000000000000000000000000000000000001011`  
+**Source:** `precompiles/p256/p256.go`
+
+The P256 precompile verifies P256 (secp256r1) ECDSA signatures. This is the signature scheme used by Apple Secure Enclave and many hardware security modules.
+
+### Methods
+
+- **`verify(bytes32 hash, bytes signature, bytes publicKey) returns (bool)`** — verify a P256 signature
+
+Gas cost is 300 per byte of input. This enables passkey-based authentication and hardware wallet integration.
+
+## Versioning
+
+Precompiles are versioned per upgrade to support historical queries and tracing. The `GetVersioned` function in each precompile package returns a map of upgrade names to precompile implementations.
+
+Versioning is managed in `precompiles/setup.go`:
+
+```go
+var PrecompileLastUpgrade = map[string]int64{
+    bank.BankAddress: 1,
+    // ...
+}
+```
+
+When querying historical state or replaying transactions, the correct precompile version is loaded based on the block height's upgrade.
+
+## ABI Files
+
+All precompiles embed their ABI JSON in the binary via `go:embed abi.json`. ABIs are accessible via:
+
+```go
+precompiles.GetPrecompileInfo("bank").ABI
+```
+
+This allows external tools to generate contract interfaces without distributing separate ABI files.

--- a/paxeer-docs/content/core/storage.md
+++ b/paxeer-docs/content/core/storage.md
@@ -1,0 +1,272 @@
+# Storage
+
+Paxeer's storage layer is split into multiple subsystems optimized for different access patterns. The architecture is defined under `paxeer-network/storage/` and implements the PaxDB design, which separates active state from historical data.
+
+## Architecture Overview
+
+PaxDB divides storage into three layers:
+
+1. **State Commitment (SC)** — in-memory Merkle tree for active state and proofs
+2. **State Store (SS)** — versioned key-value store for historical queries
+3. **Ledger DB** — block, transaction, and receipt storage
+
+This separation is based on the [Cosmos StoreV2 ADR](https://docs.cosmos.network/main/build/architecture/adr-065-store-v2), which recognizes that a single database cannot efficiently serve both consensus proofs and historical queries.
+
+### Key Benefits
+
+From `storage/README.md`:
+
+- Reduces active chain state size by 60%
+- Reduces historical data growth rate by ~90%
+- Improves state sync times by 1200% and block sync by 2x
+- 287x improvement in block commit times
+- 2x overall TPS improvement
+- Archive nodes achieve the same performance as full nodes
+
+### Trade-offs
+
+- No historical proofs for all historical blocks (only recent, unpruned heights)
+- Historical data lacks integrity validation (must trust the source)
+
+## State Commitment (SC) Layer
+
+**Path:** `storage/state_db/sc/`
+
+The SC layer provides:
+
+- Root app hash for each block
+- Data access for transaction execution
+- State import/export for state sync
+- Historical proofs for unpruned heights
+
+### MemIAVL Implementation
+
+PaxDB forks [MemIAVL](https://github.com/crypto-org-chain/cronos/tree/main/memiavl) as its SC implementation. MemIAVL uses the same Merkelized AVL tree structure as Cosmos SDK but represents it in memory-mapped flat files instead of persisting nodes as key-value pairs in a database.
+
+This design:
+
+- **Avoids database overhead** — no encoding/decoding, no read amplification from node traversal
+- **Memory-mapped I/O** — the OS manages page cache, reducing application memory pressure
+- **Fast commits** — writing a new snapshot file is sequential I/O
+- **Incremental snapshots** — only changed nodes are written
+
+The SC tree is rebuilt from disk on node restart using the memory-mapped files.
+
+### Pruning
+
+SC stores are pruned to a configurable retention window (e.g., keep last 1000 blocks). Beyond that, only the SS layer retains historical data, and proofs are unavailable.
+
+Pruning configuration is in `storage/config/sc_config.go`.
+
+## State Store (SS) Layer
+
+**Path:** `storage/state_db/ss/`
+
+The SS layer stores versioned raw key-value pairs for historical queries. It does NOT store Merkle proofs or intermediate tree nodes, only the application-level key-value data.
+
+### Responsibilities
+
+- Fast versioned queries (key at height H)
+- Versioned iteration over key ranges
+- Batching for bulk writes
+- Pruning of old versions
+
+### DB Backend
+
+PaxDB uses **PebbleDB** as the recommended backend for SS. Extensive benchmarking (documented in `storage/README.md`) showed PebbleDB outperforms LevelDB, RocksDB, and SQLite for Paxeer's workload:
+
+- Random writes
+- Random reads
+- Forward/backward iteration
+
+The SS implementation wraps PebbleDB with versioning logic, encoding each key as `{prefix}{version}{original_key}`.
+
+### Write Modes
+
+SS supports multiple write modes (`storage/config/write_mode.go`):
+
+- **Synchronous** — block until write is flushed to disk
+- **Asynchronous** — return after write is in OS buffer
+- **Batch** — accumulate writes and flush in larger batches
+
+Mode selection balances durability vs throughput. Validators typically use synchronous mode; archive nodes use async for higher throughput.
+
+### Configuration
+
+SS config is in `storage/config/ss_config.go`:
+
+- Database path
+- Cache size
+- Pruning strategy (keep last N versions)
+- Compaction settings
+
+## Ledger DB
+
+**Path:** `storage/ledger_db/`
+
+The ledger DB stores blockchain-level data outside the application state tree. It is organized into subdirectories:
+
+### Block Store
+
+**Path:** `storage/ledger_db/block/`
+
+Stores full block data (headers, transactions, evidence, commits). Implemented in `block_db.go`:
+
+```go
+type BlockDB interface {
+    SaveBlock(height int64, block *types.Block, commit *types.Commit) error
+    LoadBlock(height int64) (*types.Block, error)
+    LoadBlockMeta(height int64) (*types.BlockMeta, error)
+    DeleteBlock(height int64) error
+}
+```
+
+An in-memory implementation (`mem_block_db/`) is available for testing. Production uses on-disk storage.
+
+Pruning is independent of SC/SS pruning and configured separately.
+
+### Transaction Store
+
+**Path:** `storage/ledger_db/transaction/`
+
+Currently a placeholder. Transaction indexing is handled by the consensus layer's transaction indexer (`consensus/internal/state/indexer/`).
+
+### Receipt Store
+
+**Path:** `storage/ledger_db/receipt/`
+
+Stores EVM transaction receipts. Implemented in `receipt_store.go`:
+
+```go
+type ReceiptStore interface {
+    SaveReceipt(ctx sdk.Context, hash common.Hash, receipt *ethtypes.Receipt) error
+    GetReceipt(ctx sdk.Context, hash common.Hash) (*ethtypes.Receipt, error)
+    GetReceiptByIndex(ctx sdk.Context, height uint64, idx uint64) (*ethtypes.Receipt, common.Hash, error)
+}
+```
+
+Receipts are indexed by:
+
+- **Transaction hash** — primary lookup
+- **Block height + index** — for block-level queries
+
+A transaction hash index (`tx_hash_index.go`) maps EVM tx hashes to block height and index. This is a write-through cache with on-disk backing.
+
+Receipts are cached in memory (`receipt_cache.go`) with LRU eviction to avoid repeated disk reads.
+
+### Event Store
+
+**Path:** `storage/ledger_db/event/`
+
+Currently a placeholder. Event indexing is handled by the consensus event sinks (`consensus/internal/state/indexer/sink/`).
+
+## WAL (Write-Ahead Log)
+
+**Path:** `storage/wal/`
+
+The WAL records state changes before they are committed to the SC/SS layers. This enables:
+
+- **Crash recovery** — replay uncommitted changes after node restart
+- **Atomic commits** — ensure all layers are consistent
+- **Debugging** — inspect the sequence of state changes
+
+WAL entries are written sequentially and flushed to disk before acknowledgment. After a successful commit, WAL entries are garbage-collected.
+
+WAL configuration includes:
+- File rotation size
+- Retention policy
+- Sync mode (fsync vs OS buffer)
+
+## DB Engine
+
+**Path:** `storage/db_engine/`
+
+The db_engine package provides a unified interface for database backends:
+
+```go
+type DB interface {
+    Get(key []byte) ([]byte, error)
+    Set(key []byte, value []byte) error
+    Delete(key []byte) error
+    Iterator(start, end []byte) Iterator
+    ReverseIterator(start, end []byte) Iterator
+    NewBatch() Batch
+    Close() error
+}
+```
+
+This abstraction allows swapping between PebbleDB, LevelDB, RocksDB, or other backends without changing application code.
+
+The engine implements:
+
+- **Batch writes** — accumulate multiple writes and commit atomically
+- **Iterators** — range queries with forward/reverse traversal
+- **Prefix scans** — iterate all keys with a common prefix
+
+Backend selection is configured at node startup.
+
+## State Reconstruction
+
+A node can reconstruct its state from:
+
+1. **Genesis file** — initial state at height 0
+2. **Block replay** — apply all blocks sequentially
+3. **State sync** — download a recent snapshot and sync forward
+
+State sync uses the SC layer's export/import functionality to transfer the active state tree. After import, the node syncs blocks from the snapshot height to the chain tip.
+
+## Persistence Guarantees
+
+Different layers have different durability:
+
+| Layer      | Durable After        | Loss Impact                |
+|------------|----------------------|----------------------------|
+| SC         | Commit + sync        | Lose uncommitted state     |
+| SS         | Async flush (config) | Lose recent historical data|
+| Ledger DB  | Block write          | Lose recent blocks         |
+| WAL        | Fsync                | Lose uncommitted writes    |
+
+Validators use synchronous writes for all layers to prevent any data loss. Full nodes and archive nodes may use async writes for higher throughput at the cost of potential data loss on crash.
+
+## Configuration Files
+
+Storage configuration is loaded from `config.toml` and split into:
+
+- **SC config** (`storage/config/sc_config.go`) — pruning, cache, snapshot intervals
+- **SS config** (`storage/config/ss_config.go`) — backend, write mode, compaction
+- **Receipt config** (`storage/config/receipt_config.go`) — cache size, indexing
+
+Per-module configuration allows independent tuning of each layer.
+
+## Observability
+
+Storage metrics exposed via Prometheus:
+
+- SC commit latency and size
+- SS write/read latency
+- Ledger DB block save time
+- Receipt store cache hit rate
+- Database compaction activity
+- Disk usage per layer
+
+Logs include:
+
+- Pruning operations (which heights were pruned)
+- Snapshot creation/restoration
+- Database compaction runs
+- WAL replay on startup
+
+## Tools
+
+The `storage/tools/` directory provides utilities:
+
+- **paxdb** (`storage/tools/cmd/paxdb/`) — CLI for inspecting and manipulating PaxDB databases
+  - Dump SC/SS state
+  - Benchmark read/write performance
+  - Import/export between formats
+  - Compute state size
+  - Replay changelogs
+- **rpc_bench** (`storage/tools/rpc_bench/`) — benchmarks RPC query performance
+- **cryptosim** (`storage/state_db/bench/cryptosim/`) — synthetic workload generator for storage testing
+
+These tools are used for debugging, performance tuning, and migration testing.

--- a/paxeer-docs/content/core/wasm.md
+++ b/paxeer-docs/content/core/wasm.md
@@ -1,0 +1,453 @@
+# WASM (CosmWasm)
+
+Paxeer integrates [CosmWasm](https://cosmwasm.com/), a smart contract platform for the Cosmos ecosystem. CosmWasm contracts run in a sandboxed WebAssembly (WASM) VM and can interact with the Cosmos SDK and EVM through custom bindings.
+
+The WASM implementation is split across three directories:
+
+- `paxeer-network/wasm/` — CosmWasm app module and Cosmos SDK integration
+- `paxeer-network/wasm-runtime/` — WASM VM runtime (libwasmvm wrapper)
+- `paxeer-network/wasmbinding/` — Paxeer-specific query and message bindings
+
+## Architecture
+
+CosmWasm contracts execute in the Wasmer runtime, which compiles WASM bytecode to native machine code. The runtime is embedded in the node via CGO bindings to the Rust `libwasmvm` library.
+
+The CosmWasm `x/wasm` module (`wasm/x/wasm/`) integrates into the Cosmos SDK app as a standard module providing:
+
+- Contract upload (store compiled WASM)
+- Contract instantiation (create contract instances)
+- Contract execution (call contract entry points)
+- Contract queries (read contract state)
+- Contract migration (upgrade contract code)
+
+## App Module
+
+**Path:** `wasm/x/wasm/`
+
+The WASM app module is defined in `wasm/x/wasm/module.go`:
+
+```go
+type AppModule struct {
+    keeper Keeper
+    // ...
+}
+
+func (am AppModule) RegisterServices(cfg module.Configurator) {
+    types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+    types.RegisterQueryServer(cfg.QueryServer(), keeper.Querier{Keeper: am.keeper})
+}
+```
+
+The module exposes:
+
+- **Msg server** — state-changing operations (upload, instantiate, execute, migrate)
+- **Query server** — read-only contract queries and metadata
+- **Genesis** — export/import contract state
+- **ABCI hooks** — BeginBlock/EndBlock for contract lifecycle
+
+## Keeper
+
+**Path:** `wasm/x/wasm/keeper/keeper.go`
+
+The WASM keeper manages contract lifecycle and state:
+
+```go
+type Keeper struct {
+    storeKey          sdk.StoreKey
+    cdc               codec.Codec
+    wasmVM            types.WasmerEngine  // WASM runtime
+    accountKeeper     types.AccountKeeper
+    bankKeeper        types.BankKeeper
+    // ...
+}
+```
+
+### Key Operations
+
+**Upload:**
+
+```go
+func (k Keeper) Create(ctx sdk.Context, creator sdk.AccAddress, wasmCode []byte) (codeID uint64, err error)
+```
+
+Stores compiled WASM bytecode and assigns a code ID. The code is validated and instantiated once; multiple contracts can be instantiated from the same code.
+
+**Instantiate:**
+
+```go
+func (k Keeper) Instantiate(
+    ctx sdk.Context,
+    codeID uint64,
+    creator, admin sdk.AccAddress,
+    initMsg []byte,
+    label string,
+    deposit sdk.Coins,
+) (sdk.AccAddress, []byte, error)
+```
+
+Creates a contract instance with:
+
+- Unique contract address (derived from code ID and instance count)
+- Optional admin (can migrate the contract)
+- Initialization message (JSON-encoded)
+- Label for identification
+
+**Execute:**
+
+```go
+func (k Keeper) Execute(
+    ctx sdk.Context,
+    contractAddress sdk.AccAddress,
+    caller sdk.AccAddress,
+    msg []byte,
+    coins sdk.Coins,
+) (*sdk.Result, error)
+```
+
+Calls a contract's `execute` entry point with funds. The contract can:
+
+- Mutate its state
+- Send messages to other modules
+- Query other contracts or modules
+- Return events and data
+
+**Query:**
+
+```go
+func (k Keeper) QuerySmart(
+    ctx sdk.Context,
+    contractAddress sdk.AccAddress,
+    req []byte,
+) ([]byte, error)
+```
+
+Calls a contract's `query` entry point (read-only). Queries cannot modify state or consume significant gas.
+
+## WASM Runtime
+
+**Path:** `wasm-runtime/`
+
+The WASM runtime wraps libwasmvm, the Rust library that executes WASM bytecode. Paxeer supports two build modes:
+
+### CGO Mode (Default)
+
+Links against the C-exported libwasmvm library:
+
+```go
+// #cgo LDFLAGS: -lwasmvm
+import "C"
+
+func (vm *VM) Instantiate(...) { /* CGO calls */ }
+```
+
+This mode requires:
+
+- Rust toolchain at build time
+- `libwasmvm.so` (Linux) or `libwasmvm.dylib` (macOS) in library path
+
+CGO mode provides the best performance (Wasmer JIT compilation).
+
+### No-CGO Mode
+
+Uses a pure Go WASM interpreter (slower but avoids CGO):
+
+```go
+// +build !cgo
+
+func (vm *VM) Instantiate(...) { /* Go interpreter */ }
+```
+
+Enabled with `CGO_ENABLED=0` or when `libwasmvm` is unavailable. Useful for cross-compilation or environments without Rust.
+
+### Gas Metering
+
+The runtime injects gas metering into WASM bytecode. Every instruction consumes gas; when the gas limit is reached, execution panics with `OutOfGasError`.
+
+Gas costs are defined in `wasm/x/wasm/keeper/gas_register.go`:
+
+- Memory allocation
+- CPU cycles (per opcode)
+- Storage reads/writes
+- External calls
+
+## Wasmbinding
+
+**Path:** `wasmbinding/`
+
+Wasmbinding provides Paxeer-specific queries and messages for CosmWasm contracts. This is how CW contracts access Paxeer modules like EVM, oracle, epoch, and tokenfactory.
+
+### Custom Queries
+
+**Path:** `wasmbinding/query_plugin.go`
+
+The query plugin handles read-only queries from CW contracts to Paxeer modules:
+
+```go
+type QueryPlugin struct {
+    oracleHandler       oraclewasm.OracleWasmQueryHandler
+    epochHandler        epochwasm.EpochWasmQueryHandler
+    tokenfactoryHandler tokenfactorywasm.TokenFactoryWasmQueryHandler
+    evmHandler          evmwasm.EVMQueryHandler
+    stakingKeeper       stakingkeeper.Keeper
+}
+```
+
+Contracts send queries via the `PaxQuery` custom query type defined in `wasmbinding/bindings/`:
+
+```rust
+// From CosmWasm contract
+let response: ExchangeRatesResponse = deps.querier.query(&QueryRequest::Custom(
+    PaxQuery::ExchangeRates {}
+))?;
+```
+
+The query plugin (`HandleOracleQuery`, `HandleEpochQuery`, etc.) unmarshals the query, calls the appropriate keeper, and returns JSON-encoded results.
+
+#### Supported Queries
+
+**Oracle** (`wasmbinding/query_plugin.go`):
+
+- `ExchangeRates` — all current exchange rates
+- `OracleTwaps` — time-weighted average prices
+
+**Epoch**:
+
+- `Epoch` — current epoch number and timing
+
+**TokenFactory**:
+
+- `DenomAuthorityMetadata` — admin and creator of a tokenfactory denom
+- `DenomsFromCreator` — all denoms created by an address
+
+**EVM**:
+
+- Static EVM calls
+- ERC20/721/1155 token queries
+- Address association lookups
+- Pointer contract addresses
+
+### Custom Messages
+
+**Path:** `wasmbinding/message_plugin.go`
+
+The message plugin handles state-changing operations from CW contracts:
+
+```go
+type MessagePlugin struct {
+    wrapped msg.Handler
+}
+
+func (mp MessagePlugin) DispatchMsg(ctx sdk.Context, contractAddr sdk.AccAddress, contractIBCPortID string, msg wasmvmtypes.CosmosMsg) ([]sdk.Event, [][]byte, error)
+```
+
+Contracts send messages via the `PaxMsg` custom message type:
+
+```rust
+// From CosmWasm contract
+let msg = CosmosMsg::Custom(PaxMsg::CallEvm {
+    to: evm_contract_address,
+    data: encoded_call_data,
+    value: Uint128::zero(),
+});
+```
+
+The message plugin routes to the appropriate module (EVM, tokenfactory, oracle, etc.).
+
+#### Supported Messages
+
+**EVM**:
+
+- `CallEvm` — call an EVM contract from CW
+- `DelegateCallEvm` — delegate call (restricted to pointers)
+
+**TokenFactory**:
+
+- `CreateDenom`
+- `MintTokens`
+- `BurnTokens`
+- `ChangeAdmin`
+
+**Oracle** (if enabled):
+
+- `AggregateExchangeRatePrevote`
+- `AggregateExchangeRateVote`
+
+### Bindings
+
+**Path:** `wasmbinding/bindings/`
+
+Type definitions for Paxeer-specific queries and messages are in `wasmbinding/bindings/`:
+
+- `msg.go` — message types (`PaxMsg`)
+- `queries.go` — query types (`PaxQuery`)
+- `errors.go` — error types
+
+These are imported by CosmWasm contracts to interact with Paxeer:
+
+```rust
+use paxeer_bindings::{PaxQuery, PaxMsg, ExchangeRatesResponse};
+```
+
+## Contract-to-EVM Interaction
+
+CosmWasm contracts can call EVM contracts via the `evmHandler` in wasmbinding. This enables:
+
+- CW contracts invoking ERC20 `transfer`, `approve`
+- CW contracts calling custom EVM logic
+- Pointer contracts forwarding operations between VMs
+
+### Call Flow
+
+1. CW contract emits `PaxMsg::CallEvm`
+2. Message plugin receives the message
+3. Keeper creates an internal EVM call
+4. EVM executes the call with CW contract as caller
+5. Return data is passed back to CW contract
+
+EVM calls from CW are subject to:
+
+- Gas limits (shared gas meter)
+- Read-only enforcement (for queries)
+- Reentrancy restrictions (no CW→EVM→CW→EVM)
+
+## EVM-to-WASM Interaction
+
+EVM contracts can call CosmWasm contracts via:
+
+1. **Wasmd precompile** (`0x1002`) — direct instantiation and execution from EVM
+2. **Pointer contracts** — EVM pointers for CW20/721/1155 tokens
+
+### Call Flow
+
+1. EVM contract calls wasmd precompile or pointer
+2. Precompile converts EVM call to CW message
+3. WASM keeper executes the CW contract
+4. Return data is converted back to EVM format
+5. EVM contract receives the result
+
+EVM→CW calls support:
+
+- Passing native tokens (EVM `value` → CW `funds`)
+- JSON message encoding
+- Query and execute entry points
+
+## Gas Accounting
+
+Gas is shared between Cosmos SDK, EVM, and WASM. The keeper tracks gas usage and converts between units:
+
+- **Cosmos gas** — integer, consumed by SDK modules
+- **EVM gas** — uint64, consumed by EVM execution
+- **WASM gas** — uint64, consumed by WASM execution
+
+Conversion factors are configurable. When a CW contract calls the EVM (or vice versa), gas is deducted from the shared pool.
+
+## Contract Permissions
+
+CosmWasm supports permission policies via the `authz_policy` mechanism (`wasm/x/wasm/keeper/authz_policy.go`). Contracts can be restricted by:
+
+- Who can instantiate from a code ID
+- Who can execute a contract
+- Who can migrate a contract
+
+Paxeer uses this to restrict sensitive operations (e.g., only whitelisted contracts can delegate-call the EVM).
+
+## Contract Lifecycle
+
+### Upload
+
+Developer compiles Rust code to WASM, then uploads via:
+
+```bash
+paxd tx wasm store contract.wasm --from creator
+```
+
+The keeper validates the WASM (no floating point, no start function, valid exports) and stores it with a code ID.
+
+### Instantiate
+
+User instantiates a contract from code ID:
+
+```bash
+paxd tx wasm instantiate 1 '{"count": 0}' --from creator --label "counter"
+```
+
+The contract receives a unique address and runs its `instantiate` entry point.
+
+### Execute
+
+User sends a message to the contract:
+
+```bash
+paxd tx wasm execute pax14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr '{"increment":{}}' --from user
+```
+
+The contract's `execute` entry point runs and can mutate state.
+
+### Migrate
+
+Admin upgrades the contract to new code:
+
+```bash
+paxd tx wasm migrate pax14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9s4hmalr 2 '{}' --from admin
+```
+
+The new code's `migrate` entry point runs to upgrade state schema if needed.
+
+## Events and Attributes
+
+CosmWasm contracts emit events via:
+
+```rust
+let event = Event::new("action")
+    .add_attribute("sender", info.sender)
+    .add_attribute("amount", amount.to_string());
+```
+
+These are converted to Cosmos SDK events and indexed for queries. Contracts can also emit synthetic EVM logs (via pointer contracts) that appear in EVM receipts.
+
+## Testing
+
+**Path:** `wasm/x/wasm/keeper/`
+
+The keeper includes test helpers (`test_common.go`) for:
+
+- Mock WASM VM (no CGO required)
+- Contract upload/instantiate in tests
+- Simulated execution
+- State inspection
+
+Tests load example contracts from `wasm/x/wasm/keeper/testdata/`.
+
+## Observability
+
+WASM metrics exposed via Prometheus:
+
+- Contract instantiations per code ID
+- Execution gas usage
+- Query latency
+- Upload size
+
+Events:
+
+- `wasm-store_code` — code uploaded
+- `wasm-instantiate` — contract instantiated
+- `wasm` — contract execution (includes contract events)
+
+## Limitations
+
+- **No floating point** — WASM contracts cannot use `f32`/`f64` (disabled for determinism)
+- **No dynamic linking** — contracts must be fully self-contained
+- **Gas limits** — queries have low gas limits to prevent DoS
+- **Reentrancy** — CW→EVM→CW call chains are restricted (max 1 hop with writes)
+
+## Contract Security
+
+Best practices for CosmWasm on Paxeer:
+
+1. **Validate inputs** — contracts are public APIs, all inputs are untrusted
+2. **Check funds** — ensure sent funds match expected amounts
+3. **Avoid reentrancy** — do not call untrusted contracts during state updates
+4. **Limit queries** — external queries can be expensive or manipulated
+5. **Use pointer contracts** — for CW↔EVM interop, prefer established patterns
+
+See [CosmWasm security documentation](https://docs.cosmwasm.com/docs/1.0/security/) for general guidance.

--- a/paxeer-docs/index.md
+++ b/paxeer-docs/index.md
@@ -1,0 +1,17 @@
+# Paxeer Core Documentation
+
+Technical documentation for Paxeer's core protocol implementation, written from the source code in `paxeer-network/`.
+
+## Pages
+
+- [Consensus](consensus.md) — Byzantine Fault Tolerant consensus, block proposal, voting, ABCI integration
+- [Engine](engine.md) — Transaction execution, executor, StateDB bridge, gas metering
+- [EVM](evm.md) — Ethereum Virtual Machine integration on chain ID 125, address association, receipts, pointer contracts
+- [Modules](modules.md) — Paxeer-specific modules (epoch, mint, oracle, tokenfactory)
+- [Storage](storage.md) — PaxDB architecture (SC, SS, ledger DB, WAL)
+- [Precompiles](precompiles.md) — Custom EVM precompiles exposing Cosmos functionality
+- [WASM](wasm.md) — CosmWasm integration, wasmbinding, runtime
+
+## Source
+
+All documentation extracted from `paxeer-network/` (consensus, engine, modules, storage, precompiles, wasm, wasmbinding).


### PR DESCRIPTION
Superseded. This is leftover markdown on a parallel tree (`paxeer-docs/content/core/`). The live fill is going onto Ultron's Next.js shell (#85) and a follow-up PR from `cursor/paxeer-docs-site-8735`. Do not merge this.