### PR TITLE
Complete Paxeer documentation: REST/gRPC, Contracts, Docker, SDK, Interchain, Admin/HPX

### DIFF
--- a/paxeer-docs/src/app/admin-hpx/page.tsx
+++ b/paxeer-docs/src/app/admin-hpx/page.tsx
@@ -7,19 +7,460 @@ export default function AdminHpx() {
       <div className="page-header">
         <h1 className="page-title">Admin & HPX</h1>
         <p className="page-description">
-          Native paxd distribution and peer registry tooling.
+          Runtime administration gRPC service and HyperPax native node distribution.
         </p>
       </div>
 
       <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/hpx/</code> and <code>paxeer-network/admin/</code>
+        <strong>Admin:</strong> <code>paxeer-network/admin/</code><br />
+        <strong>HPX:</strong> <code>paxeer-network/hpx/</code>
       </div>
 
-      <h2>Chain Identifier</h2>
+      <h2>Admin gRPC Service</h2>
 
       <p>
-        The Cosmos-style chain identifier for node distribution is <code>hyperpax_125-1</code> (EVM chain ID 125).
+        The Admin service provides runtime log level control for <code>paxd</code> without restarting the node. It runs on a dedicated loopback-only gRPC server for security.
       </p>
+
+      <h3>Configuration</h3>
+
+      <p>
+        Enable in <code>app.toml</code>:
+      </p>
+
+      <pre><code>{`[admin_server]
+admin_enabled = true
+admin_address = "127.0.0.1:9095"`}</code></pre>
+
+      <p>
+        The address <strong>must</strong> be a loopback address (<code>127.0.0.1</code> or <code>::1</code>). Binding to external interfaces is rejected at startup.
+      </p>
+
+      <h3>gRPC Methods</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Request</th>
+            <th>Response</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>SetLogLevel</code></td>
+            <td><code>pattern</code>, <code>level</code></td>
+            <td><code>affected</code> count</td>
+            <td>Change log level for loggers matching pattern</td>
+          </tr>
+          <tr>
+            <td><code>GetLogLevel</code></td>
+            <td><code>logger</code></td>
+            <td><code>level</code></td>
+            <td>Get current log level for a logger</td>
+          </tr>
+          <tr>
+            <td><code>ListLoggers</code></td>
+            <td><code>prefix</code> (optional)</td>
+            <td>List of loggers</td>
+            <td>List all loggers and their levels</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>SetLogLevel Pattern Matching</h3>
+
+      <p>
+        The <code>pattern</code> parameter supports:
+      </p>
+
+      <ul>
+        <li><strong>Exact match:</strong> <code>"evm"</code> (sets log level for the EVM logger only)</li>
+        <li><strong>Glob:</strong> <code>"evm*"</code> (sets log level for all loggers starting with "evm")</li>
+        <li><strong>All loggers:</strong> <code>"*"</code> (sets log level for every logger)</li>
+      </ul>
+
+      <h3>Log Levels</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Level</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>debug</code></td>
+            <td>Verbose debugging information</td>
+          </tr>
+          <tr>
+            <td><code>info</code></td>
+            <td>General operational information</td>
+          </tr>
+          <tr>
+            <td><code>warn</code></td>
+            <td>Warning messages (potential issues)</td>
+          </tr>
+          <tr>
+            <td><code>error</code></td>
+            <td>Error messages (failures)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Example: Using grpcurl</h3>
+
+      <pre><code>{`# List all loggers
+grpcurl -plaintext localhost:9095 \\
+  paxprotocol.paxchain.admin.v0.AdminService/ListLoggers
+
+# Set EVM logger to debug
+grpcurl -plaintext -d '{"pattern":"evm","level":"debug"}' \\
+  localhost:9095 \\
+  paxprotocol.paxchain.admin.v0.AdminService/SetLogLevel
+
+# Get log level for a specific logger
+grpcurl -plaintext -d '{"logger":"evm"}' \\
+  localhost:9095 \\
+  paxprotocol.paxchain.admin.v0.AdminService/GetLogLevel`}</code></pre>
+
+      <h3>Security</h3>
+
+      <p>
+        The Admin service is loopback-only by design:
+      </p>
+
+      <ul>
+        <li>No authentication required (loopback is trusted)</li>
+        <li>Cannot be bound to external interfaces</li>
+        <li>Must access from the same machine as <code>paxd</code></li>
+      </ul>
+
+      <p>
+        For remote access, use SSH port forwarding:
+      </p>
+
+      <pre><code>{`ssh -L 9095:127.0.0.1:9095 user@node-ip`}</code></pre>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/pax/admin/v0/admin.proto</code><br />
+        <strong>Implementation:</strong> <code>paxeer-network/admin/server.go</code>, <code>service.go</code>, <code>config.go</code>
+      </div>
+
+      <h2>HPX: HyperPax Node Distribution</h2>
+
+      <p>
+        HPX is the public installer, node manager, and peer registry for HyperPax (<code>hyperpax_125-1</code>). Nodes run a native <code>paxd</code> binary under systemd. All artifacts are published outside Git.
+      </p>
+
+      <h3>Chain Identifier</h3>
+
+      <p>
+        <code>hyperpax_125-1</code> (Cosmos-style, EVM chain ID <code>125</code>)
+      </p>
+
+      <h3>Install a Node</h3>
+
+      <pre><code>{`curl -sSL https://node.hyperpaxeer.com/get-hpx.sh | sudo bash`}</code></pre>
+
+      <p>
+        The installer:
+      </p>
+
+      <ol>
+        <li>Downloads and verifies the HPX CLI against <code>checksums.txt</code></li>
+        <li>Places <code>hpx</code> in <code>/usr/local/bin/</code></li>
+      </ol>
+
+      <h3>Setup a Node</h3>
+
+      <pre><code>{`# Set node type (fullnode or validator)
+export HPX_TYPE=fullnode
+
+# Run setup
+hpx setup`}</code></pre>
+
+      <p>
+        The setup flow:
+      </p>
+
+      <ol>
+        <li>Downloads <code>paxd</code>, <code>libwasmvm</code> runtimes, genesis, and configuration</li>
+        <li>Verifies all artifacts against <code>checksums.txt</code></li>
+        <li>Installs artifacts to <code>/root/.paxeer/</code></li>
+        <li>Configures systemd service</li>
+        <li>Starts <code>paxd</code></li>
+      </ol>
+
+      <h3>HPX CLI Commands</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Command</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>hpx status</code></td>
+            <td>Show node sync status</td>
+          </tr>
+          <tr>
+            <td><code>hpx info</code></td>
+            <td>Show node configuration</td>
+          </tr>
+          <tr>
+            <td><code>hpx logs</code></td>
+            <td>Tail <code>paxd</code> logs</td>
+          </tr>
+          <tr>
+            <td><code>hpx update</code></td>
+            <td>Update <code>paxd</code> and libraries</td>
+          </tr>
+          <tr>
+            <td><code>hpx peers show</code></td>
+            <td>Show known peers</td>
+          </tr>
+          <tr>
+            <td><code>hpx peers refresh</code></td>
+            <td>Fetch latest peer list from registry</td>
+          </tr>
+          <tr>
+            <td><code>hpx register</code></td>
+            <td>Announce node to public registry</td>
+          </tr>
+          <tr>
+            <td><code>hpx statesync</code></td>
+            <td>Enable state-sync for fast bootstrap</td>
+          </tr>
+          <tr>
+            <td><code>hpx remove</code></td>
+            <td>Uninstall node and clean up</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Node Types</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Purpose</th>
+            <th>Config</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>fullnode</code></td>
+            <td>Non-validating full node (RPC, indexing)</td>
+            <td><code>/config/fullnode/</code></td>
+          </tr>
+          <tr>
+            <td><code>validator</code></td>
+            <td>Validating node (must register validator key)</td>
+            <td><code>/config/validator/</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Public Registry</h3>
+
+      <p>
+        The HPX registry at <code>https://node.hyperpaxeer.com</code> provides:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>GET /healthz</code></td>
+            <td>Registry liveness, chain and source revision</td>
+          </tr>
+          <tr>
+            <td><code>GET /checksums.txt</code></td>
+            <td>SHA-256 checksums for all artifacts</td>
+          </tr>
+          <tr>
+            <td><code>GET /chain-info.json</code></td>
+            <td>Chain metadata (chain ID, genesis hash)</td>
+          </tr>
+          <tr>
+            <td><code>GET /paxd</code></td>
+            <td>Native <code>paxd</code> binary</td>
+          </tr>
+          <tr>
+            <td><code>GET /lib/*.so</code></td>
+            <td>Architecture-specific <code>libwasmvm</code> runtimes</td>
+          </tr>
+          <tr>
+            <td><code>GET /genesis.json</code></td>
+            <td>Chain genesis file</td>
+          </tr>
+          <tr>
+            <td><code>GET /config/&lt;type&gt;/&lt;file&gt;</code></td>
+            <td>Node configuration files (<code>config.toml</code>, <code>app.toml</code>)</td>
+          </tr>
+          <tr>
+            <td><code>GET /api/myip</code></td>
+            <td>Caller's public IP address</td>
+          </tr>
+          <tr>
+            <td><code>POST /api/register</code></td>
+            <td>Announce node's public peer address</td>
+          </tr>
+          <tr>
+            <td><code>GET /api/peers</code></td>
+            <td>JSON list of registered peers</td>
+          </tr>
+          <tr>
+            <td><code>GET /api/peers.txt</code></td>
+            <td>Text list of peer addresses (Tendermint format)</td>
+          </tr>
+          <tr>
+            <td><code>GET /api/nodes</code></td>
+            <td>Detailed node metadata</td>
+          </tr>
+          <tr>
+            <td><code>GET /api/statesync</code></td>
+            <td>Current state-sync trust parameters</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Artifact Publishing</h3>
+
+      <p>
+        To publish a new <code>paxd</code> release or chain configuration:
+      </p>
+
+      <pre><code>{`# From the monorepo root
+sudo paxeer-network/hpx/publish.sh`}</code></pre>
+
+      <p>
+        This script:
+      </p>
+
+      <ol>
+        <li>Collects <code>paxd</code> binary from <code>build/paxd</code></li>
+        <li>Collects native libraries from <code>wasm-runtime/</code> and <code>wasm/x/wasm/artifacts/</code></li>
+        <li>Collects live chain configuration from <code>/root/.paxeer/config/</code> (or <code>$SRC_CFG</code>)</li>
+        <li>Stages artifacts in <code>/srv/hpx/artifacts/releases/&lt;release-id&gt;/</code></li>
+        <li>Generates <code>checksums.txt</code></li>
+        <li>Atomically moves <code>current</code> symlink to new release</li>
+      </ol>
+
+      <p>
+        Failed staging runs never change the served release.
+      </p>
+
+      <h3>Registry Runtime Deployment</h3>
+
+      <p>
+        Changes to the registry service under <code>paxeer-network/hpx/registry/</code> trigger the GitHub workflow <code>Paxeer / HPX Registry</code>, which:
+      </p>
+
+      <ol>
+        <li>Builds Linux executables (x86-64, AArch64)</li>
+        <li>Publishes them as GitHub release assets</li>
+        <li>Publishes a multi-architecture GHCR image</li>
+      </ol>
+
+      <p>
+        Deploy the registry on the public origin host:
+      </p>
+
+      <pre><code>{`sudo paxeer-network/hpx/hosting/deploy.sh`}</code></pre>
+
+      <p>
+        This script:
+      </p>
+
+      <ol>
+        <li>Downloads and verifies the latest registry executable</li>
+        <li>Installs it as a systemd service (loopback-only)</li>
+        <li>Obtains a Let's Encrypt certificate for <code>node.hyperpaxeer.com</code></li>
+        <li>Configures Nginx reverse proxy with rate-limiting</li>
+      </ol>
+
+      <p>
+        Registry state is persisted at <code>/srv/hpx/data/registry.json</code>.
+      </p>
+
+      <h3>Registry Authentication</h3>
+
+      <p>
+        Registration is public by default. To require a token:
+      </p>
+
+      <pre><code>{`export HPX_REGISTER_TOKEN=your-secret-token
+sudo paxeer-network/hpx/hosting/deploy.sh`}</code></pre>
+
+      <p>
+        The registry will then require <code>X-HPX-Token: your-secret-token</code> header on <code>POST /api/register</code>.
+      </p>
+
+      <h3>Using an Alternate Mirror</h3>
+
+      <p>
+        Set <code>HPX_MIRROR</code> only when operating an explicitly trusted alternate mirror:
+      </p>
+
+      <pre><code>{`export HPX_MIRROR=https://your-mirror.example.com
+hpx setup`}</code></pre>
+
+      <div className="source-note">
+        <strong>Warning:</strong> The mirror must serve the same artifact structure and checksums. Untrusted mirrors can serve malicious binaries.
+      </div>
+
+      <h3>Native Libraries</h3>
+
+      <p>
+        HPX distributes architecture-specific <code>libwasmvm</code> runtimes:
+      </p>
+
+      <ul>
+        <li><code>libwasmvm.x86_64.so</code> — x86-64 Linux</li>
+        <li><code>libwasmvm.aarch64.so</code> — AArch64 Linux</li>
+        <li><code>libwasmvm_muslc.x86_64.so</code> — x86-64 musl (Alpine)</li>
+        <li><code>libwasmvm_muslc.aarch64.so</code> — AArch64 musl</li>
+      </ul>
+
+      <p>
+        The installer detects the host architecture and installs the correct library.
+      </p>
+
+      <h3>State Sync</h3>
+
+      <p>
+        New nodes can bootstrap from a recent state snapshot instead of replaying full history:
+      </p>
+
+      <pre><code>{`hpx statesync`}</code></pre>
+
+      <p>
+        This fetches trust parameters from <code>/api/statesync</code> and updates <code>config.toml</code> to enable state-sync.
+      </p>
+
+      <h3>Uninstall</h3>
+
+      <pre><code>{`hpx remove`}</code></pre>
+
+      <p>
+        This stops <code>paxd</code>, removes the systemd service, and deletes <code>/root/.paxeer/</code>.
+      </p>
+
+      <div className="source-note">
+        <strong>Source:</strong> <code>paxeer-network/hpx/README.md</code>, <code>paxeer-network/hpx/hosting/</code>
+      </div>
 
       <div className="prev-next">
         <Link href="/interchain">

--- a/paxeer-docs/src/app/contracts/page.tsx
+++ b/paxeer-docs/src/app/contracts/page.tsx
@@ -7,22 +7,297 @@ export default function Contracts() {
       <div className="page-header">
         <h1 className="page-title">Contracts</h1>
         <p className="page-description">
-          Paxeer-native Solidity contracts vs LayerX settlement contracts.
+          Paxeer-native Solidity contracts and LayerX settlement contracts deployed on Paxeer.
         </p>
       </div>
 
       <div className="source-note">
-        <strong>Paxeer-native:</strong> <code>paxeer-network/contracts/</code> (WPAX, pointers, precompile interfaces)
-        <br />
-        <strong>LayerX settlement:</strong> <code>contracts/</code> at repository root (custody, checkpoints, bonds)
+        <strong>Paxeer-native:</strong> <code>paxeer-network/contracts/</code><br />
+        <strong>LayerX settlement:</strong> <code>contracts/</code> at repository root
       </div>
 
       <h2>Two Contract Trees</h2>
 
+      <p>
+        The monorepo contains two distinct contract directories serving different purposes:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Purpose</th>
+            <th>Tooling</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>paxeer-network/contracts/</code></td>
+            <td>Paxeer-native chain utilities: WPAX, pointer contracts, precompile interfaces, testing infrastructure</td>
+            <td>Foundry + Hardhat</td>
+          </tr>
+          <tr>
+            <td><code>contracts/</code> (root)</td>
+            <td>LayerX settlement contracts: custody, checkpoints, guarantor bonds, challenges, emergency exits</td>
+            <td>Solidity 0.8.28</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Paxeer-Native Contracts</h2>
+
+      <p>
+        The contracts under <code>paxeer-network/contracts/</code> are part of the Paxeer chain itself. They provide EVM-side interfaces to chain functionality.
+      </p>
+
+      <h3>Core Contracts</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Contract</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>WPAX.sol</code></td>
+            <td>Wrapped PAX (ERC-20 wrapper for native PAX gas token)</td>
+          </tr>
+          <tr>
+            <td><code>CW20ERC20Pointer.sol</code></td>
+            <td>EVM pointer for Cosmos CW20 tokens</td>
+          </tr>
+          <tr>
+            <td><code>CW721ERC721Pointer.sol</code></td>
+            <td>EVM pointer for Cosmos CW721 NFTs</td>
+          </tr>
+          <tr>
+            <td><code>CW1155ERC1155Pointer.sol</code></td>
+            <td>EVM pointer for Cosmos CW1155 multi-tokens</td>
+          </tr>
+          <tr>
+            <td><code>NativePaxTokensERC20.sol</code></td>
+            <td>ERC-20 interface for native Cosmos tokens</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Precompile Interfaces</h3>
+
+      <p>
+        Solidity interfaces for Paxeer's native precompiles:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Interface</th>
+            <th>Precompile Address</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>IAddr.sol</code></td>
+            <td>TBD</td>
+            <td>Address conversion (EVM ↔ Cosmos)</td>
+          </tr>
+          <tr>
+            <td><code>IBank.sol</code></td>
+            <td>TBD</td>
+            <td>Native token operations</td>
+          </tr>
+          <tr>
+            <td><code>IWasmd.sol</code></td>
+            <td>TBD</td>
+            <td>CosmWasm contract calls from EVM</td>
+          </tr>
+          <tr>
+            <td><code>IJson.sol</code></td>
+            <td>TBD</td>
+            <td>JSON parsing and manipulation</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Note:</strong> Precompile addresses are not documented in the contract source. Check deployment artifacts or chain configuration for actual addresses.
+      </div>
+
+      <h3>Testing Contracts</h3>
+
+      <p>
+        Development and testing utilities:
+      </p>
+
       <ul>
-        <li><strong>paxeer-network/contracts/</strong> — Paxeer-native utilities (WPAX, pointers)</li>
-        <li><strong>contracts/</strong> (root) — LayerX settlement contracts deployed on Paxeer</li>
+        <li><code>EVMCompatibilityTester.sol</code> — EVM compatibility validation</li>
+        <li><code>TransientStorageTester.sol</code> — EIP-1153 transient storage tests</li>
+        <li><code>SelfDestructTester.sol</code> — SELFDESTRUCT behavior verification</li>
+        <li><code>SnapshotRevertTester.sol</code> — State snapshot and revert testing</li>
+        <li><code>SstoreGasTest.sol</code> — SSTORE gas cost verification</li>
+        <li><code>ProxySwapTester.sol</code>, <code>MultiHopSwapTester.sol</code> — DEX testing</li>
+        <li><code>MultiSender.sol</code>, <code>BatchCallAndSponsor.sol</code> — Batch operations</li>
+        <li><code>Box.sol</code>, <code>BoxV2.sol</code> — Upgradeable proxy testing</li>
+        <li><code>TestToken.sol</code>, <code>ERC721.sol</code>, <code>ERC1155.sol</code> — Token testing</li>
       </ul>
+
+      <h3>Build & Test</h3>
+
+      <p>
+        The Paxeer contracts support both Foundry and Hardhat workflows:
+      </p>
+
+      <pre><code>{`# Foundry
+cd paxeer-network/contracts
+forge install
+forge build
+
+# Hardhat
+cd paxeer-network/contracts
+npm install
+npx hardhat compile
+npx hardhat test --network paxlocal`}</code></pre>
+
+      <p>
+        Hardhat configuration (<code>hardhat.config.js</code>) targets Solidity 0.8.28 with Prague EVM and includes networks:
+      </p>
+
+      <ul>
+        <li><code>paxlocal</code> — <code>http://127.0.0.1:8545</code> (Docker cluster)</li>
+        <li><code>devnet</code> — <code>https://evm-rpc.arctic-1.paxnetwork.io/</code></li>
+      </ul>
+
+      <h3>Updating Pointer Contracts</h3>
+
+      <p>
+        When pointer contract bytecode changes:
+      </p>
+
+      <ol>
+        <li>Compile with Foundry: <code>forge build</code></li>
+        <li>Extract bytecode from <code>contracts/out/</code></li>
+        <li>Copy to corresponding <code>.bin</code> file under <code>modules/evm/contracts/</code></li>
+        <li>Restart <code>paxd</code></li>
+      </ol>
+
+      <div className="source-note">
+        <strong>Source:</strong> <code>paxeer-network/contracts/README.md</code>, <code>paxeer-network/contracts/src/</code>
+      </div>
+
+      <h2>LayerX Settlement Contracts</h2>
+
+      <p>
+        The contracts at the repository root (<code>contracts/</code>) implement LayerX settlement on Paxeer. These contracts are <strong>deployed on Paxeer</strong> but are <strong>owned by LayerX</strong> for checkpoint settlement, custody, and exits.
+      </p>
+
+      <h3>Settlement Contracts</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Contract</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>CheckpointRegistry.sol</code></td>
+            <td>LayerX checkpoint settlement (state root hashes, block numbers, timestamps)</td>
+          </tr>
+          <tr>
+            <td><code>LayerXCustody.sol</code></td>
+            <td>Custody of USDL backing USDX (LayerX L1 asset held on Paxeer)</td>
+          </tr>
+          <tr>
+            <td><code>GuarantorBond.sol</code></td>
+            <td>Guarantor collateral and slashing for LayerX sequencer/validator set</td>
+          </tr>
+          <tr>
+            <td><code>WithdrawalClaims.sol</code></td>
+            <td>User exit claims from LayerX to Paxeer (merkle proofs against checkpoints)</td>
+          </tr>
+          <tr>
+            <td><code>EmergencyExit.sol</code></td>
+            <td>Last-resort withdrawal mechanism if LayerX sequencer halts</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Supporting Directories</h3>
+
+      <ul>
+        <li><code>challenge/</code> — Challenge and dispute contracts</li>
+        <li><code>custody/</code> — Custody-related helpers</li>
+        <li><code>governance/</code> — LayerX governance contracts</li>
+        <li><code>interfaces/</code> — Contract interfaces</li>
+        <li><code>libraries/</code> — Shared libraries (merkle proofs, signature verification)</li>
+        <li><code>manager/</code> — Settlement manager contracts</li>
+        <li><code>security/</code> — Security modules (pausability, access control)</li>
+        <li><code>storage/</code> — Storage layout contracts</li>
+        <li><code>config/</code> — Deployment configuration</li>
+        <li><code>deployment/</code> — Deployment scripts and artifacts</li>
+      </ul>
+
+      <h3>Deployment Addresses</h3>
+
+      <p>
+        <strong>No deployment addresses are documented in the tree.</strong> Check <code>contracts/deployment/</code> or the LayerX dashboard for deployed contract addresses on Paxeer mainnet.
+      </p>
+
+      <div className="source-note">
+        <strong>Warning:</strong> Do not invent or assume contract addresses. If not in the source tree, they are not public.
+      </div>
+
+      <h3>Contract Ownership</h3>
+
+      <p>
+        LayerX settlement contracts are owned and controlled by LayerX governance, not by Paxeer validators. Paxeer provides the settlement layer; LayerX operates the settlement contracts.
+      </p>
+
+      <div className="source-note">
+        <strong>Source:</strong> <code>contracts/</code> at repository root
+      </div>
+
+      <h2>Key Distinctions</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Aspect</th>
+            <th>Paxeer-native</th>
+            <th>LayerX settlement</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Location</strong></td>
+            <td><code>paxeer-network/contracts/</code></td>
+            <td><code>contracts/</code> (root)</td>
+          </tr>
+          <tr>
+            <td><strong>Purpose</strong></td>
+            <td>Chain utilities, pointers, testing</td>
+            <td>LayerX checkpoints, custody, exits</td>
+          </tr>
+          <tr>
+            <td><strong>Deployment</strong></td>
+            <td>Part of Paxeer chain (precompiles, pointers)</td>
+            <td>Deployed as contracts on Paxeer</td>
+          </tr>
+          <tr>
+            <td><strong>Ownership</strong></td>
+            <td>Paxeer chain</td>
+            <td>LayerX governance</td>
+          </tr>
+          <tr>
+            <td><strong>Trust boundary</strong></td>
+            <td>Paxeer validators</td>
+            <td>LayerX sequencer + Paxeer settlement</td>
+          </tr>
+        </tbody>
+      </table>
 
       <div className="prev-next">
         <Link href="/rest-grpc">

--- a/paxeer-docs/src/app/docker/page.tsx
+++ b/paxeer-docs/src/app/docker/page.tsx
@@ -5,15 +5,346 @@ export default function Docker() {
   return (
     <DocsLayout>
       <div className="page-header">
-        <h1 className="page-title">Docker</h1>
+        <h1 className="page-title">Docker Development</h1>
         <p className="page-description">
-          Local Docker clusters for Paxeer development and testing.
+          Local Docker clusters, state-sync RPC nodes, and monitoring for Paxeer development and testing.
         </p>
       </div>
 
       <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/docker/</code> and <code>docker/README.md</code>
+        <strong>Source:</strong> <code>paxeer-network/docker/</code>, <code>paxeer-network/Makefile</code>
       </div>
+
+      <h2>Prerequisites</h2>
+
+      <h3>macOS</h3>
+
+      <p>
+        Install Docker Desktop from <a href="https://docs.docker.com/desktop/install/mac-install/">docs.docker.com/desktop/install/mac-install/</a>
+      </p>
+
+      <h3>Ubuntu</h3>
+
+      <p>
+        Install Docker Engine and Docker Compose:
+      </p>
+
+      <ul>
+        <li>Docker: <a href="https://docs.docker.com/engine/install/ubuntu/">docs.docker.com/engine/install/ubuntu/</a></li>
+        <li>Docker Compose: <a href="https://docs.docker.com/compose/install/other/">docs.docker.com/compose/install/other/</a></li>
+      </ul>
+
+      <h2>Four-Node Local Cluster</h2>
+
+      <p>
+        The standard development setup runs a four-validator Paxeer cluster on a private network (<code>192.168.10.0/24</code>).
+      </p>
+
+      <h3>Start Cluster</h3>
+
+      <pre><code>{`# Build and start (first time or after code changes)
+make docker-cluster-start
+
+# Quick start (skip build if paxd binary exists)
+make docker-cluster-start-skipbuild`}</code></pre>
+
+      <p>
+        This launches four <code>pax-node-*</code> containers. Genesis files and logs are generated under <code>build/generated/</code>.
+      </p>
+
+      <h3>Node Ports</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Node</th>
+            <th>P2P</th>
+            <th>RPC</th>
+            <th>gRPC</th>
+            <th>EVM RPC</th>
+            <th>IP</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>node0</td>
+            <td>26656-26658</td>
+            <td>26657</td>
+            <td>9090-9091</td>
+            <td>8545-8546</td>
+            <td>192.168.10.10</td>
+          </tr>
+          <tr>
+            <td>node1</td>
+            <td>26659-26661</td>
+            <td>26660</td>
+            <td>9092-9093</td>
+            <td>8547-8548</td>
+            <td>192.168.10.11</td>
+          </tr>
+          <tr>
+            <td>node2</td>
+            <td>26662-26664</td>
+            <td>26663</td>
+            <td>9094-9095</td>
+            <td>8549-8550</td>
+            <td>192.168.10.12</td>
+          </tr>
+          <tr>
+            <td>node3</td>
+            <td>26665-26667</td>
+            <td>26666</td>
+            <td>9096-9097</td>
+            <td>8551-8552</td>
+            <td>192.168.10.13</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Monitor Logs</h3>
+
+      <pre><code>{`# Tail logs for node 0
+tail -f build/generated/logs/paxd-0.log
+
+# View all logs
+ls -l build/generated/logs/`}</code></pre>
+
+      <h3>SSH Into Container</h3>
+
+      <pre><code>{`# List containers
+docker ps -a
+
+# SSH into a node
+docker exec -it pax-node-0 /bin/bash`}</code></pre>
+
+      <h3>Environment Variables</h3>
+
+      <p>
+        The cluster supports environment variable configuration:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Variable</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>NUM_ACCOUNTS</code></td>
+            <td>Number of test accounts to create</td>
+          </tr>
+          <tr>
+            <td><code>SKIP_BUILD</code></td>
+            <td>Skip binary rebuild</td>
+          </tr>
+          <tr>
+            <td><code>INVARIANT_CHECK_INTERVAL</code></td>
+            <td>State invariant check frequency</td>
+          </tr>
+          <tr>
+            <td><code>UPGRADE_VERSION_LIST</code></td>
+            <td>Chain upgrade version schedule</td>
+          </tr>
+          <tr>
+            <td><code>MOCK_BALANCES</code></td>
+            <td>Use mock balance data</td>
+          </tr>
+          <tr>
+            <td><code>GIGA_EXECUTOR</code></td>
+            <td>Enable Giga executor backend</td>
+          </tr>
+          <tr>
+            <td><code>GIGA_OCC</code></td>
+            <td>Enable optimistic concurrency control</td>
+          </tr>
+          <tr>
+            <td><code>RECEIPT_BACKEND</code></td>
+            <td>Receipt storage backend</td>
+          </tr>
+          <tr>
+            <td><code>AUTOBAHN</code></td>
+            <td>Enable Autobahn optimizations</td>
+          </tr>
+          <tr>
+            <td><code>GIGA_STORAGE</code></td>
+            <td>Enable Giga storage engine</td>
+          </tr>
+          <tr>
+            <td><code>GIGA_MIGRATE_FROM_MEMIAVL</code></td>
+            <td>Migrate from MEMIAVL to Giga</td>
+          </tr>
+          <tr>
+            <td><code>GIGA_FLATKV_ONLY</code></td>
+            <td>Use flat key-value storage only</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Single Node (Not Recommended)</h2>
+
+      <p>
+        For minimal testing only:
+      </p>
+
+      <pre><code>{`make build-docker-node && make run-local-node`}</code></pre>
+
+      <p>
+        The four-node cluster is preferred for realistic consensus behavior.
+      </p>
+
+      <h2>Compose Files</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>File</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>docker-compose.yml</code></td>
+            <td>Four-node cluster (base configuration)</td>
+          </tr>
+          <tr>
+            <td><code>docker-compose.monitoring.yml</code></td>
+            <td>Prometheus + Grafana monitoring overlay</td>
+          </tr>
+          <tr>
+            <td><code>docker-compose.giga-mixed.yml</code></td>
+            <td>Mixed Giga/legacy storage testing overlay</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Monitoring with Prometheus & Grafana</h2>
+
+      <p>
+        Start the cluster with monitoring containers:
+      </p>
+
+      <pre><code>{`# Start cluster + monitoring together
+make docker-cluster-start-monitoring
+
+# Stop cluster + monitoring together
+make docker-cluster-stop-monitoring`}</code></pre>
+
+      <p>
+        Or run monitoring scripts independently:
+      </p>
+
+      <pre><code>{`# Start Prometheus
+./docker/monitornode/scripts/start-prometheus.sh
+
+# Start Grafana
+./docker/monitornode/scripts/start-grafana.sh
+
+# Stop
+./docker/monitornode/scripts/stop-prometheus.sh
+./docker/monitornode/scripts/stop-grafana.sh`}</code></pre>
+
+      <h3>Access UIs</h3>
+
+      <ul>
+        <li><strong>Grafana:</strong> <code>http://localhost:3000</code> (login: <code>admin</code> / <code>admin</code>)</li>
+        <li><strong>Prometheus:</strong> <code>http://localhost:9090</code></li>
+      </ul>
+
+      <h2>State Sync RPC Node</h2>
+
+      <p>
+        Test state-sync by starting an additional RPC node that syncs from the four-node cluster:
+      </p>
+
+      <pre><code>{`# Prerequisite: Start a 4-node cluster
+make docker-cluster-start
+
+# Wait until block height exceeds 500 (configurable via app.toml)
+paxd status | jq
+
+# Start state-sync RPC node
+make run-rpc-node`}</code></pre>
+
+      <p>
+        The RPC node bootstraps from a recent snapshot instead of replaying full history.
+      </p>
+
+      <div className="source-note">
+        <strong>Scripts:</strong> <code>docker/rpcnode/scripts/</code>
+      </div>
+
+      <h2>Fast Iteration & Local Development</h2>
+
+      <p>
+        Docker mounts local source directories, so you can edit code and rebuild without re-pulling dependencies:
+      </p>
+
+      <ol>
+        <li>Edit code under <code>paxeer-network/</code> (modules, consensus, SDK, storage, WASM)</li>
+        <li>Rebuild the node image: <code>make build-docker-node</code></li>
+        <li>Restart the cluster: <code>make docker-cluster-start</code></li>
+      </ol>
+
+      <p>
+        No <code>go.mod</code> replacements or sibling repositories required. The monorepo includes all dependencies.
+      </p>
+
+      <h3>Volumes</h3>
+
+      <p>
+        The compose files mount:
+      </p>
+
+      <ul>
+        <li><code>$PROJECT_HOME</code> → <code>/pax-protocol/pax-chain</code> (source tree)</li>
+        <li><code>$GO_PKG_PATH/mod</code> → <code>/root/go/pkg/mod</code> (Go module cache)</li>
+        <li><code>$GOCACHE</code> → <code>/root/.cache/go-build</code> (Go build cache)</li>
+      </ul>
+
+      <h2>Deployment Scripts</h2>
+
+      <p>
+        Each node type has a multi-step initialization flow:
+      </p>
+
+      <h3>Local Node</h3>
+
+      <ul>
+        <li><code>step0_build.sh</code> — Build <code>paxd</code> binary</li>
+        <li><code>step1_configure_init.sh</code> — Initialize node configuration</li>
+        <li><code>step2_genesis.sh</code> — Generate genesis file</li>
+        <li><code>step3_add_validator_to_genesis.sh</code> — Add validator to genesis</li>
+        <li><code>step4_config_override.sh</code> — Override config files (ports, peers)</li>
+        <li><code>step5_start_pax.sh</code> — Start <code>paxd</code></li>
+        <li><code>deploy.sh</code> — Orchestrates all steps</li>
+      </ul>
+
+      <h3>RPC Node</h3>
+
+      <ul>
+        <li><code>step0_build.sh</code> — Build <code>paxd</code></li>
+        <li><code>step1_configure_init.sh</code> — Initialize for state-sync</li>
+        <li><code>step2_start_pax.sh</code> — Start with state-sync enabled</li>
+        <li><code>deploy.sh</code> — Orchestrates RPC node setup</li>
+      </ul>
+
+      <div className="source-note">
+        <strong>Scripts:</strong> <code>docker/localnode/scripts/</code>, <code>docker/rpcnode/scripts/</code>
+      </div>
+
+      <h2>Docker Image</h2>
+
+      <p>
+        The cluster uses the <code>pax-chain/localnode</code> image built from <code>paxeer-network/Dockerfile</code>. Platform defaults to <code>linux/amd64</code> but can be overridden with <code>DOCKER_PLATFORM</code>.
+      </p>
+
+      <h2>Network Configuration</h2>
+
+      <p>
+        The cluster creates a <code>localnet</code> bridge network with subnet <code>192.168.10.0/24</code>. Each node has a static IP for deterministic peer configuration.
+      </p>
 
       <div className="prev-next">
         <Link href="/contracts">

--- a/paxeer-docs/src/app/interchain/page.tsx
+++ b/paxeer-docs/src/app/interchain/page.tsx
@@ -5,14 +5,282 @@ export default function Interchain() {
   return (
     <DocsLayout>
       <div className="page-header">
-        <h1 className="page-title">Interchain</h1>
+        <h1 className="page-title">Interchain (IBC)</h1>
         <p className="page-description">
-          IBC and cross-chain communication on Paxeer.
+          Inter-Blockchain Communication protocol implementation on Paxeer.
         </p>
       </div>
 
       <div className="source-note">
         <strong>Source:</strong> <code>paxeer-network/interchain/</code>
+      </div>
+
+      <h2>Overview</h2>
+
+      <p>
+        Paxeer includes an in-tree fork of <a href="https://github.com/cosmos/ibc-go">ibc-go</a>, the Cosmos SDK's Inter-Blockchain Communication (IBC) protocol implementation. This enables Paxeer to connect with other IBC-enabled chains for cross-chain asset transfers and messaging.
+      </p>
+
+      <h3>What is IBC?</h3>
+
+      <p>
+        IBC is an end-to-end, connection-oriented, stateful protocol for reliable, ordered, and authenticated communication between heterogeneous blockchains. It handles transport across different sovereign blockchains without relying on a trusted third party.
+      </p>
+
+      <h2>Location</h2>
+
+      <p>
+        The IBC implementation is vendored under <code>paxeer-network/interchain/</code> within the monorepo. This is <strong>not</strong> a standalone published module but an in-tree dependency for <code>paxd</code>.
+      </p>
+
+      <h2>Core IBC Components</h2>
+
+      <p>
+        Paxeer's IBC implementation includes the standard IBC stack:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Component</th>
+            <th>ICS Spec</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Client</strong></td>
+            <td>ICS-02</td>
+            <td>Light client verification of remote chain state</td>
+          </tr>
+          <tr>
+            <td><strong>Connection</strong></td>
+            <td>ICS-03</td>
+            <td>Establish authenticated connections between chains</td>
+          </tr>
+          <tr>
+            <td><strong>Channel</strong></td>
+            <td>ICS-04</td>
+            <td>Packet delivery over connections (ordered/unordered)</td>
+          </tr>
+          <tr>
+            <td><strong>Port</strong></td>
+            <td>ICS-05</td>
+            <td>Module registration and packet routing</td>
+          </tr>
+          <tr>
+            <td><strong>Commitment</strong></td>
+            <td>ICS-23</td>
+            <td>Cryptographic commitment proofs</td>
+          </tr>
+          <tr>
+            <td><strong>Host</strong></td>
+            <td>ICS-24</td>
+            <td>Chain-specific requirements and interfaces</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>IBC Applications</h2>
+
+      <p>
+        Paxeer supports standard IBC applications:
+      </p>
+
+      <h3>Fungible Token Transfers (ICS-20)</h3>
+
+      <p>
+        The <code>transfer</code> module enables cross-chain token transfers. Assets originating on Paxeer can be sent to other IBC chains, and assets from remote chains can be received on Paxeer as IBC-wrapped tokens.
+      </p>
+
+      <h3>Interchain Accounts (ICS-27)</h3>
+
+      <p>
+        Interchain Accounts allow one chain to control an account on another chain. This enables cross-chain governance, remote staking, and other advanced use cases.
+      </p>
+
+      <h2>Light Clients</h2>
+
+      <p>
+        Paxeer includes light client implementations for verifying remote chain state:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Client</th>
+            <th>ICS Spec</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Tendermint</strong></td>
+            <td>ICS-07</td>
+            <td>Light client for Tendermint/CometBFT chains</td>
+          </tr>
+          <tr>
+            <td><strong>Solo Machine</strong></td>
+            <td>ICS-06</td>
+            <td>Light client for single-signer accounts (e.g., hardware wallets)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Note:</strong> The localhost client is currently non-functional in this fork.
+      </div>
+
+      <h2>IBC Module Structure</h2>
+
+      <p>
+        The <code>interchain/</code> directory mirrors the structure of upstream <code>ibc-go</code>:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>modules/core/</code></td>
+            <td>Core IBC protocol (client, connection, channel)</td>
+          </tr>
+          <tr>
+            <td><code>modules/apps/</code></td>
+            <td>IBC applications (transfer, interchain accounts)</td>
+          </tr>
+          <tr>
+            <td><code>modules/light-clients/</code></td>
+            <td>Light client implementations</td>
+          </tr>
+          <tr>
+            <td><code>proto/</code></td>
+            <td>Protobuf definitions for IBC types</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Using IBC on Paxeer</h2>
+
+      <h3>Establishing a Connection</h3>
+
+      <p>
+        To connect Paxeer with another IBC-enabled chain:
+      </p>
+
+      <ol>
+        <li>Create a light client for the remote chain</li>
+        <li>Establish a connection using the client</li>
+        <li>Create a channel over the connection</li>
+        <li>Begin sending packets</li>
+      </ol>
+
+      <p>
+        Use the <code>paxd tx ibc</code> CLI commands or relayer software (e.g., Hermes, Go Relayer).
+      </p>
+
+      <h3>Cross-Chain Token Transfers</h3>
+
+      <pre><code>{`# Send 1000upax from Paxeer to another chain
+paxd tx ibc-transfer transfer \\
+  transfer \\
+  channel-0 \\
+  cosmos1recipient... \\
+  1000upax \\
+  --from mykey \\
+  --chain-id hyperpax_125-1`}</code></pre>
+
+      <h3>Querying IBC State</h3>
+
+      <pre><code>{`# List all IBC clients
+paxd query ibc client states
+
+# List all connections
+paxd query ibc connection connections
+
+# List all channels
+paxd query ibc channel channels`}</code></pre>
+
+      <h2>Relayers</h2>
+
+      <p>
+        IBC requires off-chain relayer software to ferry packets between chains. Relayers monitor both chains and submit proof-carrying packets to complete cross-chain transfers.
+      </p>
+
+      <h3>Supported Relayers</h3>
+
+      <ul>
+        <li><a href="https://github.com/informalsystems/hermes">Hermes</a> (Rust)</li>
+        <li><a href="https://github.com/cosmos/relayer">Go Relayer</a> (Go)</li>
+      </ul>
+
+      <p>
+        Relayers must be configured with Paxeer's chain ID (<code>hyperpax_125-1</code>) and RPC endpoints.
+      </p>
+
+      <h2>IBC and EVM</h2>
+
+      <p>
+        IBC operates at the Cosmos SDK level. EVM contracts on Paxeer cannot directly send or receive IBC packets. To bridge EVM and IBC:
+      </p>
+
+      <ul>
+        <li>Use pointer contracts to expose Cosmos tokens to EVM</li>
+        <li>Use precompiles to call Cosmos modules from EVM</li>
+        <li>Deploy bridge contracts that interact with IBC via Cosmos transactions</li>
+      </ul>
+
+      <p>
+        See <Link href="/contracts">Contracts</Link> for pointer contract details.
+      </p>
+
+      <h2>IBC Protocol Versions</h2>
+
+      <p>
+        Paxeer's IBC fork is based on <code>ibc-go</code> but may diverge from upstream. Check the version in <code>interchain/go.mod</code> or the README.
+      </p>
+
+      <div className="source-note">
+        <strong>Warning:</strong> Paxeer's IBC fork may not be compatible with the latest upstream <code>ibc-go</code> releases. Test cross-chain compatibility carefully.
+      </div>
+
+      <h2>Security Considerations</h2>
+
+      <p>
+        IBC is a trust-minimized protocol, but security depends on:
+      </p>
+
+      <ul>
+        <li><strong>Light client correctness:</strong> Remote chain state must be correctly verified</li>
+        <li><strong>Relayer liveness:</strong> Packets must be relayed promptly to avoid timeouts</li>
+        <li><strong>Chain sovereignty:</strong> Each chain controls its own IBC modules and upgrades</li>
+      </ul>
+
+      <p>
+        Ensure relayers are operated by trusted parties or use multiple independent relayers.
+      </p>
+
+      <h2>IBC Upgrades</h2>
+
+      <p>
+        IBC modules can be upgraded via on-chain governance. Upgrades must be coordinated with connected chains to avoid breaking connections.
+      </p>
+
+      <h2>Resources</h2>
+
+      <ul>
+        <li><a href="https://ibcprotocol.org/">IBC Protocol Website</a></li>
+        <li><a href="https://github.com/cosmos/ibc">IBC Specification</a></li>
+        <li><a href="https://ibc.cosmos.network/">IBC Documentation</a></li>
+        <li><a href="https://github.com/cosmos/ibc-go">ibc-go Repository</a> (upstream)</li>
+      </ul>
+
+      <div className="source-note">
+        <strong>Source:</strong> <code>paxeer-network/interchain/README.md</code>
       </div>
 
       <div className="prev-next">

--- a/paxeer-docs/src/app/rest-grpc/page.tsx
+++ b/paxeer-docs/src/app/rest-grpc/page.tsx
@@ -7,13 +7,422 @@ export default function RestGrpc() {
       <div className="page-header">
         <h1 className="page-title">REST & gRPC APIs</h1>
         <p className="page-description">
-          Cosmos SDK REST and gRPC interfaces on Paxeer.
+          Cosmos SDK REST and gRPC interfaces for Paxeer chain modules and administration.
         </p>
       </div>
 
       <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/api/</code> and proto definitions
+        <strong>Source:</strong> <code>paxeer-network/api/</code> proto definitions, <code>paxeer-network/docs/</code>
       </div>
+
+      <h2>Overview</h2>
+
+      <p>
+        Paxeer exposes Cosmos SDK-style gRPC and REST (gRPC-Gateway) endpoints for chain modules. These APIs complement the <Link href="/json-rpc">JSON-RPC interface</Link> and provide access to chain state, module parameters, and administrative operations.
+      </p>
+
+      <h3>Protocol Buffers</h3>
+
+      <p>
+        All services are defined in <code>paxeer-network/api/</code> using Protocol Buffers v3. The proto files generate:
+      </p>
+
+      <ul>
+        <li>Go types under <code>github.com/sidiora-labs/paxeer-network/modules/*/types</code></li>
+        <li>gRPC server and client interfaces</li>
+        <li>REST endpoints via <code>google.api.http</code> annotations</li>
+        <li>OpenAPI/Swagger documentation</li>
+      </ul>
+
+      <h3>Code Generation</h3>
+
+      <p>
+        Regenerate Go code from proto files:
+      </p>
+
+      <pre><code>{`ignite generate proto-go`}</code></pre>
+
+      <p>
+        Requires Ignite CLI v0.23.0. See <code>paxeer-network/api/README.md</code> for installation.
+      </p>
+
+      <h2>EVM Module Query Service</h2>
+
+      <p>
+        The EVM module provides address mapping, static calls, and pointer queries.
+      </p>
+
+      <h3>Address Mapping</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>PaxAddressByEVMAddress</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/pax_address</code></td>
+            <td>Get Cosmos address from EVM address</td>
+          </tr>
+          <tr>
+            <td><code>EVMAddressByPaxAddress</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/evm_address</code></td>
+            <td>Get EVM address from Cosmos address</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Static Calls</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>StaticCall</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/static_call</code></td>
+            <td>Execute read-only contract call</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Pointer Queries</h3>
+
+      <p>
+        Pointers bridge Cosmos-native assets (CW20/CW721/CW1155) to EVM addresses:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Pointer</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/pointer</code></td>
+            <td>Get EVM pointer for Cosmos contract</td>
+          </tr>
+          <tr>
+            <td><code>Pointee</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/pointee</code></td>
+            <td>Get Cosmos contract from EVM pointer</td>
+          </tr>
+          <tr>
+            <td><code>PointerVersion</code></td>
+            <td><code>GET /pax-protocol/paxchain/evm/pointer_version</code></td>
+            <td>Get current pointer contract version</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/evm/query.proto</code>
+      </div>
+
+      <h2>Epoch Module Query Service</h2>
+
+      <p>
+        The Epoch module tracks the current chain epoch for time-based operations:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Epoch</code></td>
+            <td><code>GET /pax-protocol/paxchain/epoch/epoch</code></td>
+            <td>Get current epoch number and metadata</td>
+          </tr>
+          <tr>
+            <td><code>Params</code></td>
+            <td><code>GET /pax-protocol/paxchain/epoch/params</code></td>
+            <td>Get epoch module parameters</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/epoch/query.proto</code>
+      </div>
+
+      <h2>Oracle Module Query Service</h2>
+
+      <p>
+        The Oracle module provides exchange rates, price feeds, and validator vote tracking:
+      </p>
+
+      <h3>Exchange Rates & Prices</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>ExchangeRate</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/{`{denom}`}/exchange_rate</code></td>
+            <td>Get exchange rate for a denom</td>
+          </tr>
+          <tr>
+            <td><code>ExchangeRates</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/exchange_rates</code></td>
+            <td>Get all exchange rates</td>
+          </tr>
+          <tr>
+            <td><code>Actives</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/actives</code></td>
+            <td>List all active denoms</td>
+          </tr>
+          <tr>
+            <td><code>VoteTargets</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/vote_targets</code></td>
+            <td>List vote target denoms</td>
+          </tr>
+          <tr>
+            <td><code>PriceSnapshotHistory</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/price_snapshot_history</code></td>
+            <td>Get historical price snapshots</td>
+          </tr>
+          <tr>
+            <td><code>Twaps</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/twaps/{`{lookback_seconds}`}</code></td>
+            <td>Get time-weighted average prices</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Validator Vote Tracking</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>FeederDelegation</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/validators/{`{validator_addr}`}/feeder</code></td>
+            <td>Get feeder delegation for validator</td>
+          </tr>
+          <tr>
+            <td><code>VotePenaltyCounter</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/validators/{`{validator_addr}`}/vote_penalty_counter</code></td>
+            <td>Get oracle miss counter</td>
+          </tr>
+          <tr>
+            <td><code>SlashWindow</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/slash_window</code></td>
+            <td>Get slash window information</td>
+          </tr>
+          <tr>
+            <td><code>Params</code></td>
+            <td><code>GET /pax-protocol/pax-chain/oracle/params</code></td>
+            <td>Get oracle module parameters</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/oracle/query.proto</code>
+      </div>
+
+      <h2>TokenFactory Module Query Service</h2>
+
+      <p>
+        The TokenFactory module manages custom token creation and metadata:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Params</code></td>
+            <td><code>GET /pax-protocol/paxchain/tokenfactory/params</code></td>
+            <td>Get tokenfactory parameters</td>
+          </tr>
+          <tr>
+            <td><code>DenomAuthorityMetadata</code></td>
+            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/{`{denom}`}/authority_metadata</code></td>
+            <td>Get denom authority metadata</td>
+          </tr>
+          <tr>
+            <td><code>DenomMetadata</code></td>
+            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/metadata</code></td>
+            <td>Get denom metadata</td>
+          </tr>
+          <tr>
+            <td><code>DenomsFromCreator</code></td>
+            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms_from_creator/{`{creator}`}</code></td>
+            <td>List denoms created by an address</td>
+          </tr>
+          <tr>
+            <td><code>DenomAllowList</code></td>
+            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/allow_list</code></td>
+            <td>Get denom allow list</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/tokenfactory/query.proto</code>
+      </div>
+
+      <h2>Mint Module Query Service</h2>
+
+      <p>
+        The Mint module exposes minting parameters and state:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>REST Endpoint</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>Params</code></td>
+            <td><code>GET /paxchain/mint/v1beta1/params</code></td>
+            <td>Get mint module parameters</td>
+          </tr>
+          <tr>
+            <td><code>Minter</code></td>
+            <td><code>GET /paxchain/mint/v1beta1/minter</code></td>
+            <td>Get minter state (start/end dates, amounts)</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/mint/v1beta1/query.proto</code>
+      </div>
+
+      <h2>Admin gRPC Service</h2>
+
+      <p>
+        The Admin service provides runtime log level control. It runs on a separate loopback-only gRPC server (default <code>127.0.0.1:9095</code>):
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Method</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>SetLogLevel</code></td>
+            <td>Change log level for loggers matching a pattern</td>
+          </tr>
+          <tr>
+            <td><code>GetLogLevel</code></td>
+            <td>Get current log level for a logger</td>
+          </tr>
+          <tr>
+            <td><code>ListLoggers</code></td>
+            <td>List all registered loggers and their levels</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        Enable in <code>app.toml</code>:
+      </p>
+
+      <pre><code>{`[admin_server]
+admin_enabled = true
+admin_address = "127.0.0.1:9095"`}</code></pre>
+
+      <div className="source-note">
+        <strong>Proto:</strong> <code>paxeer-network/api/pax/admin/v0/admin.proto</code><br />
+        <strong>Implementation:</strong> <code>paxeer-network/admin/</code>
+      </div>
+
+      <h2>OpenAPI / Swagger Documentation</h2>
+
+      <p>
+        Paxeer generates OpenAPI documentation from proto annotations. To regenerate:
+      </p>
+
+      <pre><code>{`./scripts/update-swagger-ui-statik.sh`}</code></pre>
+
+      <p>
+        This generates <code>docs/swagger-ui/swagger.yml</code> and embeds it in <code>docs/swagger/statik.go</code>.
+      </p>
+
+      <h3>Serving Swagger UI</h3>
+
+      <p>
+        Enable in <code>app.toml</code>:
+      </p>
+
+      <pre><code>{`[api]
+enable = true
+swagger = true`}</code></pre>
+
+      <p>
+        Access at <code>http://&lt;node-ip&gt;:&lt;port&gt;/swagger/</code>.
+      </p>
+
+      <div className="source-note">
+        <strong>See:</strong> <code>paxeer-network/docs/README.md</code> for generation instructions
+      </div>
+
+      <h2>gRPC Endpoints</h2>
+
+      <p>
+        gRPC services are exposed on the Cosmos SDK gRPC port (default <code>9090</code>). Use any gRPC client (e.g., <code>grpcurl</code>):
+      </p>
+
+      <pre><code>{`grpcurl -plaintext localhost:9090 list
+grpcurl -plaintext localhost:9090 paxprotocol.paxchain.evm.Query/Pointer`}</code></pre>
+
+      <h2>REST Gateway</h2>
+
+      <p>
+        REST endpoints are served via gRPC-Gateway on the API port (default <code>1317</code>). All gRPC methods have corresponding REST endpoints defined by <code>google.api.http</code> annotations in the proto files.
+      </p>
+
+      <h2>Transaction Services</h2>
+
+      <p>
+        Each module also defines a <code>Msg</code> service for transactions (e.g., <code>evm/tx.proto</code>, <code>epoch/tx.proto</code>). These are not query endpoints but message types for state-changing operations. Submit via standard Cosmos SDK transaction APIs.
+      </p>
 
       <div className="prev-next">
         <Link href="/json-rpc-unsupported">

--- a/paxeer-docs/src/app/sdk/page.tsx
+++ b/paxeer-docs/src/app/sdk/page.tsx
@@ -5,15 +5,311 @@ export default function SDK() {
   return (
     <DocsLayout>
       <div className="page-header">
-        <h1 className="page-title">SDK</h1>
+        <h1 className="page-title">Cosmos SDK Fork</h1>
         <p className="page-description">
-          Cosmos SDK fork and Paxeer-specific extensions.
+          Paxeer's in-tree Cosmos SDK fork with Paxeer-specific modifications and extensions.
         </p>
       </div>
 
       <div className="source-note">
         <strong>Source:</strong> <code>paxeer-network/sdk/</code>
       </div>
+
+      <h2>Overview</h2>
+
+      <p>
+        Paxeer vendors a fork of the Cosmos SDK directly in the monorepo under <code>paxeer-network/sdk/</code>. This is <strong>not</strong> a published Go module or npm package. It is an in-tree dependency for the <code>paxd</code> binary and Paxeer chain modules.
+      </p>
+
+      <h3>Why a Fork?</h3>
+
+      <p>
+        Paxeer maintains a fork to support:
+      </p>
+
+      <ul>
+        <li>Custom storage engines (MEMIAVL, Giga)</li>
+        <li>EVM integration and pointer contracts</li>
+        <li>Fast iteration without waiting for upstream releases</li>
+        <li>Paxeer-specific consensus and execution optimizations</li>
+        <li>Co-location with Paxeer modules and WASM runtime</li>
+      </ul>
+
+      <h2>Upstream Base</h2>
+
+      <p>
+        The fork is based on Cosmos SDK but diverges significantly. It is not compatible with upstream Cosmos SDK releases without careful rebasing and testing.
+      </p>
+
+      <div className="source-note">
+        <strong>Warning:</strong> Do not assume drop-in compatibility with standard Cosmos SDK tooling or libraries. Paxeer's SDK is a custom fork.
+      </div>
+
+      <h2>Directory Structure</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>baseapp/</code></td>
+            <td>Application framework (ABCI, routing, ante handlers)</td>
+          </tr>
+          <tr>
+            <td><code>client/</code></td>
+            <td>CLI framework and transaction builders</td>
+          </tr>
+          <tr>
+            <td><code>server/</code></td>
+            <td>Node server, gRPC, REST gateway</td>
+          </tr>
+          <tr>
+            <td><code>types/</code></td>
+            <td>Core SDK types (messages, coins, errors, context)</td>
+          </tr>
+          <tr>
+            <td><code>x/</code></td>
+            <td>Standard Cosmos modules (bank, auth, staking, gov, etc.)</td>
+          </tr>
+          <tr>
+            <td><code>proto/</code></td>
+            <td>Protobuf definitions for SDK modules</td>
+          </tr>
+          <tr>
+            <td><code>store/</code></td>
+            <td>State store abstraction and implementations</td>
+          </tr>
+          <tr>
+            <td><code>simapp/</code></td>
+            <td>Reference application for testing</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Key Modules</h2>
+
+      <p>
+        Paxeer's SDK includes standard Cosmos modules:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Module</th>
+            <th>Purpose</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>x/auth</code></td>
+            <td>Account authentication and transaction signing</td>
+          </tr>
+          <tr>
+            <td><code>x/bank</code></td>
+            <td>Token transfers and balance management</td>
+          </tr>
+          <tr>
+            <td><code>x/staking</code></td>
+            <td>Proof-of-Stake validator set and delegation</td>
+          </tr>
+          <tr>
+            <td><code>x/distribution</code></td>
+            <td>Staking rewards and fee distribution</td>
+          </tr>
+          <tr>
+            <td><code>x/gov</code></td>
+            <td>On-chain governance and proposals</td>
+          </tr>
+          <tr>
+            <td><code>x/slashing</code></td>
+            <td>Validator penalties for misbehavior</td>
+          </tr>
+          <tr>
+            <td><code>x/crisis</code></td>
+            <td>Invariant checking and chain halts</td>
+          </tr>
+          <tr>
+            <td><code>x/evidence</code></td>
+            <td>Double-sign evidence submission</td>
+          </tr>
+          <tr>
+            <td><code>x/params</code></td>
+            <td>Module parameter management</td>
+          </tr>
+          <tr>
+            <td><code>x/upgrade</code></td>
+            <td>Coordinated chain upgrades</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>
+        Plus Paxeer-specific modules under <code>paxeer-network/modules/</code>:
+      </p>
+
+      <ul>
+        <li><code>evm</code> — EVM execution and JSON-RPC</li>
+        <li><code>epoch</code> — Epoch tracking</li>
+        <li><code>oracle</code> — Price feeds</li>
+        <li><code>tokenfactory</code> — Custom token creation</li>
+        <li><code>mint</code> — Token minting</li>
+      </ul>
+
+      <h2>BaseApp</h2>
+
+      <p>
+        The core application framework (<code>baseapp/</code>) handles:
+      </p>
+
+      <ul>
+        <li>ABCI interface to Tendermint consensus</li>
+        <li>Message routing to module handlers</li>
+        <li>Ante handlers (gas, signatures, nonces)</li>
+        <li>Transaction execution and state commits</li>
+        <li>Query routing</li>
+      </ul>
+
+      <p>
+        Paxeer extends BaseApp for EVM transaction routing and concurrent execution (OCC).
+      </p>
+
+      <h2>Client & Server</h2>
+
+      <p>
+        The SDK provides:
+      </p>
+
+      <ul>
+        <li><strong>CLI:</strong> <code>paxd</code> command-line interface (transaction builders, queries)</li>
+        <li><strong>gRPC:</strong> Module query and transaction services</li>
+        <li><strong>REST:</strong> HTTP gateway (gRPC-Gateway)</li>
+        <li><strong>Tendermint RPC:</strong> Block and transaction queries</li>
+      </ul>
+
+      <p>
+        See <Link href="/rest-grpc">REST & gRPC</Link> for API documentation.
+      </p>
+
+      <h2>State Store</h2>
+
+      <p>
+        The SDK's <code>store/</code> abstraction is implemented by Paxeer's custom storage engines:
+      </p>
+
+      <ul>
+        <li><strong>MEMIAVL:</strong> In-memory IAVL tree (legacy)</li>
+        <li><strong>Giga:</strong> High-performance flat key-value store</li>
+      </ul>
+
+      <p>
+        See <Link href="/storage">Storage</Link> for engine details.
+      </p>
+
+      <h2>Protobuf Definitions</h2>
+
+      <p>
+        SDK types are defined in <code>sdk/proto/</code>. Regenerate Go code with:
+      </p>
+
+      <pre><code>{`cd paxeer-network
+ignite generate proto-go`}</code></pre>
+
+      <p>
+        Requires Ignite CLI v0.23.0. See <code>paxeer-network/api/README.md</code>.
+      </p>
+
+      <h2>Building Against the SDK</h2>
+
+      <p>
+        Paxeer modules import the SDK from the in-tree path:
+      </p>
+
+      <pre><code>{`import (
+    sdk "github.com/sidiora-labs/paxeer-network/sdk/types"
+    "github.com/sidiora-labs/paxeer-network/sdk/store"
+)`}</code></pre>
+
+      <p>
+        No <code>go.mod</code> replacement directives are needed because the SDK is part of the monorepo.
+      </p>
+
+      <h2>Makefile Targets</h2>
+
+      <p>
+        The repository Makefile includes SDK-related targets:
+      </p>
+
+      <pre><code>{`# Build paxd
+make build
+
+# Run tests
+make test
+
+# Generate proto
+make proto-gen`}</code></pre>
+
+      <h2>Documentation</h2>
+
+      <p>
+        The SDK fork includes upstream Cosmos SDK documentation under <code>sdk/docs/</code>. Note that Paxeer-specific modifications may not be fully reflected in those docs.
+      </p>
+
+      <h3>Upstream Resources</h3>
+
+      <ul>
+        <li><a href="https://docs.cosmos.network/">Cosmos SDK Docs</a> (upstream, may diverge from Paxeer)</li>
+        <li><a href="https://tutorials.cosmos.network/">Cosmos Tutorials</a> (upstream concepts apply)</li>
+        <li><a href="https://pkg.go.dev/github.com/cosmos/cosmos-sdk">GoDoc</a> (upstream SDK, not Paxeer's fork)</li>
+      </ul>
+
+      <div className="source-note">
+        <strong>Warning:</strong> Upstream documentation describes the standard Cosmos SDK, not Paxeer's fork. Treat it as reference only.
+      </div>
+
+      <h2>Contributing to the Fork</h2>
+
+      <p>
+        Changes to <code>paxeer-network/sdk/</code> affect the entire Paxeer chain. Test thoroughly:
+      </p>
+
+      <ol>
+        <li>Edit code under <code>sdk/</code></li>
+        <li>Rebuild <code>paxd</code>: <code>make build</code></li>
+        <li>Run unit tests: <code>make test</code></li>
+        <li>Test with <Link href="/docker">Docker cluster</Link>: <code>make docker-cluster-start</code></li>
+        <li>Run integration tests: <code>make test-integration</code></li>
+      </ol>
+
+      <h2>Differences from Upstream Cosmos SDK</h2>
+
+      <p>
+        Paxeer's SDK fork diverges from upstream in several areas:
+      </p>
+
+      <ul>
+        <li>Custom storage backends (MEMIAVL, Giga)</li>
+        <li>EVM module integration and pointer contracts</li>
+        <li>Optimistic concurrency control (OCC) for parallel execution</li>
+        <li>Receipt indexing and synthetic transactions</li>
+        <li>Paxeer-specific ante handlers and gas metering</li>
+        <li>Chain-specific upgrade logic</li>
+      </ul>
+
+      <p>
+        Do not assume compatibility with standard Cosmos SDK tooling (e.g., CosmJS, Keplr) without testing.
+      </p>
+
+      <h2>Go Module Path</h2>
+
+      <pre><code>{`github.com/sidiora-labs/paxeer-network/sdk`}</code></pre>
+
+      <p>
+        This is an internal module within the Paxeer monorepo, not a standalone published module.
+      </p>
 
       <div className="prev-next">
         <Link href="/docker">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Complete Paxeer Documentation

This PR completes the comprehensive documentation for six Paxeer documentation pages that were previously thin placeholders. All documentation is sourced directly from the codebase with file citations.

## Pages Completed

### ✅ REST & gRPC (`paxeer-docs/src/app/rest-grpc/`)
- **Source:** `paxeer-network/api/` proto definitions
- Documented all module Query services:
  - EVM module: address mapping, static calls, pointer queries
  - Epoch module: epoch tracking
  - Oracle module: exchange rates, price feeds, validator voting
  - TokenFactory module: custom token creation
  - Mint module: minting parameters
  - Admin gRPC: runtime log level control
- OpenAPI/Swagger generation instructions
- gRPC and REST gateway usage

### ✅ Contracts (`paxeer-docs/src/app/contracts/`)
- **Paxeer-native:** `paxeer-network/contracts/`
  - WPAX, pointer contracts (CW20/CW721/CW1155), precompile interfaces
  - Testing contracts, Foundry + Hardhat build instructions
- **LayerX settlement:** `contracts/` (root)
  - CheckpointRegistry, LayerXCustody, GuarantorBond, WithdrawalClaims, EmergencyExit
  - Clear distinction between Paxeer chain utilities and LayerX settlement contracts

### ✅ Docker (`paxeer-docs/src/app/docker/`)
- **Source:** `paxeer-network/docker/`, Makefile
- Four-node local cluster setup
- Node port mappings and IP addresses
- Environment variable configuration
- Prometheus + Grafana monitoring
- State-sync RPC node setup
- Deployment scripts and compose files

### ✅ SDK (`paxeer-docs/src/app/sdk/`)
- **Source:** `paxeer-network/sdk/`
- In-tree Cosmos SDK fork documentation
- Directory structure and key modules
- BaseApp, client/server, state store integration
- Build instructions and Paxeer-specific modifications

### ✅ Interchain (`paxeer-docs/src/app/interchain/`)
- **Source:** `paxeer-network/interchain/`
- IBC protocol implementation (ibc-go fork)
- Core IBC components (ICS-02 through ICS-24)
- IBC applications: fungible token transfers (ICS-20), interchain accounts (ICS-27)
- Light clients (Tendermint, Solo Machine)
- Relayer setup and cross-chain token transfers

### ✅ Admin & HPX (`paxeer-docs/src/app/admin-hpx/`)
- **Admin source:** `paxeer-network/admin/`
  - Runtime log level control via loopback-only gRPC
  - SetLogLevel, GetLogLevel, ListLoggers methods
- **HPX source:** `paxeer-network/hpx/`
  - HyperPax (`hyperpax_125-1`) node distribution
  - Public registry at `node.hyperpaxeer.com`
  - Installation, setup, CLI commands
  - Artifact publishing and registry deployment

## Pages NOT Modified (per instructions)

- ✅ Preserved Ultron's pages: `configuration`, `operators`, intro/install/run/paxeer-vs-layerx/network-parameters
- ✅ Preserved Jarvis's pages: consensus, engine, evm, modules, storage, precompiles, wasm, wasm-runtime, wasmbinding
- ✅ Kept existing Next.js 14 layout and paxeer.app CSS

## Verification

- All content sourced from actual code with file citations
- No invented endpoints, ports, or contract addresses
- Follows existing page component pattern
- All prev/next navigation links maintained
- Documentation builds without errors

## Source Directories Referenced

- `paxeer-network/api/` — Proto definitions
- `paxeer-network/contracts/` — Paxeer-native contracts  
- `contracts/` (root) — LayerX settlement contracts
- `paxeer-network/docker/` — Cluster setup
- `paxeer-network/sdk/` — Cosmos SDK fork
- `paxeer-network/interchain/` — IBC implementation
- `paxeer-network/admin/` — Admin gRPC service
- `paxeer-network/hpx/` — Node distribution

## Notes

- json-rpc and json-rpc-unsupported already had complete content from Gideon
- All pages include proper source citations
- Documentation is comprehensive but does not include unverified deployment addresses or invented configuration values
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cff19a9-1b33-4e36-95a9-401dda924099?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cff19a9-1b33-4e36-95a9-401dda924099&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

