### PR TITLE
docs(paxeer): restyle Jarvis core pages onto M3 tokens

### DIFF
--- a/paxeer-docs/src/app/consensus/page.tsx
+++ b/paxeer-docs/src/app/consensus/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Consensus() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Consensus</h1>
-        <p className="page-description">
-          Paxeer's BFT consensus engine with Autobahn, ABCI, node management, state machine, light client, and validator key handling.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Consensus">
+      <p className="text-on-surface-variant mb-6">
+        Paxeer's BFT consensus engine with Autobahn, ABCI, node management, state machine, light client, and validator key handling.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/</code>
       </div>
 
@@ -36,7 +34,7 @@ export default function Consensus() {
 
       <h2>Autobahn Consensus</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/autobahn/</code>
       </div>
 
@@ -85,7 +83,7 @@ export default function Consensus() {
 
       <h2>Node</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/node/</code>
       </div>
 
@@ -108,7 +106,7 @@ export default function Consensus() {
 
       <h2>State Management</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/internal/state/</code> and <code>consensus/state/</code>
       </div>
 
@@ -129,7 +127,7 @@ export default function Consensus() {
 
       <h2>Light Client</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/light/</code>
       </div>
 
@@ -156,7 +154,7 @@ export default function Consensus() {
 
       <h2>Validator Key Management (PrivVal)</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/privval/</code>
       </div>
 
@@ -176,7 +174,7 @@ export default function Consensus() {
 
       <h2>Configuration</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/config/</code>
       </div>
 
@@ -198,7 +196,7 @@ export default function Consensus() {
 
       <h2>RPC</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/rpc/</code>
       </div>
 
@@ -218,7 +216,7 @@ export default function Consensus() {
 
       <h2>Network (P2P)</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/internal/p2p/</code>
       </div>
 
@@ -235,7 +233,7 @@ export default function Consensus() {
 
       <h2>Utilities</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/libs/</code>
       </div>
 
@@ -259,16 +257,10 @@ export default function Consensus() {
         <li><Link href="/configuration">Configure consensus parameters</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/operators">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Operators Guide</div>
-        </Link>
-        <Link href="/engine">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Engine</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/operators", title: "Operators Guide" }}
+        next={{ href: "/engine", title: "Engine" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/engine/page.tsx
+++ b/paxeer-docs/src/app/engine/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Engine() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Engine</h1>
-        <p className="page-description">
-          Paxeer's EVM execution engine, transaction processing, and state transition management.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Engine">
+      <p className="text-on-surface-variant mb-6">
+        Paxeer's EVM execution engine, transaction processing, and state transition management.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/</code>
       </div>
 
@@ -23,7 +21,7 @@ export default function Engine() {
 
       <h2>Executor</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/executor/</code>
       </div>
 
@@ -83,7 +81,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h3>Internal Components</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/executor/internal/</code>
       </div>
 
@@ -99,7 +97,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h2>Precompiles</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/executor/precompiles/</code>
       </div>
 
@@ -113,7 +111,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h2>Dependencies (xbank, xevm)</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/</code>
       </div>
 
@@ -152,7 +150,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h2>Configuration</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/executor/config/</code>
       </div>
 
@@ -168,7 +166,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h2>Testing</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/tests/</code>
       </div>
 
@@ -190,7 +188,7 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
 
       <h2>Utilities</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/executor/utils/</code>
       </div>
 
@@ -225,16 +223,10 @@ func NewEvmoneExecutor(evmoneVM *evmc.VM, blockCtx vm.BlockContext,
         <li><Link href="/json-rpc">Use the JSON-RPC API</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/consensus">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Consensus</div>
-        </Link>
-        <Link href="/evm">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">EVM</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/consensus", title: "Consensus" }}
+        next={{ href: "/evm", title: "EVM" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/evm/page.tsx
+++ b/paxeer-docs/src/app/evm/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function EVM() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">EVM Module</h1>
-        <p className="page-description">
-          Native EVM execution, address association, receipts, pointers, and precompile integration on chain ID 125.
-        </p>
-      </div>
+    <DocsLayout pageTitle="EVM Module">
+      <p className="text-on-surface-variant mb-6">
+        Native EVM execution, address association, receipts, pointers, and precompile integration on chain ID 125.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/evm/</code>
       </div>
 
@@ -51,7 +49,7 @@ export default function EVM() {
 
       <h2>Address Association</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/address.go</code>
       </div>
 
@@ -76,7 +74,7 @@ export default function EVM() {
 
       <h2>State Management</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/state.go</code>
       </div>
 
@@ -113,7 +111,7 @@ export default function EVM() {
 
       <h2>Receipts</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/receipt.go</code>
       </div>
 
@@ -151,7 +149,7 @@ export default function EVM() {
 
       <h2>Precompile Integration</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/precompile.go</code>
       </div>
 
@@ -165,7 +163,7 @@ export default function EVM() {
 
       <h2>Fee Collection</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/fee.go</code>
       </div>
 
@@ -186,7 +184,7 @@ export default function EVM() {
 
       <h2>Coinbase</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/coinbase.go</code>
       </div>
 
@@ -202,7 +200,7 @@ export default function EVM() {
 
       <h2>Configuration</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/config/</code>
       </div>
 
@@ -219,7 +217,7 @@ export default function EVM() {
 
       <h2>Genesis</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/genesis.go</code>
       </div>
 
@@ -235,7 +233,7 @@ export default function EVM() {
 
       <h2>Logging</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/log.go</code>
       </div>
 
@@ -245,7 +243,7 @@ export default function EVM() {
 
       <h2>Deferred Operations</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/engine/deps/xevm/keeper/deferred.go</code>
       </div>
 
@@ -261,16 +259,10 @@ export default function EVM() {
         <li><Link href="/contracts">Deploy contracts</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/engine">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Engine</div>
-        </Link>
-        <Link href="/storage">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Storage</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/engine", title: "Engine" }}
+        next={{ href: "/storage", title: "Storage" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/epoch/page.tsx
+++ b/paxeer-docs/src/app/modules/epoch/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Epoch() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Epoch Module</h1>
-        <p className="page-description">
-          Time-based hooks and epoch lifecycle management for coordinating periodic chain operations.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Epoch Module">
+      <p className="text-on-surface-variant mb-6">
+        Time-based hooks and epoch lifecycle management for coordinating periodic chain operations.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/epoch/</code>
       </div>
 
@@ -140,16 +138,10 @@ export default function Epoch() {
         <li><Link href="/modules">Review all Paxeer modules</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Modules Overview</div>
-        </Link>
-        <Link href="/modules/mint">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Mint Module</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules", title: "Modules Overview" }}
+        next={{ href: "/modules/mint", title: "Mint Module" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/mint/page.tsx
+++ b/paxeer-docs/src/app/modules/mint/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Mint() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Mint Module</h1>
-        <p className="page-description">
-          Scheduled native token inflation, daily distribution, and governance-controlled minting policy.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Mint Module">
+      <p className="text-on-surface-variant mb-6">
+        Scheduled native token inflation, daily distribution, and governance-controlled minting policy.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/mint/</code>
       </div>
 
@@ -213,7 +211,7 @@ total_mint_amount: "100000"`}</code></pre>
       <pre><code>{`paxd tx gov submit-proposal param-change ./param_change_prop.json \\
   --from admin -b block -y --gas 200000 --fees 200000uhpx`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Note:</strong> Changes to <code>total_mint_amount</code> or <code>remaining_mint_amount</code> after the start date do not affect tokens already minted.
       </div>
 
@@ -244,16 +242,10 @@ total_mint_amount: "100000"`}</code></pre>
         <li><Link href="/modules/oracle">Learn about the oracle module</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules/epoch">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Epoch Module</div>
-        </Link>
-        <Link href="/modules/oracle">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Oracle Module</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules/epoch", title: "Epoch Module" }}
+        next={{ href: "/modules/oracle", title: "Oracle Module" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/oracle/page.tsx
+++ b/paxeer-docs/src/app/modules/oracle/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Oracle() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Oracle Module</h1>
-        <p className="page-description">
-          Validator-based exchange rate voting, weighted median price aggregation, and slashing for bad data.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Oracle Module">
+      <p className="text-on-surface-variant mb-6">
+        Validator-based exchange rate voting, weighted median price aggregation, and slashing for bad data.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/oracle/</code>
       </div>
 
@@ -166,16 +164,10 @@ export default function Oracle() {
         <li><Link href="/precompiles">Use the oracle precompile from EVM contracts</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules/mint">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Mint Module</div>
-        </Link>
-        <Link href="/modules/store">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Store Module</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules/mint", title: "Mint Module" }}
+        next={{ href: "/modules/store", title: "Store Module" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/page.tsx
+++ b/paxeer-docs/src/app/modules/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Modules() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Paxeer Modules</h1>
-        <p className="page-description">
-          Paxeer-specific chain modules that extend the Cosmos SDK base.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Paxeer Modules">
+      <p className="text-on-surface-variant mb-6">
+        Paxeer-specific chain modules that extend the Cosmos SDK base.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/README.md</code>
       </div>
 
@@ -177,16 +175,10 @@ export default function Modules() {
         <li><strong>Query routing:</strong> Module-specific queries routed to keepers</li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/storage">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Storage</div>
-        </Link>
-        <Link href="/modules/epoch">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Epoch Module</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/storage", title: "Storage" }}
+        next={{ href: "/modules/epoch", title: "Epoch Module" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/store/page.tsx
+++ b/paxeer-docs/src/app/modules/store/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Store() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Store Module</h1>
-        <p className="page-description">
-          Module-level store integration helpers for key formatting, iterators, and codec utilities.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Store Module">
+      <p className="text-on-surface-variant mb-6">
+        Module-level store integration helpers for key formatting, iterators, and codec utilities.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/store/</code>
       </div>
 
@@ -158,16 +156,10 @@ func (k Keeper) SetAccount(ctx sdk.Context, addr common.Address, acc Account) {
         <li><Link href="/modules">Review other Paxeer modules</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules/oracle">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Oracle Module</div>
-        </Link>
-        <Link href="/modules/tokenfactory">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Token Factory Module</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules/oracle", title: "Oracle Module" }}
+        next={{ href: "/modules/tokenfactory", title: "Token Factory Module" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/modules/tokenfactory/page.tsx
+++ b/paxeer-docs/src/app/modules/tokenfactory/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function TokenFactory() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Token Factory Module</h1>
-        <p className="page-description">
-          Permissionless creation and management of native token denominations with namespace protection.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Token Factory Module">
+      <p className="text-on-surface-variant mb-6">
+        Permissionless creation and management of native token denominations with namespace protection.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/tokenfactory/</code>
       </div>
 
@@ -228,16 +226,10 @@ export default function TokenFactory() {
         <li><Link href="/modules">Review other Paxeer modules</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules/store">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Store Module</div>
-        </Link>
-        <Link href="/precompiles">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Precompiles</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules/store", title: "Store Module" }}
+        next={{ href: "/precompiles", title: "Precompiles" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/precompiles/page.tsx
+++ b/paxeer-docs/src/app/precompiles/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Precompiles() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Precompiles</h1>
-        <p className="page-description">
-          Paxeer-specific precompiled contracts exposing Cosmos modules to EVM contracts.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Precompiles">
+      <p className="text-on-surface-variant mb-6">
+        Paxeer-specific precompiled contracts exposing Cosmos modules to EVM contracts.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/</code>
       </div>
 
@@ -33,7 +31,7 @@ export default function Precompiles() {
 
       <h3>addr</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/addr/</code>
       </div>
 
@@ -43,7 +41,7 @@ export default function Precompiles() {
 
       <h3>bank</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/bank/</code>
       </div>
 
@@ -63,7 +61,7 @@ export default function Precompiles() {
 
       <h3>common</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/common/</code>
       </div>
 
@@ -79,7 +77,7 @@ export default function Precompiles() {
 
       <h3>distribution</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/distribution/</code>
       </div>
 
@@ -95,7 +93,7 @@ export default function Precompiles() {
 
       <h3>gov</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/gov/</code>
       </div>
 
@@ -115,7 +113,7 @@ export default function Precompiles() {
 
       <h3>ibc</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/ibc/</code>
       </div>
 
@@ -130,7 +128,7 @@ export default function Precompiles() {
 
       <h3>json</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/json/</code>
       </div>
 
@@ -140,7 +138,7 @@ export default function Precompiles() {
 
       <h3>oracle</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/oracle/</code>
       </div>
 
@@ -159,7 +157,7 @@ export default function Precompiles() {
 
       <h3>p256</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/p256/</code>
       </div>
 
@@ -173,7 +171,7 @@ export default function Precompiles() {
 
       <h3>pointer</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/pointer/</code>
       </div>
 
@@ -193,7 +191,7 @@ export default function Precompiles() {
 
       <h3>pointerview</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/pointerview/</code>
       </div>
 
@@ -209,7 +207,7 @@ export default function Precompiles() {
 
       <h3>solo</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/solo/</code>
       </div>
 
@@ -219,7 +217,7 @@ export default function Precompiles() {
 
       <h3>staking</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/staking/</code>
       </div>
 
@@ -237,7 +235,7 @@ export default function Precompiles() {
 
       <h3>wasmd</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/wasmd/</code>
       </div>
 
@@ -260,7 +258,7 @@ export default function Precompiles() {
         Precompile addresses are determined at chain initialization and registered in the EVM module. Addresses are not declared in the paxeer-network tree; they are assigned by the node application during setup.
       </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Note:</strong> Contract addresses for precompiles are not hardcoded in <code>paxeer-network/precompiles/</code>. They are registered at runtime in <code>node/app.go</code>.
       </div>
 
@@ -272,7 +270,7 @@ export default function Precompiles() {
 
       <h2>Setup and Registration</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/precompiles/setup.go</code>
       </div>
 
@@ -323,16 +321,10 @@ contract MyContract {
         <li><Link href="/wasm">Explore CosmWasm integration</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/modules/tokenfactory">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Token Factory Module</div>
-        </Link>
-        <Link href="/wasm">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">WASM</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/modules/tokenfactory", title: "Token Factory Module" }}
+        next={{ href: "/wasm", title: "WASM" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/storage/page.tsx
+++ b/paxeer-docs/src/app/storage/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Storage() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Storage</h1>
-        <p className="page-description">
-          PaxDB: Paxeer's next-generation storage engine with state commitment, state store, WAL, and performance optimizations.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Storage">
+      <p className="text-on-surface-variant mb-6">
+        PaxDB: Paxeer's next-generation storage engine with state commitment, state store, WAL, and performance optimizations.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/</code>
       </div>
 
@@ -48,7 +46,7 @@ export default function Storage() {
 
       <h3>State Commitment (SC) Layer</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/state_db/sc/</code>
       </div>
 
@@ -69,7 +67,7 @@ export default function Storage() {
 
       <h3>State Store (SS) Layer</h3>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/state_db/ss/</code>
       </div>
 
@@ -106,7 +104,7 @@ export default function Storage() {
 
       <h2>Database Engine</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/db_engine/</code>
       </div>
 
@@ -140,7 +138,7 @@ export default function Storage() {
 
       <h2>Write-Ahead Log (WAL)</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/wal/</code>
       </div>
 
@@ -150,7 +148,7 @@ export default function Storage() {
 
       <h2>Common Utilities</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/common/</code>
       </div>
 
@@ -169,7 +167,7 @@ export default function Storage() {
 
       <h2>Benchmarking and Tools</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/tools/</code>
       </div>
 
@@ -184,7 +182,7 @@ export default function Storage() {
 
       <h2>Protobuf Definitions</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/storage/proto/</code>
       </div>
 
@@ -237,16 +235,10 @@ export default function Storage() {
         <li><Link href="/modules">Understand module state storage</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/evm">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">EVM</div>
-        </Link>
-        <Link href="/modules">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Modules Overview</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/evm", title: "EVM" }}
+        next={{ href: "/modules", title: "Modules Overview" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/wasm-runtime/page.tsx
+++ b/paxeer-docs/src/app/wasm-runtime/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function WasmRuntime() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">WASM Runtime</h1>
-        <p className="page-description">
-          The CosmWasm VM, libwasmvm linking, CGO vs no-CGO builds, and WASM execution internals.
-        </p>
-      </div>
+    <DocsLayout pageTitle="WASM Runtime">
+      <p className="text-on-surface-variant mb-6">
+        The CosmWasm VM, libwasmvm linking, CGO vs no-CGO builds, and WASM execution internals.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/wasm-runtime/</code>
       </div>
 
@@ -23,7 +21,7 @@ export default function WasmRuntime() {
 
       <h2>libwasmvm</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/wasm-runtime/libwasmvm/</code>
       </div>
 
@@ -260,16 +258,10 @@ CGO_ENABLED=0 go build .  # Compiles, but WASM calls fail`}</code></pre>
         <li><Link href="/wasmbinding">Review Paxeer-specific bindings</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/wasm">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">WASM</div>
-        </Link>
-        <Link href="/wasmbinding">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">WASM Bindings</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/wasm", title: "WASM" }}
+        next={{ href: "/wasmbinding", title: "WASM Bindings" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/wasm/page.tsx
+++ b/paxeer-docs/src/app/wasm/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Wasm() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">WASM</h1>
-        <p className="page-description">
-          WebAssembly smart contract support via CosmWasm on Paxeer.
-        </p>
-      </div>
+    <DocsLayout pageTitle="WASM">
+      <p className="text-on-surface-variant mb-6">
+        WebAssembly smart contract support via CosmWasm on Paxeer.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/wasm/</code>
       </div>
 
@@ -195,7 +193,7 @@ export default function Wasm() {
 
       <h2>Contract Examples</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/example/cosmwasm/</code>
       </div>
 
@@ -205,7 +203,7 @@ export default function Wasm() {
 
       <h2>Testing</h2>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/integration_test/wasm_module/</code>
       </div>
 
@@ -221,16 +219,10 @@ export default function Wasm() {
         <li><Link href="/precompiles">Use the wasmd precompile from EVM</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/precompiles">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Precompiles</div>
-        </Link>
-        <Link href="/wasm-runtime">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">WASM Runtime</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/precompiles", title: "Precompiles" }}
+        next={{ href: "/wasm-runtime", title: "WASM Runtime" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/wasmbinding/page.tsx
+++ b/paxeer-docs/src/app/wasmbinding/page.tsx
@@ -1,17 +1,15 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function WasmBinding() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">WASM Bindings</h1>
-        <p className="page-description">
-          Custom Paxeer message types and queries for CosmWasm contracts.
-        </p>
-      </div>
+    <DocsLayout pageTitle="WASM Bindings">
+      <p className="text-on-surface-variant mb-6">
+        Custom Paxeer message types and queries for CosmWasm contracts.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/wasmbinding/</code>
       </div>
 
@@ -154,16 +152,10 @@ pub fn query_pax_usd_rate(deps: Deps) -> StdResult<ExchangeRateResponse> {
         <li><Link href="/precompiles">Compare with EVM precompiles</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/wasm-runtime">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">WASM Runtime</div>
-        </Link>
-        <Link href="/json-rpc">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">JSON-RPC API</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/wasm-runtime", title: "WASM Runtime" }}
+        next={{ href: "/json-rpc", title: "JSON-RPC API" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/components/PrevNext.tsx
+++ b/paxeer-docs/src/components/PrevNext.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export function PrevNext({
+  prev,
+  next,
+}: {
+  prev: { href: string; title: string }
+  next: { href: string; title: string }
+}) {
+  return (
+    <nav className="grid grid-cols-2 gap-3 mt-12 pt-8 border-t border-outline-variant">
+      <Link
+        href={prev.href}
+        className="bg-surface-high rounded-lg p-5 border border-outline-variant hover:border-ink-text transition-all duration-150 hover:translate-y-[-2px]"
+      >
+        <div className="text-xs text-on-surface-variant uppercase tracking-wider mb-2">Previous</div>
+        <div className="text-lg font-medium text-on-surface">{prev.title}</div>
+      </Link>
+      <Link
+        href={next.href}
+        className="bg-surface-high rounded-lg p-5 border border-outline-variant hover:border-ink-text transition-all duration-150 hover:translate-y-[-2px] text-right"
+      >
+        <div className="text-xs text-on-surface-variant uppercase tracking-wider mb-2">Next</div>
+        <div className="text-lg font-medium text-on-surface">{next.title}</div>
+      </Link>
+    </nav>
+  )
+}

--- a/paxeer-docs/src/styles/globals.css
+++ b/paxeer-docs/src/styles/globals.css
@@ -287,6 +287,32 @@ pre {
   margin: 1rem 0;
 }
 
+pre .copy-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.5rem;
+  border: none;
+  border-radius: var(--shape-sm);
+  background: var(--surface-container);
+  color: var(--on-surface-variant);
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity var(--duration-short) var(--ease-standard),
+    background var(--duration-short) var(--ease-standard),
+    color var(--duration-short) var(--ease-standard);
+}
+
+pre:hover .copy-button,
+pre:focus-within .copy-button {
+  opacity: 1;
+}
+
+pre .copy-button:hover {
+  background: var(--surface-high);
+  color: var(--on-surface);
+}
+
 pre code {
   background: none;
   padding: 0;

--- a/paxeer-docs/src/styles/globals.css
+++ b/paxeer-docs/src/styles/globals.css
@@ -342,6 +342,112 @@ hr {
   margin: 2rem 0;
 }
 
+/* Shared docs chrome remapped to M3 tokens from #89.
+   Keeps leftover page-header / source-note / prev-next / badge classes
+   on Gideon and Ultron pages without rewriting those files. */
+.page-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--outline-variant);
+}
+
+.page-title {
+  font-size: 3rem;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+  color: var(--on-surface);
+}
+
+.page-description {
+  font-size: 1.125rem;
+  color: var(--on-surface-variant);
+  margin-bottom: 0;
+}
+
+.source-note {
+  background: var(--surface-high);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--shape-lg);
+  padding: 0.75rem 1rem;
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
+  color: var(--on-surface-variant);
+}
+
+.source-note code {
+  color: var(--ink-text);
+}
+
+.prev-next {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--outline-variant);
+}
+
+.prev-next a {
+  background: var(--surface-high);
+  border: 1px solid var(--outline-variant);
+  border-radius: var(--shape-lg);
+  padding: 1.25rem;
+  transition: border-color var(--duration-short) var(--ease-standard),
+    transform var(--duration-short) var(--ease-standard);
+}
+
+.prev-next a:hover {
+  border-color: var(--ink-text);
+  transform: translateY(-2px);
+  color: var(--on-surface);
+}
+
+.prev-next-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--on-surface-variant);
+  margin-bottom: 0.5rem;
+}
+
+.prev-next-title {
+  color: var(--on-surface);
+  font-size: 1.125rem;
+  font-weight: 500;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--shape-xs);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.badge-warning {
+  background: color-mix(in oklch, var(--warning) 18%, transparent);
+  color: var(--warning);
+}
+
+.badge-info {
+  background: color-mix(in oklch, var(--ink-text) 18%, transparent);
+  color: var(--ink-text);
+}
+
+.badge-success {
+  background: color-mix(in oklch, var(--success) 18%, transparent);
+  color: var(--success);
+}
+
+@media (max-width: 1024px) {
+  .page-title {
+    font-size: 2rem;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finishes the Paxeer docs M3 restyle that stopped after chrome, landing, search, and copy-for-agent (#89). Jarvis architecture pages now use the same surface tiers, LTWave chrome, Copy for agent header, and prev/next cards. Technical facts on those pages are unchanged.

#89 is already merged, so this is a sibling PR against `cursor/paxeer-docs-m3-ui-86ef`. Do not merge to main.

## Specification

- Requirement clause(s): docs restyle only; no protocol / wire / ABI change
- Codify task: n/a (continuation of #89 M3 chrome)
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI: none

## What changed

Jarvis pages only:

- `/consensus`
- `/engine`, `/evm`, `/storage`
- `/modules` plus epoch / mint / oracle / store / tokenfactory
- `/precompiles`, `/wasm`, `/wasm-runtime`, `/wasmbinding`

Each page now:

- uses `DocsLayout pageTitle` so the M3 header and Copy for agent button appear
- maps source notes to `surface-high` / `outline-variant` cards
- uses the shared `PrevNext` cards

Shared layout CSS remaps leftover `page-header`, `source-note`, `prev-next`, and `badge` classes to the #89 M3 tokens so Gideon API and Ultron install/config/operators pages keep working without a content rewrite. Code-block copy buttons injected at runtime now have hover styles in that same CSS, because Tailwind never saw the dynamically assigned utility classes.

## What was not changed

- No Gideon API page content (json-rpc, rest-grpc, contracts, docker, sdk, interchain, admin-hpx)
- No Ultron install/config/operators page content
- No new palette, no Docusaurus, no invented fees
- No paxeer-network source or technical fact rewrites

## Verification

Local `next dev` on this branch:

- All 14 Jarvis routes returned HTTP 200 with Copy for agent and prev/next.
- Browser pass: consensus → engine → evm → storage, modules / epoch / tokenfactory, precompiles, wasm, plus json-rpc (untouched content, shared CSS) and installation.
- Sidebar, surface cards, and prev/next navigation worked. No JS errors.
- Code-copy hover is now pinned in CSS after the first pass found the injected buttons invisible.

Clipboard "Copied" feedback was not confirmed in the automation browser (clipboard permission). That control is the existing #89 client button.

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. (n/a — docs site only)
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants.
- [ ] I added real positive, negative, and adversarial coverage appropriate to the change.
- [ ] I ran `make public-audit` and the affected native or Solidity suites.
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b59a891-874a-42c6-a933-7e35d1190b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b59a891-874a-42c6-a933-7e35d1190b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

