### PR TITLE
Restyle Gideon's eight API docs pages onto the M3 chrome

### DIFF
--- a/paxeer-docs/src/app/admin-hpx/page.tsx
+++ b/paxeer-docs/src/app/admin-hpx/page.tsx
@@ -1,474 +1,194 @@
 import { DocsLayout } from '@/components/DocsLayout'
-import Link from 'next/link'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 
 export default function AdminHpx() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Admin & HPX</h1>
-        <p className="page-description">
-          Runtime administration gRPC service and HyperPax native node distribution.
+    <DocsLayout pageTitle="Admin & HPX">
+      <PageLead overline="AdminService :9095 · hpx · node.hyperpaxeer.com" source="paxeer-network/admin/, paxeer-network/hpx/">
+        <p>
+          Two surfaces. <code>AdminService</code> is loopback gRPC at <code>127.0.0.1:9095</code> for live log levels. HPX installs a native <code>paxd</code> for <code>hyperpax_125-1</code> (EVM 125) from <code>https://node.hyperpaxeer.com</code>.
         </p>
-      </div>
+        <p>
+          Artifacts live outside git. PAX is gas. LayerX fee is 5,000 µUSDX per activity, not zero. HPX is not a LayerX RPC.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Admin:</strong> <code>paxeer-network/admin/</code><br />
-        <strong>HPX:</strong> <code>paxeer-network/hpx/</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'Admin gRPC', value: '127.0.0.1:9095' },
+          { label: 'Proto', value: 'paxprotocol.paxchain.admin.v0' },
+          { label: 'HPX origin', value: 'node.hyperpaxeer.com' },
+          { label: 'Chain ID', value: 'hyperpax_125-1' },
+        ]}
+      />
 
-      <h2>Admin gRPC Service</h2>
+      <JumpNav
+        items={[
+          { id: 'admin', label: 'AdminService' },
+          { id: 'grpcurl', label: 'grpcurl' },
+          { id: 'hpx', label: 'HPX install' },
+          { id: 'cli', label: 'hpx CLI' },
+          { id: 'registry', label: 'Registry' },
+          { id: 'publish', label: 'Publish' },
+        ]}
+      />
 
-      <p>
-        The Admin service provides runtime log level control for <code>paxd</code> without restarting the node. It runs on a dedicated loopback-only gRPC server for security.
-      </p>
-
-      <h3>Configuration</h3>
-
-      <p>
-        Enable in <code>app.toml</code>:
-      </p>
-
-      <pre><code>{`[admin_server]
+      <Section id="admin" title="AdminService">
+        <p className={m3.body}>
+          Runtime log control without restarting <code>paxd</code>. Address must be loopback (<code>127.0.0.1</code> or <code>::1</code>). Non-loopback binds are rejected. Proto: <code>paxeer-network/api/pax/admin/v0/admin.proto</code>. Code: <code>paxeer-network/admin/server.go</code>, <code>service.go</code>, <code>config.go</code>.
+        </p>
+        <SnippetBlock
+          method="[admin_server]"
+          args="admin_address = 127.0.0.1:9095"
+          source="paxeer-network/admin/config.go"
+          purpose="Enable the loopback-only admin gRPC server."
+          code={`[admin_server]
 admin_enabled = true
-admin_address = "127.0.0.1:9095"`}</code></pre>
+admin_address = "127.0.0.1:9095"`}
+        />
+        <MethodTable
+          columns={['RPC', 'Request', 'Response', 'Purpose']}
+          rows={[
+            ['SetLogLevel', 'pattern, level', 'affected count', 'Set level for matching loggers'],
+            ['GetLogLevel', 'logger', 'level', 'Read one logger'],
+            ['ListLoggers', 'prefix (optional)', 'loggers[]', 'List registered loggers'],
+          ]}
+        />
+        <Subhead>Patterns</Subhead>
+        <p className={m3.body}>
+          Exact <code>evm</code>, glob <code>evm*</code>, or <code>*</code> for every logger. Levels: <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>.
+        </p>
+        <p className={m3.body}>
+          No auth on loopback. For a remote host, tunnel: <code>ssh -L 9095:127.0.0.1:9095 user@node-ip</code>.
+        </p>
+      </Section>
 
-      <p>
-        The address <strong>must</strong> be a loopback address (<code>127.0.0.1</code> or <code>::1</code>). Binding to external interfaces is rejected at startup.
-      </p>
-
-      <h3>gRPC Methods</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>Request</th>
-            <th>Response</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>SetLogLevel</code></td>
-            <td><code>pattern</code>, <code>level</code></td>
-            <td><code>affected</code> count</td>
-            <td>Change log level for loggers matching pattern</td>
-          </tr>
-          <tr>
-            <td><code>GetLogLevel</code></td>
-            <td><code>logger</code></td>
-            <td><code>level</code></td>
-            <td>Get current log level for a logger</td>
-          </tr>
-          <tr>
-            <td><code>ListLoggers</code></td>
-            <td><code>prefix</code> (optional)</td>
-            <td>List of loggers</td>
-            <td>List all loggers and their levels</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>SetLogLevel Pattern Matching</h3>
-
-      <p>
-        The <code>pattern</code> parameter supports:
-      </p>
-
-      <ul>
-        <li><strong>Exact match:</strong> <code>"evm"</code> (sets log level for the EVM logger only)</li>
-        <li><strong>Glob:</strong> <code>"evm*"</code> (sets log level for all loggers starting with "evm")</li>
-        <li><strong>All loggers:</strong> <code>"*"</code> (sets log level for every logger)</li>
-      </ul>
-
-      <h3>Log Levels</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Level</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>debug</code></td>
-            <td>Verbose debugging information</td>
-          </tr>
-          <tr>
-            <td><code>info</code></td>
-            <td>General operational information</td>
-          </tr>
-          <tr>
-            <td><code>warn</code></td>
-            <td>Warning messages (potential issues)</td>
-          </tr>
-          <tr>
-            <td><code>error</code></td>
-            <td>Error messages (failures)</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Example: Using grpcurl</h3>
-
-      <pre><code>{`# List all loggers
-grpcurl -plaintext localhost:9095 \\
+      <Section id="grpcurl" title="grpcurl">
+        <SnippetBlock
+          method="paxprotocol.paxchain.admin.v0.AdminService/ListLoggers"
+          args="localhost:9095"
+          source="paxeer-network/api/pax/admin/v0/admin.proto"
+          purpose="List loggers, set evm to debug, then read the evm level back."
+          code={`grpcurl -plaintext localhost:9095 \\
   paxprotocol.paxchain.admin.v0.AdminService/ListLoggers
 
-# Set EVM logger to debug
 grpcurl -plaintext -d '{"pattern":"evm","level":"debug"}' \\
   localhost:9095 \\
   paxprotocol.paxchain.admin.v0.AdminService/SetLogLevel
 
-# Get log level for a specific logger
 grpcurl -plaintext -d '{"logger":"evm"}' \\
   localhost:9095 \\
-  paxprotocol.paxchain.admin.v0.AdminService/GetLogLevel`}</code></pre>
+  paxprotocol.paxchain.admin.v0.AdminService/GetLogLevel`}
+        />
+      </Section>
 
-      <h3>Security</h3>
-
-      <p>
-        The Admin service is loopback-only by design:
-      </p>
-
-      <ul>
-        <li>No authentication required (loopback is trusted)</li>
-        <li>Cannot be bound to external interfaces</li>
-        <li>Must access from the same machine as <code>paxd</code></li>
-      </ul>
-
-      <p>
-        For remote access, use SSH port forwarding:
-      </p>
-
-      <pre><code>{`ssh -L 9095:127.0.0.1:9095 user@node-ip`}</code></pre>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/pax/admin/v0/admin.proto</code><br />
-        <strong>Implementation:</strong> <code>paxeer-network/admin/server.go</code>, <code>service.go</code>, <code>config.go</code>
-      </div>
-
-      <h2>HPX: HyperPax Node Distribution</h2>
-
-      <p>
-        HPX is the public installer, node manager, and peer registry for HyperPax (<code>hyperpax_125-1</code>). Nodes run a native <code>paxd</code> binary under systemd. All artifacts are published outside Git.
-      </p>
-
-      <h3>Chain Identifier</h3>
-
-      <p>
-        <code>hyperpax_125-1</code> (Cosmos-style, EVM chain ID <code>125</code>)
-      </p>
-
-      <h3>Install a Node</h3>
-
-      <pre><code>{`curl -sSL https://node.hyperpaxeer.com/get-hpx.sh | sudo bash`}</code></pre>
-
-      <p>
-        The installer:
-      </p>
-
-      <ol>
-        <li>Downloads and verifies the HPX CLI against <code>checksums.txt</code></li>
-        <li>Places <code>hpx</code> in <code>/usr/local/bin/</code></li>
-      </ol>
-
-      <h3>Setup a Node</h3>
-
-      <pre><code>{`# Set node type (fullnode or validator)
+      <Section id="hpx" title="HPX">
+        <p className={m3.body}>
+          Public installer, node manager, artifact publisher, and peer registry. Nodes run native <code>paxd</code> under systemd. Generated binaries, libs, live config, registry state, and TLS stay outside git.
+        </p>
+        <SnippetBlock
+          method="get-hpx.sh"
+          args="https://node.hyperpaxeer.com"
+          source="paxeer-network/hpx/README.md"
+          purpose="Install the hpx CLI after checksum verification, then set up a fullnode."
+          code={`curl -sSL https://node.hyperpaxeer.com/get-hpx.sh | sudo bash
 export HPX_TYPE=fullnode
+hpx setup`}
+        />
+        <p className={m3.body}>
+          Setup pulls <code>paxd</code>, libwasmvm runtimes, genesis, and config; verifies <code>checksums.txt</code>; installs under <code>/root/.paxeer/</code>; enables systemd; starts <code>paxd</code>.
+        </p>
+      </Section>
 
-# Run setup
-hpx setup`}</code></pre>
+      <Section id="cli" title="hpx CLI">
+        <MethodTable
+          columns={['Command', 'Purpose']}
+          rows={[
+            ['hpx status', 'Sync status'],
+            ['hpx info', 'Node config'],
+            ['hpx logs', 'paxd logs'],
+            ['hpx update', 'Update paxd and libs'],
+            ['hpx peers show', 'Known peers'],
+            ['hpx peers refresh', 'Pull the registry peer list'],
+            ['hpx register', 'Announce this node'],
+            ['hpx statesync', 'Write state-sync trust params into config.toml'],
+            ['hpx remove', 'Stop paxd, drop systemd, delete /root/.paxeer/'],
+          ]}
+        />
+        <MethodTable
+          columns={['HPX_TYPE', 'Role', 'Config']}
+          rows={[
+            ['fullnode', 'Non-validating node', '/config/fullnode/'],
+            ['validator', 'Validating node', '/config/validator/'],
+          ]}
+        />
+      </Section>
 
-      <p>
-        The setup flow:
-      </p>
+      <Section id="registry" title="Registry">
+        <p className={m3.body}>
+          Origin <code>https://node.hyperpaxeer.com</code>. Paths from <code>paxeer-network/hpx/README.md</code> and <code>paxeer-network/hpx/registry/main.go</code>.
+        </p>
+        <MethodTable
+          columns={['Method', 'Path', 'Purpose']}
+          rows={[
+            ['GET', '/healthz', 'Liveness, chain, source revision'],
+            ['GET', '/checksums.txt', 'SHA-256 manifest'],
+            ['GET', '/chain-info.json', 'Chain metadata'],
+            ['GET', '/paxd', 'Native paxd'],
+            ['GET', '/lib/*.so', 'Declared libwasmvm runtimes'],
+            ['GET', '/genesis.json', 'Genesis'],
+            ['GET', '/config/<type>/<file>', 'config.toml / app.toml'],
+            ['GET', '/api/myip', 'Caller public address'],
+            ['POST', '/api/register', 'Announce peer address'],
+            ['GET', '/api/peers', 'JSON peers'],
+            ['GET', '/api/peers.txt', 'Tendermint peer text'],
+            ['GET', '/api/nodes', 'Node metadata'],
+            ['GET', '/api/statesync', 'State-sync trust parameters'],
+          ]}
+        />
+        <p className={m3.body}>
+          Served libs: <code>libwasmvm.x86_64.so</code>, <code>libwasmvm.aarch64.so</code>, <code>libwasmvm152.*.so</code>, <code>libwasmvm155.*.so</code>. Directory indexes and undeclared paths are denied.
+        </p>
+        <Callout label="Register token">
+          Public by default. Set <code>HPX_REGISTER_TOKEN</code> before <code>hosting/deploy.sh</code> to require <code>X-HPX-Token</code> on <code>POST /api/register</code>.
+        </Callout>
+      </Section>
 
-      <ol>
-        <li>Downloads <code>paxd</code>, <code>libwasmvm</code> runtimes, genesis, and configuration</li>
-        <li>Verifies all artifacts against <code>checksums.txt</code></li>
-        <li>Installs artifacts to <code>/root/.paxeer/</code></li>
-        <li>Configures systemd service</li>
-        <li>Starts <code>paxd</code></li>
-      </ol>
+      <Section id="publish" title="Publish and deploy">
+        <SnippetBlock
+          method="paxeer-network/hpx/publish.sh"
+          args="stages /srv/hpx/artifacts/releases/<id>"
+          source="paxeer-network/hpx/publish.sh"
+          purpose="Stage paxd, six libwasmvm files, genesis, and config; flip the current symlink only after checksums succeed."
+          code={`sudo paxeer-network/hpx/publish.sh`}
+        />
+        <p className={m3.body}>
+          Inputs: <code>build/paxd</code>, wasm-runtime plus <code>wasm/x/wasm/artifacts</code> v152/v155 libs, live config from <code>/root/.paxeer/config</code> or <code>$SRC_CFG</code>. Failed staging never moves <code>current</code>.
+        </p>
+        <SnippetBlock
+          method="paxeer-network/hpx/hosting/deploy.sh"
+          args="loopback registry + Nginx + node.hyperpaxeer.com"
+          source="paxeer-network/hpx/hosting/"
+          purpose="Install the registry executable as a loopback systemd unit and terminate TLS on Nginx."
+          code={`sudo paxeer-network/hpx/hosting/deploy.sh
 
-      <h3>HPX CLI Commands</h3>
+# optional register token
+export HPX_REGISTER_TOKEN=<token>
+sudo paxeer-network/hpx/hosting/deploy.sh
 
-      <table>
-        <thead>
-          <tr>
-            <th>Command</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>hpx status</code></td>
-            <td>Show node sync status</td>
-          </tr>
-          <tr>
-            <td><code>hpx info</code></td>
-            <td>Show node configuration</td>
-          </tr>
-          <tr>
-            <td><code>hpx logs</code></td>
-            <td>Tail <code>paxd</code> logs</td>
-          </tr>
-          <tr>
-            <td><code>hpx update</code></td>
-            <td>Update <code>paxd</code> and libraries</td>
-          </tr>
-          <tr>
-            <td><code>hpx peers show</code></td>
-            <td>Show known peers</td>
-          </tr>
-          <tr>
-            <td><code>hpx peers refresh</code></td>
-            <td>Fetch latest peer list from registry</td>
-          </tr>
-          <tr>
-            <td><code>hpx register</code></td>
-            <td>Announce node to public registry</td>
-          </tr>
-          <tr>
-            <td><code>hpx statesync</code></td>
-            <td>Enable state-sync for fast bootstrap</td>
-          </tr>
-          <tr>
-            <td><code>hpx remove</code></td>
-            <td>Uninstall node and clean up</td>
-          </tr>
-        </tbody>
-      </table>
+# trusted mirror only
+export HPX_MIRROR=https://<your-mirror>
+hpx setup`}
+        />
+        <p className={m3.body}>
+          Workflow <code>Paxeer / HPX Registry</code> builds Linux x86-64 and AArch64 executables and a multi-arch GHCR image when <code>paxeer-network/hpx/registry/</code> changes. Registry state: <code>/srv/hpx/data/registry.json</code>.
+        </p>
+        <Callout label="Mirrors">
+          <code>HPX_MIRROR</code> only for a mirror you already trust. An untrusted mirror can serve a different binary with matching path names.
+        </Callout>
+      </Section>
 
-      <h3>Node Types</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Type</th>
-            <th>Purpose</th>
-            <th>Config</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>fullnode</code></td>
-            <td>Non-validating full node (RPC, indexing)</td>
-            <td><code>/config/fullnode/</code></td>
-          </tr>
-          <tr>
-            <td><code>validator</code></td>
-            <td>Validating node (must register validator key)</td>
-            <td><code>/config/validator/</code></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Public Registry</h3>
-
-      <p>
-        The HPX registry at <code>https://node.hyperpaxeer.com</code> provides:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>GET /healthz</code></td>
-            <td>Registry liveness, chain and source revision</td>
-          </tr>
-          <tr>
-            <td><code>GET /checksums.txt</code></td>
-            <td>SHA-256 checksums for all artifacts</td>
-          </tr>
-          <tr>
-            <td><code>GET /chain-info.json</code></td>
-            <td>Chain metadata (chain ID, genesis hash)</td>
-          </tr>
-          <tr>
-            <td><code>GET /paxd</code></td>
-            <td>Native <code>paxd</code> binary</td>
-          </tr>
-          <tr>
-            <td><code>GET /lib/*.so</code></td>
-            <td>Architecture-specific <code>libwasmvm</code> runtimes</td>
-          </tr>
-          <tr>
-            <td><code>GET /genesis.json</code></td>
-            <td>Chain genesis file</td>
-          </tr>
-          <tr>
-            <td><code>GET /config/&lt;type&gt;/&lt;file&gt;</code></td>
-            <td>Node configuration files (<code>config.toml</code>, <code>app.toml</code>)</td>
-          </tr>
-          <tr>
-            <td><code>GET /api/myip</code></td>
-            <td>Caller's public IP address</td>
-          </tr>
-          <tr>
-            <td><code>POST /api/register</code></td>
-            <td>Announce node's public peer address</td>
-          </tr>
-          <tr>
-            <td><code>GET /api/peers</code></td>
-            <td>JSON list of registered peers</td>
-          </tr>
-          <tr>
-            <td><code>GET /api/peers.txt</code></td>
-            <td>Text list of peer addresses (Tendermint format)</td>
-          </tr>
-          <tr>
-            <td><code>GET /api/nodes</code></td>
-            <td>Detailed node metadata</td>
-          </tr>
-          <tr>
-            <td><code>GET /api/statesync</code></td>
-            <td>Current state-sync trust parameters</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Artifact Publishing</h3>
-
-      <p>
-        To publish a new <code>paxd</code> release or chain configuration:
-      </p>
-
-      <pre><code>{`# From the monorepo root
-sudo paxeer-network/hpx/publish.sh`}</code></pre>
-
-      <p>
-        This script:
-      </p>
-
-      <ol>
-        <li>Collects <code>paxd</code> binary from <code>build/paxd</code></li>
-        <li>Collects native libraries from <code>wasm-runtime/</code> and <code>wasm/x/wasm/artifacts/</code></li>
-        <li>Collects live chain configuration from <code>/root/.paxeer/config/</code> (or <code>$SRC_CFG</code>)</li>
-        <li>Stages artifacts in <code>/srv/hpx/artifacts/releases/&lt;release-id&gt;/</code></li>
-        <li>Generates <code>checksums.txt</code></li>
-        <li>Atomically moves <code>current</code> symlink to new release</li>
-      </ol>
-
-      <p>
-        Failed staging runs never change the served release.
-      </p>
-
-      <h3>Registry Runtime Deployment</h3>
-
-      <p>
-        Changes to the registry service under <code>paxeer-network/hpx/registry/</code> trigger the GitHub workflow <code>Paxeer / HPX Registry</code>, which:
-      </p>
-
-      <ol>
-        <li>Builds Linux executables (x86-64, AArch64)</li>
-        <li>Publishes them as GitHub release assets</li>
-        <li>Publishes a multi-architecture GHCR image</li>
-      </ol>
-
-      <p>
-        Deploy the registry on the public origin host:
-      </p>
-
-      <pre><code>{`sudo paxeer-network/hpx/hosting/deploy.sh`}</code></pre>
-
-      <p>
-        This script:
-      </p>
-
-      <ol>
-        <li>Downloads and verifies the latest registry executable</li>
-        <li>Installs it as a systemd service (loopback-only)</li>
-        <li>Obtains a Let's Encrypt certificate for <code>node.hyperpaxeer.com</code></li>
-        <li>Configures Nginx reverse proxy with rate-limiting</li>
-      </ol>
-
-      <p>
-        Registry state is persisted at <code>/srv/hpx/data/registry.json</code>.
-      </p>
-
-      <h3>Registry Authentication</h3>
-
-      <p>
-        Registration is public by default. To require a token:
-      </p>
-
-      <pre><code>{`export HPX_REGISTER_TOKEN=your-secret-token
-sudo paxeer-network/hpx/hosting/deploy.sh`}</code></pre>
-
-      <p>
-        The registry will then require <code>X-HPX-Token: your-secret-token</code> header on <code>POST /api/register</code>.
-      </p>
-
-      <h3>Using an Alternate Mirror</h3>
-
-      <p>
-        Set <code>HPX_MIRROR</code> only when operating an explicitly trusted alternate mirror:
-      </p>
-
-      <pre><code>{`export HPX_MIRROR=https://your-mirror.example.com
-hpx setup`}</code></pre>
-
-      <div className="source-note">
-        <strong>Warning:</strong> The mirror must serve the same artifact structure and checksums. Untrusted mirrors can serve malicious binaries.
-      </div>
-
-      <h3>Native Libraries</h3>
-
-      <p>
-        HPX distributes architecture-specific <code>libwasmvm</code> runtimes:
-      </p>
-
-      <ul>
-        <li><code>libwasmvm.x86_64.so</code> — x86-64 Linux</li>
-        <li><code>libwasmvm.aarch64.so</code> — AArch64 Linux</li>
-        <li><code>libwasmvm_muslc.x86_64.so</code> — x86-64 musl (Alpine)</li>
-        <li><code>libwasmvm_muslc.aarch64.so</code> — AArch64 musl</li>
-      </ul>
-
-      <p>
-        The installer detects the host architecture and installs the correct library.
-      </p>
-
-      <h3>State Sync</h3>
-
-      <p>
-        New nodes can bootstrap from a recent state snapshot instead of replaying full history:
-      </p>
-
-      <pre><code>{`hpx statesync`}</code></pre>
-
-      <p>
-        This fetches trust parameters from <code>/api/statesync</code> and updates <code>config.toml</code> to enable state-sync.
-      </p>
-
-      <h3>Uninstall</h3>
-
-      <pre><code>{`hpx remove`}</code></pre>
-
-      <p>
-        This stops <code>paxd</code>, removes the systemd service, and deletes <code>/root/.paxeer/</code>.
-      </p>
-
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/hpx/README.md</code>, <code>paxeer-network/hpx/hosting/</code>
-      </div>
-
-      <div className="prev-next">
-        <Link href="/interchain">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Interchain</div>
-        </Link>
-        <div></div>
-      </div>
+      <PageNav prev={{ href: '/interchain', title: 'Interchain' }} />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/contracts/page.tsx
+++ b/paxeer-docs/src/app/contracts/page.tsx
@@ -1,314 +1,148 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function Contracts() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Contracts</h1>
-        <p className="page-description">
-          Paxeer-native Solidity contracts and LayerX settlement contracts deployed on Paxeer.
+    <DocsLayout pageTitle="Contracts">
+      <PageLead overline="paxeer-network/contracts/ · contracts/ · Solidity 0.8.28" source="paxeer-network/contracts/, contracts/ at repository root">
+        <p>
+          Two trees. Paxeer-native utilities live under <code>paxeer-network/contracts/</code>. LayerX settlement — custody, checkpoints, guarantor bonds, withdrawals, emergency exit — lives at repo-root <code>contracts/</code> and deploys <em>on</em> Paxeer (chain ID 125).
         </p>
-      </div>
+        <p>
+          PAX is gas. LayerX activities charge 5,000 µUSDX, not zero. No public LayerX RPC is documented here. Do not invent deployment addresses; none are published in the tree.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Paxeer-native:</strong> <code>paxeer-network/contracts/</code><br />
-        <strong>LayerX settlement:</strong> <code>contracts/</code> at repository root
-      </div>
+      <FactChips
+        items={[
+          { label: 'Paxeer-native', value: 'paxeer-network/contracts/' },
+          { label: 'LayerX settlement', value: 'contracts/' },
+          { label: 'Solidity', value: '0.8.28 / Prague' },
+          { label: 'Local EVM', value: 'http://127.0.0.1:8545' },
+        ]}
+      />
 
-      <h2>Two Contract Trees</h2>
+      <JumpNav
+        items={[
+          { id: 'trees', label: 'Two trees' },
+          { id: 'native', label: 'Paxeer-native' },
+          { id: 'precompiles', label: 'Precompile interfaces' },
+          { id: 'build', label: 'Build' },
+          { id: 'layerx', label: 'LayerX settlement' },
+        ]}
+      />
 
-      <p>
-        The monorepo contains two distinct contract directories serving different purposes:
-      </p>
+      <Section id="trees" title="Two trees">
+        <MethodTable
+          columns={['Path', 'Purpose', 'Tooling']}
+          rows={[
+            ['paxeer-network/contracts/', 'WPAX, pointer contracts, precompile interfaces, testers', 'Foundry + Hardhat'],
+            ['contracts/', 'LayerX custody, checkpoints, bonds, claims, emergency exit', 'Solidity 0.8.28'],
+          ]}
+        />
+      </Section>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Path</th>
-            <th>Purpose</th>
-            <th>Tooling</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>paxeer-network/contracts/</code></td>
-            <td>Paxeer-native chain utilities: WPAX, pointer contracts, precompile interfaces, testing infrastructure</td>
-            <td>Foundry + Hardhat</td>
-          </tr>
-          <tr>
-            <td><code>contracts/</code> (root)</td>
-            <td>LayerX settlement contracts: custody, checkpoints, guarantor bonds, challenges, emergency exits</td>
-            <td>Solidity 0.8.28</td>
-          </tr>
-        </tbody>
-      </table>
+      <Section id="native" title="Paxeer-native">
+        <p className={m3.body}>
+          Chain-side Solidity under <code>paxeer-network/contracts/src/</code>.
+        </p>
+        <MethodTable
+          columns={['Contract', 'Purpose']}
+          rows={[
+            ['WPAX.sol', 'ERC-20 wrapper for native PAX'],
+            ['CW20ERC20Pointer.sol', 'EVM pointer for CW20'],
+            ['CW721ERC721Pointer.sol', 'EVM pointer for CW721'],
+            ['CW1155ERC1155Pointer.sol', 'EVM pointer for CW1155'],
+            ['NativePaxTokensERC20.sol', 'ERC-20 view of native Cosmos tokens'],
+          ]}
+        />
+        <Subhead>Testers</Subhead>
+        <p className={m3.body}>
+          <code>EVMCompatibilityTester.sol</code>, <code>TransientStorageTester.sol</code>, <code>SelfDestructTester.sol</code>, <code>SnapshotRevertTester.sol</code>, <code>SstoreGasTest.sol</code>, <code>ProxySwapTester.sol</code>, <code>MultiHopSwapTester.sol</code>, <code>MultiSender.sol</code>, <code>BatchCallAndSponsor.sol</code>, <code>Box.sol</code>, <code>BoxV2.sol</code>, <code>TestToken.sol</code>, <code>ERC721.sol</code>, <code>ERC1155.sol</code>.
+        </p>
+      </Section>
 
-      <h2>Paxeer-Native Contracts</h2>
+      <Section id="precompiles" title="Precompile interfaces">
+        <p className={m3.body}>
+          Addresses are the constants in <code>paxeer-network/contracts/src/precompiles/</code> (same values in <code>paxeer-network/precompiles/</code>).
+        </p>
+        <MethodTable
+          columns={['Interface', 'Address', 'Purpose']}
+          rows={[
+            ['IAddr.sol', '0x0000000000000000000000000000000000001004', 'EVM ↔ Cosmos address map'],
+            ['IBank.sol', '0x0000000000000000000000000000000000001001', 'Native bank send and balance'],
+            ['IWasmd.sol', '0x0000000000000000000000000000000000001002', 'CosmWasm calls from EVM'],
+            ['IJson.sol', '0x0000000000000000000000000000000000001003', 'JSON extract helpers'],
+          ]}
+        />
+      </Section>
 
-      <p>
-        The contracts under <code>paxeer-network/contracts/</code> are part of the Paxeer chain itself. They provide EVM-side interfaces to chain functionality.
-      </p>
-
-      <h3>Core Contracts</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Contract</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>WPAX.sol</code></td>
-            <td>Wrapped PAX (ERC-20 wrapper for native PAX gas token)</td>
-          </tr>
-          <tr>
-            <td><code>CW20ERC20Pointer.sol</code></td>
-            <td>EVM pointer for Cosmos CW20 tokens</td>
-          </tr>
-          <tr>
-            <td><code>CW721ERC721Pointer.sol</code></td>
-            <td>EVM pointer for Cosmos CW721 NFTs</td>
-          </tr>
-          <tr>
-            <td><code>CW1155ERC1155Pointer.sol</code></td>
-            <td>EVM pointer for Cosmos CW1155 multi-tokens</td>
-          </tr>
-          <tr>
-            <td><code>NativePaxTokensERC20.sol</code></td>
-            <td>ERC-20 interface for native Cosmos tokens</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Precompile Interfaces</h3>
-
-      <p>
-        Solidity interfaces for Paxeer's native precompiles:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Interface</th>
-            <th>Precompile Address</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>IAddr.sol</code></td>
-            <td>TBD</td>
-            <td>Address conversion (EVM ↔ Cosmos)</td>
-          </tr>
-          <tr>
-            <td><code>IBank.sol</code></td>
-            <td>TBD</td>
-            <td>Native token operations</td>
-          </tr>
-          <tr>
-            <td><code>IWasmd.sol</code></td>
-            <td>TBD</td>
-            <td>CosmWasm contract calls from EVM</td>
-          </tr>
-          <tr>
-            <td><code>IJson.sol</code></td>
-            <td>TBD</td>
-            <td>JSON parsing and manipulation</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Note:</strong> Precompile addresses are not documented in the contract source. Check deployment artifacts or chain configuration for actual addresses.
-      </div>
-
-      <h3>Testing Contracts</h3>
-
-      <p>
-        Development and testing utilities:
-      </p>
-
-      <ul>
-        <li><code>EVMCompatibilityTester.sol</code> — EVM compatibility validation</li>
-        <li><code>TransientStorageTester.sol</code> — EIP-1153 transient storage tests</li>
-        <li><code>SelfDestructTester.sol</code> — SELFDESTRUCT behavior verification</li>
-        <li><code>SnapshotRevertTester.sol</code> — State snapshot and revert testing</li>
-        <li><code>SstoreGasTest.sol</code> — SSTORE gas cost verification</li>
-        <li><code>ProxySwapTester.sol</code>, <code>MultiHopSwapTester.sol</code> — DEX testing</li>
-        <li><code>MultiSender.sol</code>, <code>BatchCallAndSponsor.sol</code> — Batch operations</li>
-        <li><code>Box.sol</code>, <code>BoxV2.sol</code> — Upgradeable proxy testing</li>
-        <li><code>TestToken.sol</code>, <code>ERC721.sol</code>, <code>ERC1155.sol</code> — Token testing</li>
-      </ul>
-
-      <h3>Build & Test</h3>
-
-      <p>
-        The Paxeer contracts support both Foundry and Hardhat workflows:
-      </p>
-
-      <pre><code>{`# Foundry
-cd paxeer-network/contracts
+      <Section id="build" title="Build">
+        <SnippetBlock
+          method="forge build / npx hardhat compile"
+          args="Solidity 0.8.28, evmVersion prague"
+          source="paxeer-network/contracts/README.md, paxeer-network/contracts/hardhat.config.js"
+          purpose="Compile Paxeer-native contracts with Foundry or Hardhat against local :8545."
+          code={`cd paxeer-network/contracts
 forge install
 forge build
 
-# Hardhat
-cd paxeer-network/contracts
 npm install
 npx hardhat compile
-npx hardhat test --network paxlocal`}</code></pre>
+npx hardhat test --network paxlocal`}
+        />
+        <MethodTable
+          columns={['Hardhat network', 'URL']}
+          rows={[
+            ['paxlocal', 'http://127.0.0.1:8545'],
+            ['devnet', 'https://evm-rpc.arctic-1.paxnetwork.io/'],
+          ]}
+        />
+        <p className={m3.body}>
+          URLs are the <code>networks</code> entries in <code>paxeer-network/contracts/hardhat.config.js</code>. That file is not a LayerX RPC.
+        </p>
+        <Subhead>Pointer bytecode</Subhead>
+        <p className={m3.body}>
+          After a pointer change: <code>forge build</code>, copy bytecode from <code>contracts/out/</code> into the matching <code>.bin</code> under <code>modules/evm/contracts/</code>, restart <code>paxd</code>.
+        </p>
+      </Section>
 
-      <p>
-        Hardhat configuration (<code>hardhat.config.js</code>) targets Solidity 0.8.28 with Prague EVM and includes networks:
-      </p>
+      <Section id="layerx" title="LayerX settlement">
+        <p className={m3.body}>
+          Root <code>contracts/</code> is owned by LayerX governance and deployed on Paxeer. Paxeer validators do not operate these contracts.
+        </p>
+        <MethodTable
+          columns={['Contract', 'Purpose']}
+          rows={[
+            ['CheckpointRegistry.sol', 'Checkpoint settlement: state roots, heights, timestamps'],
+            ['LayerXCustody.sol', 'Custody of USDL backing USDX'],
+            ['GuarantorBond.sol', 'Guarantor collateral and slashing'],
+            ['WithdrawalClaims.sol', 'Exit claims against checkpoint merkle proofs'],
+            ['EmergencyExit.sol', 'Last-resort exit if the LayerX sequencer halts'],
+          ]}
+        />
+        <p className={m3.body}>
+          Supporting dirs in that tree: <code>challenge/</code>, <code>custody/</code>, <code>governance/</code>, <code>interfaces/</code>, <code>libraries/</code>, <code>manager/</code>, <code>security/</code>, <code>storage/</code>, <code>config/</code>, <code>deployment/</code>.
+        </p>
+        <Callout label="Addresses">
+          No mainnet or testnet deployment addresses are checked in. Do not invent them. Look at <code>contracts/deployment/</code> only for scripts and helpers that exist in git.
+        </Callout>
+        <MethodTable
+          columns={['', 'Paxeer-native', 'LayerX settlement']}
+          rows={[
+            ['Path', 'paxeer-network/contracts/', 'contracts/'],
+            ['Role', 'Pointers, WPAX, testers', 'Checkpoints, custody, exits'],
+            ['Deploy', 'Chain utilities and precompile interfaces', 'Ordinary contracts on Paxeer'],
+            ['Control', 'Paxeer chain', 'LayerX governance'],
+          ]}
+        />
+      </Section>
 
-      <ul>
-        <li><code>paxlocal</code> — <code>http://127.0.0.1:8545</code> (Docker cluster)</li>
-        <li><code>devnet</code> — <code>https://evm-rpc.arctic-1.paxnetwork.io/</code></li>
-      </ul>
-
-      <h3>Updating Pointer Contracts</h3>
-
-      <p>
-        When pointer contract bytecode changes:
-      </p>
-
-      <ol>
-        <li>Compile with Foundry: <code>forge build</code></li>
-        <li>Extract bytecode from <code>contracts/out/</code></li>
-        <li>Copy to corresponding <code>.bin</code> file under <code>modules/evm/contracts/</code></li>
-        <li>Restart <code>paxd</code></li>
-      </ol>
-
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/contracts/README.md</code>, <code>paxeer-network/contracts/src/</code>
-      </div>
-
-      <h2>LayerX Settlement Contracts</h2>
-
-      <p>
-        The contracts at the repository root (<code>contracts/</code>) implement LayerX settlement on Paxeer. These contracts are <strong>deployed on Paxeer</strong> but are <strong>owned by LayerX</strong> for checkpoint settlement, custody, and exits.
-      </p>
-
-      <h3>Settlement Contracts</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Contract</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>CheckpointRegistry.sol</code></td>
-            <td>LayerX checkpoint settlement (state root hashes, block numbers, timestamps)</td>
-          </tr>
-          <tr>
-            <td><code>LayerXCustody.sol</code></td>
-            <td>Custody of USDL backing USDX (LayerX L1 asset held on Paxeer)</td>
-          </tr>
-          <tr>
-            <td><code>GuarantorBond.sol</code></td>
-            <td>Guarantor collateral and slashing for LayerX sequencer/validator set</td>
-          </tr>
-          <tr>
-            <td><code>WithdrawalClaims.sol</code></td>
-            <td>User exit claims from LayerX to Paxeer (merkle proofs against checkpoints)</td>
-          </tr>
-          <tr>
-            <td><code>EmergencyExit.sol</code></td>
-            <td>Last-resort withdrawal mechanism if LayerX sequencer halts</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Supporting Directories</h3>
-
-      <ul>
-        <li><code>challenge/</code> — Challenge and dispute contracts</li>
-        <li><code>custody/</code> — Custody-related helpers</li>
-        <li><code>governance/</code> — LayerX governance contracts</li>
-        <li><code>interfaces/</code> — Contract interfaces</li>
-        <li><code>libraries/</code> — Shared libraries (merkle proofs, signature verification)</li>
-        <li><code>manager/</code> — Settlement manager contracts</li>
-        <li><code>security/</code> — Security modules (pausability, access control)</li>
-        <li><code>storage/</code> — Storage layout contracts</li>
-        <li><code>config/</code> — Deployment configuration</li>
-        <li><code>deployment/</code> — Deployment scripts and artifacts</li>
-      </ul>
-
-      <h3>Deployment Addresses</h3>
-
-      <p>
-        <strong>No deployment addresses are documented in the tree.</strong> Check <code>contracts/deployment/</code> or the LayerX dashboard for deployed contract addresses on Paxeer mainnet.
-      </p>
-
-      <div className="source-note">
-        <strong>Warning:</strong> Do not invent or assume contract addresses. If not in the source tree, they are not public.
-      </div>
-
-      <h3>Contract Ownership</h3>
-
-      <p>
-        LayerX settlement contracts are owned and controlled by LayerX governance, not by Paxeer validators. Paxeer provides the settlement layer; LayerX operates the settlement contracts.
-      </p>
-
-      <div className="source-note">
-        <strong>Source:</strong> <code>contracts/</code> at repository root
-      </div>
-
-      <h2>Key Distinctions</h2>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Aspect</th>
-            <th>Paxeer-native</th>
-            <th>LayerX settlement</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Location</strong></td>
-            <td><code>paxeer-network/contracts/</code></td>
-            <td><code>contracts/</code> (root)</td>
-          </tr>
-          <tr>
-            <td><strong>Purpose</strong></td>
-            <td>Chain utilities, pointers, testing</td>
-            <td>LayerX checkpoints, custody, exits</td>
-          </tr>
-          <tr>
-            <td><strong>Deployment</strong></td>
-            <td>Part of Paxeer chain (precompiles, pointers)</td>
-            <td>Deployed as contracts on Paxeer</td>
-          </tr>
-          <tr>
-            <td><strong>Ownership</strong></td>
-            <td>Paxeer chain</td>
-            <td>LayerX governance</td>
-          </tr>
-          <tr>
-            <td><strong>Trust boundary</strong></td>
-            <td>Paxeer validators</td>
-            <td>LayerX sequencer + Paxeer settlement</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="prev-next">
-        <Link href="/rest-grpc">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">REST & gRPC</div>
-        </Link>
-        <Link href="/docker">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Docker</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/rest-grpc', title: 'REST & gRPC' }}
+        next={{ href: '/docker', title: 'Docker' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/docker/page.tsx
+++ b/paxeer-docs/src/app/docker/page.tsx
@@ -1,361 +1,174 @@
 import { DocsLayout } from '@/components/DocsLayout'
-import Link from 'next/link'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 
 export default function Docker() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Docker Development</h1>
-        <p className="page-description">
-          Local Docker clusters, state-sync RPC nodes, and monitoring for Paxeer development and testing.
+    <DocsLayout pageTitle="Docker">
+      <PageLead overline="make docker-cluster-start · 192.168.10.0/24 · node0 :8545" source="paxeer-network/docker/docker-compose.yml, paxeer-network/Makefile">
+        <p>
+          Four-validator localnet on bridge subnet <code>192.168.10.0/24</code>. Node0 publishes EVM JSON-RPC at <code>8545-8546</code> and gRPC at <code>9090-9091</code>. Tendermint ports are the host range <code>26656-26658</code>.
         </p>
-      </div>
+        <p>
+          Image <code>pax-chain/localnode</code> from <code>paxeer-network/Dockerfile</code>. Platform defaults to <code>linux/amd64</code> unless <code>DOCKER_PLATFORM</code> is set.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/docker/</code>, <code>paxeer-network/Makefile</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'Node0 EVM', value: '8545-8546' },
+          { label: 'Node0 gRPC', value: '9090-9091' },
+          { label: 'Subnet', value: '192.168.10.0/24' },
+          { label: 'Prometheus host', value: ':9099' },
+        ]}
+      />
 
-      <h2>Prerequisites</h2>
+      <JumpNav
+        items={[
+          { id: 'prereq', label: 'Prerequisites' },
+          { id: 'cluster', label: 'Four-node cluster' },
+          { id: 'ports', label: 'Ports' },
+          { id: 'env', label: 'Env' },
+          { id: 'compose', label: 'Compose files' },
+          { id: 'monitor', label: 'Monitoring' },
+          { id: 'statesync', label: 'State sync' },
+        ]}
+      />
 
-      <h3>macOS</h3>
+      <Section id="prereq" title="Prerequisites">
+        <p className={m3.body}>
+          macOS: Docker Desktop from docs.docker.com. Ubuntu: Docker Engine plus Compose from the Docker install docs.
+        </p>
+      </Section>
 
-      <p>
-        Install Docker Desktop from <a href="https://docs.docker.com/desktop/install/mac-install/">docs.docker.com/desktop/install/mac-install/</a>
-      </p>
-
-      <h3>Ubuntu</h3>
-
-      <p>
-        Install Docker Engine and Docker Compose:
-      </p>
-
-      <ul>
-        <li>Docker: <a href="https://docs.docker.com/engine/install/ubuntu/">docs.docker.com/engine/install/ubuntu/</a></li>
-        <li>Docker Compose: <a href="https://docs.docker.com/compose/install/other/">docs.docker.com/compose/install/other/</a></li>
-      </ul>
-
-      <h2>Four-Node Local Cluster</h2>
-
-      <p>
-        The standard development setup runs a four-validator Paxeer cluster on a private network (<code>192.168.10.0/24</code>).
-      </p>
-
-      <h3>Start Cluster</h3>
-
-      <pre><code>{`# Build and start (first time or after code changes)
-make docker-cluster-start
-
-# Quick start (skip build if paxd binary exists)
-make docker-cluster-start-skipbuild`}</code></pre>
-
-      <p>
-        This launches four <code>pax-node-*</code> containers. Genesis files and logs are generated under <code>build/generated/</code>.
-      </p>
-
-      <h3>Node Ports</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Node</th>
-            <th>P2P</th>
-            <th>RPC</th>
-            <th>gRPC</th>
-            <th>EVM RPC</th>
-            <th>IP</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>node0</td>
-            <td>26656-26658</td>
-            <td>26657</td>
-            <td>9090-9091</td>
-            <td>8545-8546</td>
-            <td>192.168.10.10</td>
-          </tr>
-          <tr>
-            <td>node1</td>
-            <td>26659-26661</td>
-            <td>26660</td>
-            <td>9092-9093</td>
-            <td>8547-8548</td>
-            <td>192.168.10.11</td>
-          </tr>
-          <tr>
-            <td>node2</td>
-            <td>26662-26664</td>
-            <td>26663</td>
-            <td>9094-9095</td>
-            <td>8549-8550</td>
-            <td>192.168.10.12</td>
-          </tr>
-          <tr>
-            <td>node3</td>
-            <td>26665-26667</td>
-            <td>26666</td>
-            <td>9096-9097</td>
-            <td>8551-8552</td>
-            <td>192.168.10.13</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Monitor Logs</h3>
-
-      <pre><code>{`# Tail logs for node 0
-tail -f build/generated/logs/paxd-0.log
-
-# View all logs
-ls -l build/generated/logs/`}</code></pre>
-
-      <h3>SSH Into Container</h3>
-
-      <pre><code>{`# List containers
+      <Section id="cluster" title="Four-node cluster">
+        <SnippetBlock
+          method="make docker-cluster-start"
+          args="build-docker-node, then four pax-node-* containers"
+          source="paxeer-network/Makefile"
+          purpose="Build the localnode image and start the four-validator cluster."
+          code={`make docker-cluster-start
+make docker-cluster-start-skipbuild`}
+        />
+        <p className={m3.body}>
+          Genesis and logs land under <code>build/generated/</code>. Single-node (<code>make build-docker-node && make run-local-node</code>) is for minimal checks only.
+        </p>
+        <SnippetBlock
+          method="tail / docker exec"
+          args="pax-node-0"
+          source="paxeer-network/docker/"
+          purpose="Follow node0 logs or open a shell in the container."
+          code={`tail -f build/generated/logs/paxd-0.log
+ls -l build/generated/logs/
 docker ps -a
+docker exec -it pax-node-0 /bin/bash`}
+        />
+      </Section>
 
-# SSH into a node
-docker exec -it pax-node-0 /bin/bash`}</code></pre>
+      <Section id="ports" title="Host ports">
+        <p className={m3.body}>
+          Published mappings from <code>paxeer-network/docker/docker-compose.yml</code>. Container Tendermint is always <code>26656-26658</code>; host ranges shift per node.
+        </p>
+        <MethodTable
+          columns={['Node', 'Tendermint host', 'gRPC host', 'EVM host', 'IP']}
+          rows={[
+            ['node0 / pax-node-0', '26656-26658', '9090-9091', '8545-8546', '192.168.10.10'],
+            ['node1 / pax-node-1', '26659-26661', '9092-9093', '8547-8548', '192.168.10.11'],
+            ['node2 / pax-node-2', '26662-26664', '9094-9095', '8549-8550', '192.168.10.12'],
+            ['node3 / pax-node-3', '26665-26667', '9096-9097', '8551-8552', '192.168.10.13'],
+          ]}
+        />
+        <Callout label="REST :1317">
+          The SDK default REST address is <code>tcp://0.0.0.0:1317</code>. This compose file does not publish 1317 on the host.
+        </Callout>
+      </Section>
 
-      <h3>Environment Variables</h3>
+      <Section id="env" title="Environment">
+        <MethodTable
+          columns={['Variable', 'Purpose']}
+          rows={[
+            ['NUM_ACCOUNTS', 'Test accounts to create'],
+            ['SKIP_BUILD', 'Skip binary rebuild'],
+            ['INVARIANT_CHECK_INTERVAL', 'Invariant check frequency'],
+            ['UPGRADE_VERSION_LIST', 'Upgrade version schedule'],
+            ['MOCK_BALANCES', 'Mock balances (node0)'],
+            ['GIGA_EXECUTOR', 'Giga executor backend'],
+            ['GIGA_OCC', 'Optimistic concurrency'],
+            ['RECEIPT_BACKEND', 'Receipt storage backend'],
+            ['AUTOBAHN', 'Autobahn consensus path'],
+            ['GIGA_STORAGE', 'Giga storage engine'],
+            ['GIGA_MIGRATE_FROM_MEMIAVL', 'Migrate MEMIAVL → Giga'],
+            ['GIGA_FLATKV_ONLY', 'Flat KV only'],
+          ]}
+        />
+      </Section>
 
-      <p>
-        The cluster supports environment variable configuration:
-      </p>
+      <Section id="compose" title="Compose files">
+        <MethodTable
+          columns={['File', 'Purpose']}
+          rows={[
+            ['docker/docker-compose.yml', 'Four-node cluster'],
+            ['docker/docker-compose.monitoring.yml', 'Prometheus + Grafana overlay'],
+            ['docker/docker-compose.giga-mixed.yml', 'Mixed Giga / legacy storage'],
+          ]}
+        />
+        <p className={m3.body}>
+          Mounts: <code>$PROJECT_HOME</code> → <code>/pax-protocol/pax-chain</code>, <code>$GO_PKG_PATH/mod</code> → <code>/root/go/pkg/mod</code>, <code>$GOCACHE</code> → <code>/root/.cache/go-build</code>.
+        </p>
+        <Subhead>Local node scripts</Subhead>
+        <p className={m3.body}>
+          <code>docker/localnode/scripts/</code>: <code>step0_build.sh</code>, <code>step1_configure_init.sh</code>, <code>step2_genesis.sh</code>, <code>step3_add_validator_to_genesis.sh</code>, <code>step4_config_override.sh</code>, <code>step5_start_pax.sh</code>, <code>deploy.sh</code>.
+        </p>
+        <Subhead>RPC node scripts</Subhead>
+        <p className={m3.body}>
+          <code>docker/rpcnode/scripts/</code>: <code>step0_build.sh</code>, <code>step1_configure_init.sh</code>, <code>step2_start_pax.sh</code>, <code>deploy.sh</code>.
+        </p>
+      </Section>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Variable</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>NUM_ACCOUNTS</code></td>
-            <td>Number of test accounts to create</td>
-          </tr>
-          <tr>
-            <td><code>SKIP_BUILD</code></td>
-            <td>Skip binary rebuild</td>
-          </tr>
-          <tr>
-            <td><code>INVARIANT_CHECK_INTERVAL</code></td>
-            <td>State invariant check frequency</td>
-          </tr>
-          <tr>
-            <td><code>UPGRADE_VERSION_LIST</code></td>
-            <td>Chain upgrade version schedule</td>
-          </tr>
-          <tr>
-            <td><code>MOCK_BALANCES</code></td>
-            <td>Use mock balance data</td>
-          </tr>
-          <tr>
-            <td><code>GIGA_EXECUTOR</code></td>
-            <td>Enable Giga executor backend</td>
-          </tr>
-          <tr>
-            <td><code>GIGA_OCC</code></td>
-            <td>Enable optimistic concurrency control</td>
-          </tr>
-          <tr>
-            <td><code>RECEIPT_BACKEND</code></td>
-            <td>Receipt storage backend</td>
-          </tr>
-          <tr>
-            <td><code>AUTOBAHN</code></td>
-            <td>Enable Autobahn optimizations</td>
-          </tr>
-          <tr>
-            <td><code>GIGA_STORAGE</code></td>
-            <td>Enable Giga storage engine</td>
-          </tr>
-          <tr>
-            <td><code>GIGA_MIGRATE_FROM_MEMIAVL</code></td>
-            <td>Migrate from MEMIAVL to Giga</td>
-          </tr>
-          <tr>
-            <td><code>GIGA_FLATKV_ONLY</code></td>
-            <td>Use flat key-value storage only</td>
-          </tr>
-        </tbody>
-      </table>
+      <Section id="monitor" title="Monitoring">
+        <SnippetBlock
+          method="make docker-cluster-start-monitoring"
+          args="Prometheus host :9099, Grafana :3000"
+          source="paxeer-network/docker/docker-compose.monitoring.yml"
+          purpose="Start the four-node cluster plus Prometheus (host 9099) and Grafana (host 3000)."
+          code={`make docker-cluster-start-monitoring
+make docker-cluster-stop-monitoring
 
-      <h2>Single Node (Not Recommended)</h2>
-
-      <p>
-        For minimal testing only:
-      </p>
-
-      <pre><code>{`make build-docker-node && make run-local-node`}</code></pre>
-
-      <p>
-        The four-node cluster is preferred for realistic consensus behavior.
-      </p>
-
-      <h2>Compose Files</h2>
-
-      <table>
-        <thead>
-          <tr>
-            <th>File</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>docker-compose.yml</code></td>
-            <td>Four-node cluster (base configuration)</td>
-          </tr>
-          <tr>
-            <td><code>docker-compose.monitoring.yml</code></td>
-            <td>Prometheus + Grafana monitoring overlay</td>
-          </tr>
-          <tr>
-            <td><code>docker-compose.giga-mixed.yml</code></td>
-            <td>Mixed Giga/legacy storage testing overlay</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>Monitoring with Prometheus & Grafana</h2>
-
-      <p>
-        Start the cluster with monitoring containers:
-      </p>
-
-      <pre><code>{`# Start cluster + monitoring together
-make docker-cluster-start-monitoring
-
-# Stop cluster + monitoring together
-make docker-cluster-stop-monitoring`}</code></pre>
-
-      <p>
-        Or run monitoring scripts independently:
-      </p>
-
-      <pre><code>{`# Start Prometheus
 ./docker/monitornode/scripts/start-prometheus.sh
-
-# Start Grafana
 ./docker/monitornode/scripts/start-grafana.sh
-
-# Stop
 ./docker/monitornode/scripts/stop-prometheus.sh
-./docker/monitornode/scripts/stop-grafana.sh`}</code></pre>
+./docker/monitornode/scripts/stop-grafana.sh`}
+        />
+        <MethodTable
+          columns={['UI', 'Host']}
+          rows={[
+            ['Grafana', 'http://localhost:3000 (admin / admin)'],
+            ['Prometheus', 'http://localhost:9099'],
+          ]}
+        />
+        <p className={m3.body}>
+          Prometheus is published as <code>9099:9090</code> so it does not collide with node0 gRPC on host 9090.
+        </p>
+      </Section>
 
-      <h3>Access UIs</h3>
-
-      <ul>
-        <li><strong>Grafana:</strong> <code>http://localhost:3000</code> (login: <code>admin</code> / <code>admin</code>)</li>
-        <li><strong>Prometheus:</strong> <code>http://localhost:9090</code></li>
-      </ul>
-
-      <h2>State Sync RPC Node</h2>
-
-      <p>
-        Test state-sync by starting an additional RPC node that syncs from the four-node cluster:
-      </p>
-
-      <pre><code>{`# Prerequisite: Start a 4-node cluster
-make docker-cluster-start
-
-# Wait until block height exceeds 500 (configurable via app.toml)
+      <Section id="statesync" title="State-sync RPC node">
+        <SnippetBlock
+          method="make run-rpc-node"
+          args="requires a running 4-node cluster"
+          source="paxeer-network/Makefile, docker/rpcnode/scripts/"
+          purpose="Add a state-sync RPC node after the cluster is past the configured height."
+          code={`make docker-cluster-start
 paxd status | jq
+make run-rpc-node`}
+        />
+        <p className={m3.body}>
+          Fast iteration: edit under <code>paxeer-network/</code>, <code>make build-docker-node</code>, <code>make docker-cluster-start</code>. No sibling-repo <code>go.mod</code> replace is required.
+        </p>
+      </Section>
 
-# Start state-sync RPC node
-make run-rpc-node`}</code></pre>
-
-      <p>
-        The RPC node bootstraps from a recent snapshot instead of replaying full history.
-      </p>
-
-      <div className="source-note">
-        <strong>Scripts:</strong> <code>docker/rpcnode/scripts/</code>
-      </div>
-
-      <h2>Fast Iteration & Local Development</h2>
-
-      <p>
-        Docker mounts local source directories, so you can edit code and rebuild without re-pulling dependencies:
-      </p>
-
-      <ol>
-        <li>Edit code under <code>paxeer-network/</code> (modules, consensus, SDK, storage, WASM)</li>
-        <li>Rebuild the node image: <code>make build-docker-node</code></li>
-        <li>Restart the cluster: <code>make docker-cluster-start</code></li>
-      </ol>
-
-      <p>
-        No <code>go.mod</code> replacements or sibling repositories required. The monorepo includes all dependencies.
-      </p>
-
-      <h3>Volumes</h3>
-
-      <p>
-        The compose files mount:
-      </p>
-
-      <ul>
-        <li><code>$PROJECT_HOME</code> → <code>/pax-protocol/pax-chain</code> (source tree)</li>
-        <li><code>$GO_PKG_PATH/mod</code> → <code>/root/go/pkg/mod</code> (Go module cache)</li>
-        <li><code>$GOCACHE</code> → <code>/root/.cache/go-build</code> (Go build cache)</li>
-      </ul>
-
-      <h2>Deployment Scripts</h2>
-
-      <p>
-        Each node type has a multi-step initialization flow:
-      </p>
-
-      <h3>Local Node</h3>
-
-      <ul>
-        <li><code>step0_build.sh</code> — Build <code>paxd</code> binary</li>
-        <li><code>step1_configure_init.sh</code> — Initialize node configuration</li>
-        <li><code>step2_genesis.sh</code> — Generate genesis file</li>
-        <li><code>step3_add_validator_to_genesis.sh</code> — Add validator to genesis</li>
-        <li><code>step4_config_override.sh</code> — Override config files (ports, peers)</li>
-        <li><code>step5_start_pax.sh</code> — Start <code>paxd</code></li>
-        <li><code>deploy.sh</code> — Orchestrates all steps</li>
-      </ul>
-
-      <h3>RPC Node</h3>
-
-      <ul>
-        <li><code>step0_build.sh</code> — Build <code>paxd</code></li>
-        <li><code>step1_configure_init.sh</code> — Initialize for state-sync</li>
-        <li><code>step2_start_pax.sh</code> — Start with state-sync enabled</li>
-        <li><code>deploy.sh</code> — Orchestrates RPC node setup</li>
-      </ul>
-
-      <div className="source-note">
-        <strong>Scripts:</strong> <code>docker/localnode/scripts/</code>, <code>docker/rpcnode/scripts/</code>
-      </div>
-
-      <h2>Docker Image</h2>
-
-      <p>
-        The cluster uses the <code>pax-chain/localnode</code> image built from <code>paxeer-network/Dockerfile</code>. Platform defaults to <code>linux/amd64</code> but can be overridden with <code>DOCKER_PLATFORM</code>.
-      </p>
-
-      <h2>Network Configuration</h2>
-
-      <p>
-        The cluster creates a <code>localnet</code> bridge network with subnet <code>192.168.10.0/24</code>. Each node has a static IP for deterministic peer configuration.
-      </p>
-
-      <div className="prev-next">
-        <Link href="/contracts">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Contracts</div>
-        </Link>
-        <Link href="/sdk">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">SDK</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/contracts', title: 'Contracts' }}
+        next={{ href: '/sdk', title: 'SDK' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/interchain/page.tsx
+++ b/paxeer-docs/src/app/interchain/page.tsx
@@ -1,298 +1,133 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function Interchain() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Interchain (IBC)</h1>
-        <p className="page-description">
-          Inter-Blockchain Communication protocol implementation on Paxeer.
+    <DocsLayout pageTitle="Interchain">
+      <PageLead overline="paxeer-network/interchain/ · ibc-go fork · hyperpax_125-1" source="paxeer-network/interchain/">
+        <p>
+          In-tree ibc-go fork for <code>paxd</code>. Not a published module. IBC is Cosmos-level: client, connection, channel, then packets. EVM contracts do not send or receive IBC packets directly.
         </p>
-      </div>
+        <p>
+          Relayers need chain ID <code>hyperpax_125-1</code> (EVM 125) and a Paxeer RPC you operate. There is no public LayerX RPC on this page.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/interchain/</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'Tree', value: 'paxeer-network/interchain/' },
+          { label: 'Chain ID', value: 'hyperpax_125-1' },
+          { label: 'EVM chain ID', value: '125' },
+          { label: 'Transfer app', value: 'ICS-20' },
+        ]}
+      />
 
-      <h2>Overview</h2>
+      <JumpNav
+        items={[
+          { id: 'core', label: 'Core' },
+          { id: 'apps', label: 'Apps' },
+          { id: 'clients', label: 'Light clients' },
+          { id: 'tree', label: 'Tree' },
+          { id: 'cli', label: 'CLI' },
+          { id: 'evm', label: 'IBC and EVM' },
+        ]}
+      />
 
-      <p>
-        Paxeer includes an in-tree fork of <a href="https://github.com/cosmos/ibc-go">ibc-go</a>, the Cosmos SDK's Inter-Blockchain Communication (IBC) protocol implementation. This enables Paxeer to connect with other IBC-enabled chains for cross-chain asset transfers and messaging.
-      </p>
+      <Section id="core" title="Core stack">
+        <MethodTable
+          columns={['Component', 'ICS', 'Purpose']}
+          rows={[
+            ['Client', 'ICS-02', 'Light-client verification of a remote chain'],
+            ['Connection', 'ICS-03', 'Authenticated connection'],
+            ['Channel', 'ICS-04', 'Ordered or unordered packet delivery'],
+            ['Port', 'ICS-05', 'Module registration and routing'],
+            ['Commitment', 'ICS-23', 'Proofs'],
+            ['Host', 'ICS-24', 'Host requirements'],
+          ]}
+        />
+      </Section>
 
-      <h3>What is IBC?</h3>
+      <Section id="apps" title="Applications">
+        <Subhead>ICS-20 transfer</Subhead>
+        <p className={m3.body}>
+          <code>modules/apps/transfer</code> moves tokens. Paxeer-origin assets leave as ICS-20 packets. Remote assets arrive as IBC-prefixed denoms.
+        </p>
+        <Subhead>ICS-27 interchain accounts</Subhead>
+        <p className={m3.body}>
+          One chain controls an account on another. Used for remote staking and governance, not for LayerX settlement.
+        </p>
+      </Section>
 
-      <p>
-        IBC is an end-to-end, connection-oriented, stateful protocol for reliable, ordered, and authenticated communication between heterogeneous blockchains. It handles transport across different sovereign blockchains without relying on a trusted third party.
-      </p>
+      <Section id="clients" title="Light clients">
+        <MethodTable
+          columns={['Client', 'ICS', 'Purpose']}
+          rows={[
+            ['Tendermint', 'ICS-07', 'Tendermint / CometBFT counterparties'],
+            ['Solo machine', 'ICS-06', 'Single-signer counterparties'],
+          ]}
+        />
+        <Callout label="09-localhost">
+          <code>paxeer-network/interchain/README.md</code> states the localhost client is currently non-functional in this fork.
+        </Callout>
+      </Section>
 
-      <h2>Location</h2>
+      <Section id="tree" title="Tree">
+        <MethodTable
+          columns={['Path', 'Purpose']}
+          rows={[
+            ['modules/core/', 'Client, connection, channel'],
+            ['modules/apps/', 'transfer, interchain accounts'],
+            ['modules/light-clients/', 'ICS-07, ICS-06, 09-localhost'],
+            ['proto/', 'IBC protobufs'],
+          ]}
+        />
+        <p className={m3.body}>
+          Upstream version is the ibc-go pin in <code>paxeer-network/interchain/go.mod</code>. Do not assume latest upstream ibc-go.
+        </p>
+      </Section>
 
-      <p>
-        The IBC implementation is vendored under <code>paxeer-network/interchain/</code> within the monorepo. This is <strong>not</strong> a standalone published module but an in-tree dependency for <code>paxd</code>.
-      </p>
-
-      <h2>Core IBC Components</h2>
-
-      <p>
-        Paxeer's IBC implementation includes the standard IBC stack:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Component</th>
-            <th>ICS Spec</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Client</strong></td>
-            <td>ICS-02</td>
-            <td>Light client verification of remote chain state</td>
-          </tr>
-          <tr>
-            <td><strong>Connection</strong></td>
-            <td>ICS-03</td>
-            <td>Establish authenticated connections between chains</td>
-          </tr>
-          <tr>
-            <td><strong>Channel</strong></td>
-            <td>ICS-04</td>
-            <td>Packet delivery over connections (ordered/unordered)</td>
-          </tr>
-          <tr>
-            <td><strong>Port</strong></td>
-            <td>ICS-05</td>
-            <td>Module registration and packet routing</td>
-          </tr>
-          <tr>
-            <td><strong>Commitment</strong></td>
-            <td>ICS-23</td>
-            <td>Cryptographic commitment proofs</td>
-          </tr>
-          <tr>
-            <td><strong>Host</strong></td>
-            <td>ICS-24</td>
-            <td>Chain-specific requirements and interfaces</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>IBC Applications</h2>
-
-      <p>
-        Paxeer supports standard IBC applications:
-      </p>
-
-      <h3>Fungible Token Transfers (ICS-20)</h3>
-
-      <p>
-        The <code>transfer</code> module enables cross-chain token transfers. Assets originating on Paxeer can be sent to other IBC chains, and assets from remote chains can be received on Paxeer as IBC-wrapped tokens.
-      </p>
-
-      <h3>Interchain Accounts (ICS-27)</h3>
-
-      <p>
-        Interchain Accounts allow one chain to control an account on another chain. This enables cross-chain governance, remote staking, and other advanced use cases.
-      </p>
-
-      <h2>Light Clients</h2>
-
-      <p>
-        Paxeer includes light client implementations for verifying remote chain state:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Client</th>
-            <th>ICS Spec</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><strong>Tendermint</strong></td>
-            <td>ICS-07</td>
-            <td>Light client for Tendermint/CometBFT chains</td>
-          </tr>
-          <tr>
-            <td><strong>Solo Machine</strong></td>
-            <td>ICS-06</td>
-            <td>Light client for single-signer accounts (e.g., hardware wallets)</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Note:</strong> The localhost client is currently non-functional in this fork.
-      </div>
-
-      <h2>IBC Module Structure</h2>
-
-      <p>
-        The <code>interchain/</code> directory mirrors the structure of upstream <code>ibc-go</code>:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Path</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>modules/core/</code></td>
-            <td>Core IBC protocol (client, connection, channel)</td>
-          </tr>
-          <tr>
-            <td><code>modules/apps/</code></td>
-            <td>IBC applications (transfer, interchain accounts)</td>
-          </tr>
-          <tr>
-            <td><code>modules/light-clients/</code></td>
-            <td>Light client implementations</td>
-          </tr>
-          <tr>
-            <td><code>proto/</code></td>
-            <td>Protobuf definitions for IBC types</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>Using IBC on Paxeer</h2>
-
-      <h3>Establishing a Connection</h3>
-
-      <p>
-        To connect Paxeer with another IBC-enabled chain:
-      </p>
-
-      <ol>
-        <li>Create a light client for the remote chain</li>
-        <li>Establish a connection using the client</li>
-        <li>Create a channel over the connection</li>
-        <li>Begin sending packets</li>
-      </ol>
-
-      <p>
-        Use the <code>paxd tx ibc</code> CLI commands or relayer software (e.g., Hermes, Go Relayer).
-      </p>
-
-      <h3>Cross-Chain Token Transfers</h3>
-
-      <pre><code>{`# Send 1000upax from Paxeer to another chain
-paxd tx ibc-transfer transfer \\
+      <Section id="cli" title="CLI">
+        <p className={m3.body}>
+          Open a client, a connection, a channel, then send packets. Relayers (Hermes, Go Relayer) ferry proofs. Query live channel IDs; do not assume <code>channel-0</code>.
+        </p>
+        <SnippetBlock
+          method="paxd tx ibc-transfer transfer"
+          args="port channel recipient amount --chain-id hyperpax_125-1"
+          source="paxeer-network/interchain/modules/apps/transfer/"
+          purpose="ICS-20 send. Replace channel, recipient, and amount. Native microdenom in-tree is uhpx; PAX is gas."
+          code={`paxd tx ibc-transfer transfer \\
   transfer \\
-  channel-0 \\
-  cosmos1recipient... \\
-  1000upax \\
-  --from mykey \\
-  --chain-id hyperpax_125-1`}</code></pre>
-
-      <h3>Querying IBC State</h3>
-
-      <pre><code>{`# List all IBC clients
-paxd query ibc client states
-
-# List all connections
+  <channel-id> \\
+  <recipient> \\
+  <amount>uhpx \\
+  --from <key> \\
+  --chain-id hyperpax_125-1`}
+        />
+        <SnippetBlock
+          method="paxd query ibc"
+          args="client | connection | channel"
+          source="paxeer-network/interchain/"
+          purpose="Read IBC clients, connections, and channels from a running node."
+          code={`paxd query ibc client states
 paxd query ibc connection connections
+paxd query ibc channel channels`}
+        />
+        <p className={m3.body}>
+          Relayer security depends on light-client correctness, relayer liveness (timeouts), and each chain's own IBC upgrades. Coordinate upgrades with counterparties.
+        </p>
+      </Section>
 
-# List all channels
-paxd query ibc channel channels`}</code></pre>
+      <Section id="evm" title="IBC and EVM">
+        <p className={m3.body}>
+          Solidity cannot emit IBC packets. Bridge paths that exist in this repo: pointer contracts for Cosmos tokens, precompiles for module calls, or a Cosmos tx that talks to IBC. See <Link href="/contracts">Contracts</Link>.
+        </p>
+      </Section>
 
-      <h2>Relayers</h2>
-
-      <p>
-        IBC requires off-chain relayer software to ferry packets between chains. Relayers monitor both chains and submit proof-carrying packets to complete cross-chain transfers.
-      </p>
-
-      <h3>Supported Relayers</h3>
-
-      <ul>
-        <li><a href="https://github.com/informalsystems/hermes">Hermes</a> (Rust)</li>
-        <li><a href="https://github.com/cosmos/relayer">Go Relayer</a> (Go)</li>
-      </ul>
-
-      <p>
-        Relayers must be configured with Paxeer's chain ID (<code>hyperpax_125-1</code>) and RPC endpoints.
-      </p>
-
-      <h2>IBC and EVM</h2>
-
-      <p>
-        IBC operates at the Cosmos SDK level. EVM contracts on Paxeer cannot directly send or receive IBC packets. To bridge EVM and IBC:
-      </p>
-
-      <ul>
-        <li>Use pointer contracts to expose Cosmos tokens to EVM</li>
-        <li>Use precompiles to call Cosmos modules from EVM</li>
-        <li>Deploy bridge contracts that interact with IBC via Cosmos transactions</li>
-      </ul>
-
-      <p>
-        See <Link href="/contracts">Contracts</Link> for pointer contract details.
-      </p>
-
-      <h2>IBC Protocol Versions</h2>
-
-      <p>
-        Paxeer's IBC fork is based on <code>ibc-go</code> but may diverge from upstream. Check the version in <code>interchain/go.mod</code> or the README.
-      </p>
-
-      <div className="source-note">
-        <strong>Warning:</strong> Paxeer's IBC fork may not be compatible with the latest upstream <code>ibc-go</code> releases. Test cross-chain compatibility carefully.
-      </div>
-
-      <h2>Security Considerations</h2>
-
-      <p>
-        IBC is a trust-minimized protocol, but security depends on:
-      </p>
-
-      <ul>
-        <li><strong>Light client correctness:</strong> Remote chain state must be correctly verified</li>
-        <li><strong>Relayer liveness:</strong> Packets must be relayed promptly to avoid timeouts</li>
-        <li><strong>Chain sovereignty:</strong> Each chain controls its own IBC modules and upgrades</li>
-      </ul>
-
-      <p>
-        Ensure relayers are operated by trusted parties or use multiple independent relayers.
-      </p>
-
-      <h2>IBC Upgrades</h2>
-
-      <p>
-        IBC modules can be upgraded via on-chain governance. Upgrades must be coordinated with connected chains to avoid breaking connections.
-      </p>
-
-      <h2>Resources</h2>
-
-      <ul>
-        <li><a href="https://ibcprotocol.org/">IBC Protocol Website</a></li>
-        <li><a href="https://github.com/cosmos/ibc">IBC Specification</a></li>
-        <li><a href="https://ibc.cosmos.network/">IBC Documentation</a></li>
-        <li><a href="https://github.com/cosmos/ibc-go">ibc-go Repository</a> (upstream)</li>
-      </ul>
-
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/interchain/README.md</code>
-      </div>
-
-      <div className="prev-next">
-        <Link href="/sdk">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">SDK</div>
-        </Link>
-        <Link href="/admin-hpx">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Admin & HPX</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/sdk', title: 'SDK' }}
+        next={{ href: '/admin-hpx', title: 'Admin & HPX' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/json-rpc-unsupported/page.tsx
+++ b/paxeer-docs/src/app/json-rpc-unsupported/page.tsx
@@ -1,176 +1,104 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function JsonRpcUnsupported() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Unsupported JSON-RPC Methods</h1>
-        <p className="page-description">
-          Ethereum JSON-RPC methods that are explicitly unsupported on Paxeer EVM.
+    <DocsLayout pageTitle="Unsupported Methods">
+      <PageLead overline="-32000 · registered failures · not -32601" source="paxeer-network/docs/evm_jsonrpc_unsupported.md, paxeer-network/rpc/AGENTS.md">
+        <p>
+          These Ethereum JSON-RPC names are registered on the Paxeer EVM endpoint and return a JSON-RPC error. Clients get <code>-32000</code> instead of <code>-32601</code> method-not-found.
         </p>
-      </div>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/docs/evm_jsonrpc_unsupported.md</code> and <code>paxeer-network/rpc/AGENTS.md</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'Error code', value: '-32000' },
+          { label: 'Not-found code (not used)', value: '-32601' },
+          { label: 'Local EVM HTTP', value: '127.0.0.1:8545' },
+          { label: 'Fixtures', value: 'testdata/<method>/not-supported.iox' },
+        ]}
+      />
 
-      <h2>Overview</h2>
+      <JumpNav
+        items={[
+          { id: 'methods', label: 'Methods' },
+          { id: 'error', label: 'Error body' },
+          { id: 'notes', label: 'Notes' },
+          { id: 'broader', label: 'Broader rules' },
+        ]}
+      />
 
-      <p>
-        Some Ethereum JSON-RPC methods are <strong>registered</strong> on Paxeer's EVM endpoint but return a <strong>JSON-RPC error</strong> instead of a result. This gives clients and tools a stable, documented failure (code <code>-32000</code>) rather than "method not found" (<code>-32601</code>).
-      </p>
+      <Section id="methods" title="Registered unsupported methods">
+        <MethodTable
+          columns={['Method', 'error.message', 'Reason']}
+          rows={[
+            ['eth_blobBaseFee', 'blobs not supported on this chain', 'No EIP-4844 blobs'],
+            ['eth_syncing', 'eth_syncing is not supported on Pax EVM RPC', 'BFT sync is not Ethereum sync'],
+            ['eth_newPendingTransactionFilter', 'eth_newPendingTransactionFilter is not supported on Pax EVM RPC', 'No Ethereum-style pending filter'],
+            ['debug_getRawBlock', 'debug_getRawBlock is not supported on Pax EVM RPC', 'No raw RLP block'],
+            ['debug_getRawHeader', 'debug_getRawHeader is not supported on Pax EVM RPC', 'No raw RLP header'],
+            ['debug_getRawReceipts', 'debug_getRawReceipts is not supported on Pax EVM RPC', 'No raw RLP receipts'],
+            ['debug_getRawTransaction', 'debug_getRawTransaction is not supported on Pax EVM RPC', 'No raw RLP transaction'],
+          ]}
+        />
+      </Section>
 
-      <h2>Explicitly Unsupported Methods</h2>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>Typical Error Message</th>
-            <th>Reason</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>eth_blobBaseFee</code></td>
-            <td>"blobs not supported on this chain"</td>
-            <td>EIP-4844 blob transactions not supported</td>
-          </tr>
-          <tr>
-            <td><code>eth_syncing</code></td>
-            <td>"eth_syncing is not supported on Pax EVM RPC"</td>
-            <td>Consensus model differs from Ethereum sync semantics</td>
-          </tr>
-          <tr>
-            <td><code>eth_newPendingTransactionFilter</code></td>
-            <td>"eth_newPendingTransactionFilter is not supported on Pax EVM RPC"</td>
-            <td>Instant finality, no Ethereum-style pending tx filters</td>
-          </tr>
-          <tr>
-            <td><code>debug_getRawBlock</code></td>
-            <td>"debug_getRawBlock is not supported on Pax EVM RPC"</td>
-            <td>Raw RLP block payloads not served</td>
-          </tr>
-          <tr>
-            <td><code>debug_getRawHeader</code></td>
-            <td>"debug_getRawHeader is not supported on Pax EVM RPC"</td>
-            <td>Raw RLP header payloads not served</td>
-          </tr>
-          <tr>
-            <td><code>debug_getRawReceipts</code></td>
-            <td>"debug_getRawReceipts is not supported on Pax EVM RPC"</td>
-            <td>Raw RLP receipt payloads not served</td>
-          </tr>
-          <tr>
-            <td><code>debug_getRawTransaction</code></td>
-            <td>"debug_getRawTransaction is not supported on Pax EVM RPC"</td>
-            <td>Raw RLP transaction payloads not served</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>Error Response Format</h2>
-
-      <p>
-        Unsupported methods return a standard JSON-RPC error:
-      </p>
-
-      <pre><code>{`{
+      <Section id="error" title="Error body">
+        <SnippetBlock
+          method="eth_blobBaseFee"
+          args="[]"
+          source="paxeer-network/docs/evm_jsonrpc_unsupported.md"
+          purpose="Stable -32000 failure for blob fee. Same code for every method in the table."
+          code={`{
   "jsonrpc": "2.0",
   "id": 1,
   "error": {
     "code": -32000,
     "message": "blobs not supported on this chain"
   }
-}`}</code></pre>
+}`}
+        />
+      </Section>
 
-      <h2>Behavior Notes</h2>
+      <Section id="notes" title="Method notes">
+        <Subhead>eth_syncing</Subhead>
+        <p className={m3.body}>
+          BFT consensus is not Ethereum sync. Do not poll this method for node catch-up.
+        </p>
+        <Subhead>eth_newPendingTransactionFilter</Subhead>
+        <p className={m3.body}>
+          Instant finality. A tx is in a finalized block or it is not yet submitted. There is no pending-filter surface.
+        </p>
+        <Subhead>debug_getRaw*</Subhead>
+        <p className={m3.body}>
+          Raw RLP payloads are not served. Use structured <code>eth_*</code> JSON.
+        </p>
+        <Subhead>eth_blobBaseFee</Subhead>
+        <p className={m3.body}>
+          EIP-4844 blob transactions are not on this chain.
+        </p>
+      </Section>
 
-      <h3>eth_syncing</h3>
+      <Section id="broader" title="Broader compatibility">
+        <MethodTable
+          columns={['Rule', 'Behavior']}
+          rows={[
+            ['pending tag', 'Accepted, treated as latest / safe / final'],
+            ['Uncle methods', 'Unsupported'],
+            ['Trie methods', 'Unsupported (state is not an Ethereum trie)'],
+            ['eth_mining / eth_hashrate', 'Unsupported (BFT, not PoW)'],
+          ]}
+        />
+        <p className={m3.body}>
+          Integration fixtures: <code>paxeer-network/integration_test/evm_module/rpc_io_test/testdata/&lt;method&gt;/not-supported.iox</code>. Full namespace notes: <Link href="/json-rpc">JSON-RPC</Link>.
+        </p>
+      </Section>
 
-      <p>
-        Paxeer's BFT consensus model differs fundamentally from Ethereum's sync semantics. Callers should not rely on this method to determine node sync status.
-      </p>
-
-      <h3>eth_newPendingTransactionFilter</h3>
-
-      <p>
-        Paxeer has instant finality with no Ethereum-style pending state. Transactions are either included in a finalized block or not yet submitted.
-      </p>
-
-      <h3>debug_getRaw* Methods</h3>
-
-      <p>
-        Raw RLP-encoded block, header, receipt, and transaction payloads are not served on this RPC surface. Use the standard <code>eth_*</code> endpoints which return structured JSON.
-      </p>
-
-      <h3>eth_blobBaseFee</h3>
-
-      <p>
-        Paxeer does not support EIP-4844 blob transactions. This is a permanent architectural decision, not a temporary limitation.
-      </p>
-
-      <h2>Broader Compatibility Notes</h2>
-
-      <p>
-        Beyond explicitly unsupported methods, Paxeer's RPC diverges from Ethereum in several conceptual areas:
-      </p>
-
-      <h3>No Pending Blocks</h3>
-
-      <ul>
-        <li>The <code>pending</code> block tag is accepted but treated as <code>latest</code>/<code>safe</code>/<code>final</code></li>
-        <li>All blocks are instantly finalized (BFT consensus)</li>
-      </ul>
-
-      <h3>No Uncle Blocks</h3>
-
-      <ul>
-        <li>Instant BFT finality means no uncle blocks</li>
-        <li>Uncle-related endpoints are not supported</li>
-      </ul>
-
-      <h3>No Trie Endpoints</h3>
-
-      <ul>
-        <li>Paxeer does not store state in Ethereum-style tries</li>
-        <li>Trie-related endpoints (<code>eth_getProof</code>, etc.) are not supported</li>
-      </ul>
-
-      <h3>No Proof-of-Work</h3>
-
-      <ul>
-        <li><code>eth_mining</code> and <code>eth_hashrate</code> are not supported</li>
-        <li>Paxeer uses BFT consensus, not PoW</li>
-      </ul>
-
-      <p>
-        See <Link href="/json-rpc">JSON-RPC API</Link> for full compatibility details.
-      </p>
-
-      <h2>Integration Coverage</h2>
-
-      <p>
-        Each unsupported method has dedicated integration test coverage:
-      </p>
-
-      <pre><code>{`integration_test/evm_module/rpc_io_test/testdata/<method>/not-supported.iox`}</code></pre>
-
-      <p>
-        This ensures the error responses remain stable and documented.
-      </p>
-
-      <div className="prev-next">
-        <Link href="/json-rpc">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">JSON-RPC API</div>
-        </Link>
-        <Link href="/rest-grpc">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">REST & gRPC</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/json-rpc', title: 'JSON-RPC' }}
+        next={{ href: '/rest-grpc', title: 'REST & gRPC' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/json-rpc/page.tsx
+++ b/paxeer-docs/src/app/json-rpc/page.tsx
@@ -1,313 +1,224 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function JsonRpc() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">JSON-RPC API</h1>
-        <p className="page-description">
-          Paxeer's EVM JSON-RPC interface with standard Ethereum compatibility and Paxeer-specific enhancements.
+    <DocsLayout pageTitle="JSON-RPC">
+      <PageLead overline="eth_ · pax_ · pax2_ · debug_ · EVM HTTP :8545" source="paxeer-network/rpc/README.md, paxeer-network/rpc/AGENTS.md, paxeer-network/rpc/pax_legacy.go">
+        <p>
+          EVM JSON-RPC on the node HTTP port. Docker localnet node0 publishes it at <code>127.0.0.1:8545</code> (<code>paxeer-network/docker/docker-compose.yml</code>). There is no public LayerX RPC on this surface.
         </p>
-      </div>
-
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/rpc/README.md</code> and <code>paxeer-network/rpc/AGENTS.md</code>
-      </div>
-
-      <h2>Architecture Overview</h2>
-
-      <p>
-        Paxeer provides a comprehensive RPC interface that combines standard <a href="https://ethereum.org/en/developers/docs/apis/json-rpc/">Ethereum JSON-RPC</a> compatibility with Paxeer-specific enhancements. The API is organized into three namespaces:
-      </p>
-
-      <h3>Namespace Summary</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Namespace</th>
-            <th>Transaction Visibility</th>
-            <th>Use Case</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>eth_</code></td>
-            <td>EVM transactions only</td>
-            <td>Pure EVM applications, Ethereum tooling compatibility</td>
-          </tr>
-          <tr>
-            <td><code>pax_</code></td>
-            <td>EVM + Cosmos transactions (synthetic receipts)</td>
-            <td>Full chain visibility, cross-chain event indexing</td>
-          </tr>
-          <tr>
-            <td><code>pax2_</code></td>
-            <td>EVM + Cosmos + bank transfers</td>
-            <td>Complete transaction view including native transfers</td>
-          </tr>
-          <tr>
-            <td><code>debug_</code></td>
-            <td>EVM tracing and debugging</td>
-            <td>Transaction replay, gas profiling, state inspection</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>eth_ Endpoints</h2>
-
-      <p>
-        The <code>eth_</code> prefixed endpoints provide a pure EVM-compatible view:
-      </p>
-
-      <ul>
-        <li><strong>EVM-only:</strong> Only process and return EVM transactions</li>
-        <li><strong>Ethereum tooling:</strong> Full compatibility with ethers.js, viem, web3.js, Hardhat, Foundry</li>
-        <li><strong>Cosmos-blind:</strong> Ignore Cosmos-native transactions</li>
-        <li><strong>Standard behavior:</strong> Follow Ethereum JSON-RPC spec</li>
-      </ul>
-
-      <h3>Key eth_ Methods</h3>
-
-      <ul>
-        <li><code>eth_blockNumber</code></li>
-        <li><code>eth_getBlockByNumber</code>, <code>eth_getBlockByHash</code></li>
-        <li><code>eth_getTransactionByHash</code></li>
-        <li><code>eth_getTransactionReceipt</code></li>
-        <li><code>eth_getLogs</code></li>
-        <li><code>eth_call</code>, <code>eth_estimateGas</code></li>
-        <li><code>eth_sendRawTransaction</code></li>
-        <li><code>eth_getBalance</code>, <code>eth_getCode</code></li>
-      </ul>
-
-      <h2>pax_ Endpoints</h2>
-
-      <p>
-        The <code>pax_</code> prefixed endpoints provide an enhanced view that includes both EVM and relevant Cosmos transactions:
-      </p>
-
-      <ul>
-        <li><strong>Synthetic transactions:</strong> Cosmos events (CW20, CW721) exposed as EVM logs</li>
-        <li><strong>Full visibility:</strong> See both EVM and Cosmos activity</li>
-        <li><strong>Cross-chain events:</strong> Index pointer contracts and token transfers</li>
-        <li><strong>Trace filtering:</strong> Variants to exclude pre-state check failures</li>
-      </ul>
-
-      <h3>Synthetic Transaction Endpoints</h3>
-
-      <p>
-        These endpoints bridge Cosmos and EVM by exposing Cosmos-native events as EVM-compatible logs:
-      </p>
-
-      <ul>
-        <li><code>pax_getLogs</code> — Enhanced <code>eth_getLogs</code> with synthetic logs</li>
-        <li><code>pax_getFilterLogs</code> — Enhanced <code>eth_getFilterLogs</code> with synthetic logs</li>
-        <li><code>pax_getBlockByNumber</code>, <code>pax_getBlockByHash</code> — Include synthetic transactions</li>
-        <li><code>pax_getBlockReceipts</code> — Include receipts for synthetic transactions</li>
-      </ul>
-
-      <div className="source-note">
-        <strong>Note:</strong> For synthetic transactions, use <code>eth_getTransactionReceipt</code> with the synthetic transaction hash. There is no <code>pax_getTransactionByReceipt</code>.
-      </div>
-
-      <h3>Trace Failure Filtering</h3>
-
-      <p>
-        Paxeer's unique mempool implementation means some transactions fail pre-state checks (nonce mismatches, insufficient funds, panic conditions). These are included in blocks but not executed. The following endpoints exclude them:
-      </p>
-
-      <ul>
-        <li><code>pax_traceBlockByNumberExcludeTraceFail</code></li>
-        <li><code>pax_traceBlockByHashExcludeTraceFail</code></li>
-        <li><code>pax_getTransactionReceiptExcludeTraceFail</code></li>
-        <li><code>pax_getBlockByNumberExcludeTraceFail</code></li>
-        <li><code>pax_getBlockByHashExcludeTraceFail</code></li>
-      </ul>
-
-      <h2>pax2_ Endpoints (Bank Transfers)</h2>
-
-      <p>
-        The <code>pax2_</code> namespace exposes the same block shape as <code>pax_</code> but includes <strong>bank transfers</strong> in block payloads:
-      </p>
-
-      <ul>
-        <li>Seven methods: block, block receipts, transaction counts, <code>ExcludeTraceFail</code> variants</li>
-        <li>No <code>pax2_</code> transaction or filter API</li>
-        <li>HTTP only (not WebSocket)</li>
-      </ul>
-
-      <h3>Legacy API Gating</h3>
-
-      <p>
-        Both <code>pax_*</code> and <code>pax2_*</code> are <strong>legacy APIs</strong> gated by <code>[evm].enabled_legacy_pax_apis</code> in <code>app.toml</code>:
-      </p>
-
-      <ul>
-        <li><strong>Deprecated:</strong> Scheduled for removal</li>
-        <li><strong>Allow list:</strong> Only methods in the config array are enabled</li>
-        <li><strong>Default config:</strong> Three <code>pax_*</code> address/Cosmos helpers pre-filled</li>
-        <li><strong>Docker localnet:</strong> Enables all gated methods except <code>pax_sign</code></li>
-        <li><strong>Disabled response:</strong> JSON-RPC error <code>-32601</code>, message explains deprecation</li>
-      </ul>
-
-      <div className="source-note">
-        <strong>Coverage:</strong> <code>rpc/pax_legacy_test.go</code> and <code>integration_test/evm_module/rpc_io_test/testdata/pax_legacy_deprecation/*.iox</code>
-      </div>
-
-      <h2>Transaction Index Mismatches</h2>
-
-      <p>
-        <strong>Important:</strong> Transaction indices differ between <code>eth_</code> and <code>pax_</code> endpoints.
-      </p>
-
-      <h3>Example</h3>
-
-      <p>
-        Consider a block with:
-      </p>
-
-      <ol>
-        <li>EVM Transaction 1</li>
-        <li>Cosmos Transaction 1</li>
-        <li>EVM Transaction 2</li>
-      </ol>
-
-      <h4>eth_getBlockReceipts</h4>
-
-      <p>
-        Returns only EVM transactions with sequential indices:
-      </p>
-
-      <ul>
-        <li>EVM Transaction 1 (tx index: 0)</li>
-        <li>EVM Transaction 2 (tx index: 1)</li>
-      </ul>
-
-      <h4>pax_getBlockReceipts</h4>
-
-      <p>
-        Returns all transactions (EVM + Cosmos) with sequential indices:
-      </p>
-
-      <ul>
-        <li>EVM Transaction 1 (tx index: 0)</li>
-        <li>Cosmos Transaction 1 (tx index: 1)</li>
-        <li>EVM Transaction 2 (tx index: 2)</li>
-      </ul>
-
-      <h3>Receipts and Logs</h3>
-
-      <ul>
-        <li><strong>EVM-originating:</strong> Synthetic events included in both <code>eth_getLogs</code> and <code>eth_getTransactionReceipt</code></li>
-        <li><strong>Cosmos-originating:</strong> Synthetic events <em>not</em> in <code>eth_</code> methods; use <code>pax_getLogs</code> and <code>pax_getBlockReceipts</code></li>
-        <li><strong>logIndex values:</strong> Strictly increasing and consistent within each namespace</li>
-      </ul>
-
-      <h3>Best Practice</h3>
-
-      <ul>
-        <li>Use the same endpoint consistently within your application</li>
-        <li>Account for index differences when switching endpoints</li>
-        <li>Prefer transaction hashes over indices (hashes are consistent across endpoints)</li>
-      </ul>
-
-      <h2>debug_ Endpoints</h2>
-
-      <p>
-        <code>debug_trace*</code> endpoints faithfully replay historical execution:
-      </p>
-
-      <ul>
-        <li>If a transaction errored during execution, the trace reflects that error</li>
-        <li>Gas consumption matches the actual execution gas used</li>
-        <li>State changes are replayed exactly as they occurred</li>
-      </ul>
-
-      <h3>Key debug_ Methods</h3>
-
-      <ul>
-        <li><code>debug_traceBlockByNumber</code>, <code>debug_traceBlockByHash</code></li>
-        <li><code>debug_traceTransaction</code></li>
-        <li><code>debug_traceCall</code></li>
-      </ul>
-
-      <h2>Paxeer RPC Distinctions</h2>
-
-      <p>
-        Paxeer's RPC deviates from Ethereum in several areas:
-      </p>
-
-      <h3>No Pending State</h3>
-
-      <ul>
-        <li>Paxeer has instant finality and no pending blocks</li>
-        <li><code>pending</code> parameter is accepted but treated as <code>latest</code>/<code>safe</code>/<code>final</code></li>
-      </ul>
-
-      <h3>No Uncle Blocks</h3>
-
-      <ul>
-        <li>BFT consensus means no uncle blocks or reorgs</li>
-        <li>Uncle-related endpoints are not supported</li>
-      </ul>
-
-      <h3>No Trie Endpoints</h3>
-
-      <ul>
-        <li>Paxeer does not store state in Ethereum-style tries</li>
-        <li>Trie-related endpoints are not supported</li>
-      </ul>
-
-      <h3>No Proof-of-Work</h3>
-
-      <ul>
-        <li><code>eth_mining</code>, <code>eth_hashrate</code> not supported</li>
-        <li>Paxeer uses BFT consensus, not PoW</li>
-      </ul>
-
-      <h3>No Blobs</h3>
-
-      <ul>
-        <li>EIP-4844 blob transactions not supported</li>
-        <li><code>eth_blobBaseFee</code> returns error <code>-32000</code>: "blobs not supported on this chain"</li>
-      </ul>
-
-      <p>
-        See <Link href="/json-rpc-unsupported">Unsupported Methods</Link> for the complete list.
-      </p>
-
-      <h2>Consistency Guarantee</h2>
-
-      <p>
-        <strong>RPC responses for historical heights never change</strong> as the blockchain progresses or as code upgrades. This is a stability guarantee for indexers and applications.
-      </p>
-
-      <h2>WebSocket Support</h2>
-
-      <p>
-        Paxeer RPC supports WebSocket for:
-      </p>
-
-      <ul>
-        <li><code>eth_subscribe</code> (newHeads, logs, newPendingTransactions)</li>
-        <li><code>eth_unsubscribe</code></li>
-      </ul>
-
-      <p>
-        Legacy <code>pax2_*</code> endpoints are HTTP-only.
-      </p>
-
-      <div className="prev-next">
-        <Link href="/wasm-runtime">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">WASM Runtime</div>
-        </Link>
-        <Link href="/json-rpc-unsupported">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Unsupported Methods</div>
-        </Link>
-      </div>
+        <p>
+          <code>eth_</code> sees EVM transactions only. <code>pax_</code> adds Cosmos transactions with synthetic receipts. <code>pax2_</code> is the same block shape as <code>pax_</code> plus bank transfers, HTTP only. <code>debug_trace*</code> replays historical execution.
+        </p>
+      </PageLead>
+
+      <FactChips
+        items={[
+          { label: 'Local EVM HTTP', value: '127.0.0.1:8545' },
+          { label: 'Chain ID', value: '125' },
+          { label: 'Gas token', value: 'PAX' },
+          { label: 'Legacy gate', value: '[evm].enabled_legacy_pax_apis' },
+        ]}
+      />
+
+      <JumpNav
+        items={[
+          { id: 'namespaces', label: 'Namespaces' },
+          { id: 'eth', label: 'eth_' },
+          { id: 'pax', label: 'pax_' },
+          { id: 'pax2', label: 'pax2_' },
+          { id: 'indices', label: 'Tx indices' },
+          { id: 'debug', label: 'debug_' },
+          { id: 'distinctions', label: 'Distinctions' },
+          { id: 'websocket', label: 'WebSocket' },
+        ]}
+      />
+
+      <Section id="namespaces" title="Namespaces">
+        <MethodTable
+          columns={['Prefix', 'Visibility', 'Use']}
+          rows={[
+            ['eth_', 'EVM transactions only', 'Ethereum tooling: ethers, viem, web3.js, Hardhat, Foundry'],
+            ['pax_', 'EVM + Cosmos with synthetic receipts', 'Indexers that need Cosmos events as EVM logs'],
+            ['pax2_', 'EVM + Cosmos + bank transfers in blocks', 'Seven HTTP block methods; no tx or filter API'],
+            ['debug_', 'EVM trace replay', 'Historical gas, errors, and state as executed'],
+          ]}
+        />
+      </Section>
+
+      <Section id="eth" title="eth_">
+        <p className={m3.body}>
+          Pure EVM view. Cosmos-native transactions are omitted. Method names follow the Ethereum JSON-RPC spec except where <Link href="/json-rpc-unsupported">unsupported methods</Link> return <code>-32000</code>.
+        </p>
+        <MethodTable
+          columns={['Method', 'Args', 'Purpose']}
+          rows={[
+            ['eth_blockNumber', '[]', 'Current EVM head as a hex quantity'],
+            ['eth_getBlockByNumber', '[block, fullTx]', 'Block by number or tag'],
+            ['eth_getBlockByHash', '[hash, fullTx]', 'Block by hash'],
+            ['eth_getTransactionByHash', '[hash]', 'EVM transaction'],
+            ['eth_getTransactionReceipt', '[hash]', 'Receipt; also accepts a synthetic hash'],
+            ['eth_getLogs', '[filter]', 'EVM logs in a range'],
+            ['eth_call', '[tx, block]', 'Read-only call'],
+            ['eth_estimateGas', '[tx]', 'Gas estimate'],
+            ['eth_sendRawTransaction', '[raw]', 'Submit a signed EVM tx'],
+            ['eth_getBalance', '[addr, block]', 'Account balance'],
+            ['eth_getCode', '[addr, block]', 'Contract bytecode'],
+          ]}
+        />
+        <SnippetBlock
+          method="eth_blockNumber"
+          args="[]"
+          source="paxeer-network/rpc/"
+          purpose="Read the EVM head on the local Docker node0 port."
+          code={`curl -s -X POST http://127.0.0.1:8545 \\
+  -H 'content-type: application/json' \\
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}'`}
+        />
+      </Section>
+
+      <Section id="pax" title="pax_">
+        <p className={m3.body}>
+          Cosmos events (CW20, CW721) appear as synthetic EVM logs. For a synthetic transaction, call <code>eth_getTransactionReceipt</code> with that hash. There is no <code>pax_getTransactionByReceipt</code>.
+        </p>
+        <Subhead>Synthetic logs and blocks</Subhead>
+        <MethodTable
+          columns={['Method', 'Args', 'Purpose']}
+          rows={[
+            ['pax_getLogs', '[filter]', 'eth_getLogs plus synthetic logs'],
+            ['pax_getFilterLogs', '[id]', 'eth_getFilterLogs plus synthetic logs'],
+            ['pax_getBlockByNumber', '[block, fullTx]', 'Block including synthetic txs'],
+            ['pax_getBlockByHash', '[hash, fullTx]', 'Block including synthetic txs'],
+            ['pax_getBlockReceipts', '[block]', 'Receipts including synthetic txs'],
+            ['pax_getPaxAddress', '[evmAddr]', 'Cosmos bech32 from EVM address'],
+            ['pax_getEVMAddress', '[paxAddr]', 'EVM address from Cosmos bech32'],
+            ['pax_getCosmosTx', '[hash]', 'Cosmos tx by hash'],
+          ]}
+        />
+        <Subhead>ExcludeTraceFail</Subhead>
+        <p className={m3.body}>
+          Some mempool txs fail pre-state checks (nonce, funds, panic) and land in a block without executing. These methods drop them:
+        </p>
+        <MethodTable
+          columns={['Method', 'Args', 'Purpose']}
+          rows={[
+            ['pax_traceBlockByNumberExcludeTraceFail', '[block]', 'Trace block, skip pre-state failures'],
+            ['pax_traceBlockByHashExcludeTraceFail', '[hash]', 'Trace block by hash, skip failures'],
+            ['pax_getTransactionReceiptExcludeTraceFail', '[hash]', 'Receipt if the tx actually executed'],
+            ['pax_getBlockByNumberExcludeTraceFail', '[block, fullTx]', 'Block without failed pre-state txs'],
+            ['pax_getBlockByHashExcludeTraceFail', '[hash, fullTx]', 'Block without failed pre-state txs'],
+          ]}
+        />
+        <Callout label="Receipt lookup">
+          Synthetic txs use <code>eth_getTransactionReceipt</code> with the synthetic hash. Do not invent a <code>pax_</code> receipt-by-receipt method.
+        </Callout>
+      </Section>
+
+      <Section id="pax2" title="pax2_">
+        <p className={m3.body}>
+          Seven HTTP methods. Same block JSON as <code>pax_</code>, with bank transfers in the payload. No transaction API, no filter API, no WebSocket.
+        </p>
+        <MethodTable
+          columns={['Method', 'Args', 'Purpose']}
+          rows={[
+            ['pax2_getBlockByHash', '[hash, fullTx]', 'Block plus bank transfers'],
+            ['pax2_getBlockByNumber', '[block, fullTx]', 'Block plus bank transfers'],
+            ['pax2_getBlockReceipts', '[block]', 'Receipts plus bank transfers'],
+            ['pax2_getBlockTransactionCountByHash', '[hash]', 'Tx count including bank transfers'],
+            ['pax2_getBlockTransactionCountByNumber', '[block]', 'Tx count including bank transfers'],
+            ['pax2_getBlockByHashExcludeTraceFail', '[hash, fullTx]', 'Block minus pre-state failures'],
+            ['pax2_getBlockByNumberExcludeTraceFail', '[block, fullTx]', 'Block minus pre-state failures'],
+          ]}
+        />
+        <Subhead>Legacy gate</Subhead>
+        <p className={m3.body}>
+          Every gated <code>pax_*</code> and <code>pax2_*</code> name is allowlisted by <code>[evm].enabled_legacy_pax_apis</code> in <code>app.toml</code>. Both prefixes share one list. The surfaces are deprecated and scheduled for removal. <code>paxd init</code> pre-fills <code>pax_getPaxAddress</code>, <code>pax_getEVMAddress</code>, and <code>pax_getCosmosTx</code>. Docker localnet enables every gated method except <code>pax_sign</code> (<code>paxeer-network/docker/localnode/config/app.toml</code>).
+        </p>
+        <p className={m3.body}>
+          A disabled method returns HTTP 200 with JSON-RPC <code>-32601</code>, <code>data: "legacy_pax_deprecated"</code>. Allowed single-object bodies pass through unchanged. Allowed responses may set header <code>Pax-Legacy-RPC-Deprecation</code>.
+        </p>
+        <SnippetBlock
+          method="pax_getLogs"
+          args="[filter]"
+          source="paxeer-network/rpc/pax_legacy.go"
+          purpose="Legacy pax_* call. Fails with -32601 unless the method is on the allowlist."
+          code={`# Disabled methods (not on enabled_legacy_pax_apis):
+# { "jsonrpc":"2.0", "id":1, "error": { "code":-32601, "data":"legacy_pax_deprecated" } }
+#
+# Coverage: paxeer-network/rpc/pax_legacy_test.go
+# and integration_test/evm_module/rpc_io_test/testdata/pax_legacy_deprecation/*.iox`}
+        />
+      </Section>
+
+      <Section id="indices" title="Transaction indices">
+        <p className={m3.body}>
+          Indices are namespace-local. Hashes are stable across namespaces; indices are not.
+        </p>
+        <div className="grid grid-cols-2 gap-3 my-6">
+          <div className="rounded-lg bg-surface-container shadow-1 px-4 py-4">
+            <div className={m3.overline}>eth_getBlockReceipts</div>
+            <p className={`${m3.body} mt-3`}>EVM Transaction 1 → index 0</p>
+            <p className={m3.body}>EVM Transaction 2 → index 1</p>
+            <p className={`${m3.label} mt-3`}>Cosmos tx omitted</p>
+          </div>
+          <div className="rounded-lg bg-surface-container shadow-1 px-4 py-4">
+            <div className={m3.overline}>pax_getBlockReceipts</div>
+            <p className={`${m3.body} mt-3`}>EVM Transaction 1 → index 0</p>
+            <p className={m3.body}>Cosmos Transaction 1 → index 1</p>
+            <p className={m3.body}>EVM Transaction 2 → index 2</p>
+          </div>
+        </div>
+        <ul>
+          <li>EVM-originating synthetic events appear in both <code>eth_getLogs</code> and <code>eth_getTransactionReceipt</code>.</li>
+          <li>Cosmos-originating synthetic events are not in <code>eth_</code> methods. Use <code>pax_getLogs</code> and <code>pax_getBlockReceipts</code>.</li>
+          <li><code>logIndex</code> is strictly increasing inside one namespace.</li>
+        </ul>
+      </Section>
+
+      <Section id="debug" title="debug_">
+        <p className={m3.body}>
+          <code>debug_trace*</code> replays the historical execution. If the tx errored, the trace errors. Gas used matches the executed amount.
+        </p>
+        <MethodTable
+          columns={['Method', 'Args', 'Purpose']}
+          rows={[
+            ['debug_traceBlockByNumber', '[block, opts]', 'Replay every tx in a block'],
+            ['debug_traceBlockByHash', '[hash, opts]', 'Replay by block hash'],
+            ['debug_traceTransaction', '[hash, opts]', 'Replay one tx'],
+            ['debug_traceCall', '[tx, block, opts]', 'Trace a call against a block'],
+          ]}
+        />
+      </Section>
+
+      <Section id="distinctions" title="Distinctions from Ethereum">
+        <MethodTable
+          columns={['Rule', 'Behavior']}
+          rows={[
+            ['No pending state', 'pending is accepted and treated as latest / safe / final'],
+            ['No uncle blocks', 'BFT finality. Uncle methods are unsupported'],
+            ['No trie', 'State is not an Ethereum trie. Trie methods are unsupported'],
+            ['No PoW', 'eth_mining and eth_hashrate are unsupported'],
+            ['No blobs', 'eth_blobBaseFee returns -32000: blobs not supported on this chain'],
+            ['Historical stability', 'Responses at a height do not change after upgrades'],
+          ]}
+        />
+        <p className={m3.body}>
+          Registered failures live on <Link href="/json-rpc-unsupported">Unsupported Methods</Link>.
+        </p>
+      </Section>
+
+      <Section id="websocket" title="WebSocket">
+        <p className={m3.body}>
+          <code>eth_subscribe</code> and <code>eth_unsubscribe</code> accept <code>newHeads</code>, <code>logs</code>, and <code>newPendingTransactions</code>. <code>pax2_*</code> is HTTP only.
+        </p>
+      </Section>
+
+      <PageNav
+        prev={{ href: '/wasmbinding', title: 'WASM Bindings' }}
+        next={{ href: '/json-rpc-unsupported', title: 'Unsupported Methods' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/rest-grpc/page.tsx
+++ b/paxeer-docs/src/app/rest-grpc/page.tsx
@@ -1,439 +1,193 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, Subhead, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function RestGrpc() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">REST & gRPC APIs</h1>
-        <p className="page-description">
-          Cosmos SDK REST and gRPC interfaces for Paxeer chain modules and administration.
+    <DocsLayout pageTitle="REST & gRPC">
+      <PageLead overline="gRPC :9090 · REST :1317 · proto Query services" source="paxeer-network/api/">
+        <p>
+          Cosmos query services generated from <code>paxeer-network/api/</code>. Default gRPC bind is <code>0.0.0.0:9090</code>. Default REST gateway is <code>tcp://0.0.0.0:1317</code> (<code>paxeer-network/sdk/server/config/config.go</code>). Docker localnet node0 publishes gRPC at <code>9090-9091</code>, not 1317.
         </p>
-      </div>
+        <p>
+          JSON-RPC on <code>:8545</code> is a different process. LayerX activities are not queried here. LayerX fee is 5,000 µUSDX per activity, not zero. PAX is gas on this chain.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/api/</code> proto definitions, <code>paxeer-network/docs/</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'gRPC default', value: '0.0.0.0:9090' },
+          { label: 'REST default', value: 'tcp://0.0.0.0:1317' },
+          { label: 'Docker node0 gRPC', value: '9090-9091' },
+          { label: 'Admin gRPC', value: '127.0.0.1:9095' },
+        ]}
+      />
 
-      <h2>Overview</h2>
+      <JumpNav
+        items={[
+          { id: 'codegen', label: 'Codegen' },
+          { id: 'evm', label: 'evm.Query' },
+          { id: 'epoch', label: 'epoch.Query' },
+          { id: 'oracle', label: 'oracle.Query' },
+          { id: 'tokenfactory', label: 'tokenfactory.Query' },
+          { id: 'mint', label: 'mint.Query' },
+          { id: 'admin', label: 'AdminService' },
+          { id: 'swagger', label: 'Swagger' },
+        ]}
+      />
 
-      <p>
-        Paxeer exposes Cosmos SDK-style gRPC and REST (gRPC-Gateway) endpoints for chain modules. These APIs complement the <Link href="/json-rpc">JSON-RPC interface</Link> and provide access to chain state, module parameters, and administrative operations.
-      </p>
+      <Section id="codegen" title="Code generation">
+        <p className={m3.body}>
+          Proto files emit Go types under <code>github.com/sidiora-labs/paxeer-network/modules/*/types</code>, gRPC interfaces, REST via <code>google.api.http</code>, and OpenAPI. Regen:
+        </p>
+        <SnippetBlock
+          method="ignite generate proto-go"
+          args="Ignite CLI v0.23.0"
+          source="paxeer-network/api/README.md"
+          purpose="Regenerate Go types, gRPC stubs, and REST annotations from api/ protos."
+          code={`ignite generate proto-go`}
+        />
+      </Section>
 
-      <h3>Protocol Buffers</h3>
+      <Section id="evm" title="paxprotocol.paxchain.evm.Query">
+        <p className={m3.body}>Address maps, static calls, pointer lookups. Proto: <code>paxeer-network/api/evm/query.proto</code>.</p>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['PaxAddressByEVMAddress', 'GET /pax-protocol/paxchain/evm/pax_address', 'Cosmos address from EVM address'],
+            ['EVMAddressByPaxAddress', 'GET /pax-protocol/paxchain/evm/evm_address', 'EVM address from Cosmos address'],
+            ['StaticCall', 'GET /pax-protocol/paxchain/evm/static_call', 'Read-only contract call'],
+            ['Pointer', 'GET /pax-protocol/paxchain/evm/pointer', 'EVM pointer for a Cosmos contract'],
+            ['Pointee', 'GET /pax-protocol/paxchain/evm/pointee', 'Cosmos contract from an EVM pointer'],
+            ['PointerVersion', 'GET /pax-protocol/paxchain/evm/pointer_version', 'Current pointer contract version'],
+          ]}
+        />
+        <SnippetBlock
+          method="paxprotocol.paxchain.evm.Query/Pointer"
+          args="gRPC :9090"
+          source="paxeer-network/api/evm/query.proto"
+          purpose="List services, then call Pointer on the default gRPC port."
+          code={`grpcurl -plaintext localhost:9090 list
+grpcurl -plaintext localhost:9090 paxprotocol.paxchain.evm.Query/Pointer`}
+        />
+      </Section>
 
-      <p>
-        All services are defined in <code>paxeer-network/api/</code> using Protocol Buffers v3. The proto files generate:
-      </p>
+      <Section id="epoch" title="paxprotocol.paxchain.epoch.Query">
+        <p className={m3.body}>Proto: <code>paxeer-network/api/epoch/query.proto</code>.</p>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['Epoch', 'GET /pax-protocol/paxchain/epoch/epoch', 'Current epoch number and metadata'],
+            ['Params', 'GET /pax-protocol/paxchain/epoch/params', 'Epoch module parameters'],
+          ]}
+        />
+      </Section>
 
-      <ul>
-        <li>Go types under <code>github.com/sidiora-labs/paxeer-network/modules/*/types</code></li>
-        <li>gRPC server and client interfaces</li>
-        <li>REST endpoints via <code>google.api.http</code> annotations</li>
-        <li>OpenAPI/Swagger documentation</li>
-      </ul>
+      <Section id="oracle" title="oracle Query">
+        <p className={m3.body}>
+          HTTP paths use <code>/pax-protocol/pax-chain/oracle/...</code> (hyphen). Proto: <code>paxeer-network/api/oracle/query.proto</code>.
+        </p>
+        <Subhead>Rates</Subhead>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['ExchangeRate', 'GET /pax-protocol/pax-chain/oracle/denoms/{denom}/exchange_rate', 'Rate for one denom'],
+            ['ExchangeRates', 'GET /pax-protocol/pax-chain/oracle/denoms/exchange_rates', 'All rates'],
+            ['Actives', 'GET /pax-protocol/pax-chain/oracle/denoms/actives', 'Active denoms'],
+            ['VoteTargets', 'GET /pax-protocol/pax-chain/oracle/denoms/vote_targets', 'Vote-target denoms'],
+            ['PriceSnapshotHistory', 'GET /pax-protocol/pax-chain/oracle/denoms/price_snapshot_history', 'Price snapshots'],
+            ['Twaps', 'GET /pax-protocol/pax-chain/oracle/denoms/twaps/{lookback_seconds}', 'TWAP over lookback'],
+          ]}
+        />
+        <Subhead>Validators</Subhead>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['FeederDelegation', 'GET /pax-protocol/pax-chain/oracle/validators/{validator_addr}/feeder', 'Feeder for a validator'],
+            ['VotePenaltyCounter', 'GET /pax-protocol/pax-chain/oracle/validators/{validator_addr}/vote_penalty_counter', 'Oracle miss counter'],
+            ['SlashWindow', 'GET /pax-protocol/pax-chain/oracle/slash_window', 'Slash window'],
+            ['Params', 'GET /pax-protocol/pax-chain/oracle/params', 'Oracle parameters'],
+          ]}
+        />
+      </Section>
 
-      <h3>Code Generation</h3>
+      <Section id="tokenfactory" title="paxprotocol.paxchain.tokenfactory.Query">
+        <p className={m3.body}>Proto: <code>paxeer-network/api/tokenfactory/query.proto</code>.</p>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['Params', 'GET /pax-protocol/paxchain/tokenfactory/params', 'Tokenfactory parameters'],
+            ['DenomAuthorityMetadata', 'GET /pax-protocol/paxchain/tokenfactory/denoms/{denom}/authority_metadata', 'Denom authority'],
+            ['DenomMetadata', 'GET /pax-protocol/paxchain/tokenfactory/denoms/metadata', 'Denom metadata'],
+            ['DenomsFromCreator', 'GET /pax-protocol/paxchain/tokenfactory/denoms_from_creator/{creator}', 'Denoms created by an address'],
+            ['DenomAllowList', 'GET /pax-protocol/paxchain/tokenfactory/denoms/allow_list', 'Allow list'],
+          ]}
+        />
+      </Section>
 
-      <p>
-        Regenerate Go code from proto files:
-      </p>
+      <Section id="mint" title="mint.v1beta1.Query">
+        <p className={m3.body}>Proto: <code>paxeer-network/api/mint/v1beta1/query.proto</code>. Paths omit the <code>pax-protocol</code> prefix.</p>
+        <MethodTable
+          columns={['RPC', 'REST', 'Purpose']}
+          rows={[
+            ['Params', 'GET /paxchain/mint/v1beta1/params', 'Mint parameters'],
+            ['Minter', 'GET /paxchain/mint/v1beta1/minter', 'Minter state'],
+          ]}
+        />
+      </Section>
 
-      <pre><code>{`ignite generate proto-go`}</code></pre>
-
-      <p>
-        Requires Ignite CLI v0.23.0. See <code>paxeer-network/api/README.md</code> for installation.
-      </p>
-
-      <h2>EVM Module Query Service</h2>
-
-      <p>
-        The EVM module provides address mapping, static calls, and pointer queries.
-      </p>
-
-      <h3>Address Mapping</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>PaxAddressByEVMAddress</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/pax_address</code></td>
-            <td>Get Cosmos address from EVM address</td>
-          </tr>
-          <tr>
-            <td><code>EVMAddressByPaxAddress</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/evm_address</code></td>
-            <td>Get EVM address from Cosmos address</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Static Calls</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>StaticCall</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/static_call</code></td>
-            <td>Execute read-only contract call</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Pointer Queries</h3>
-
-      <p>
-        Pointers bridge Cosmos-native assets (CW20/CW721/CW1155) to EVM addresses:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>Pointer</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/pointer</code></td>
-            <td>Get EVM pointer for Cosmos contract</td>
-          </tr>
-          <tr>
-            <td><code>Pointee</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/pointee</code></td>
-            <td>Get Cosmos contract from EVM pointer</td>
-          </tr>
-          <tr>
-            <td><code>PointerVersion</code></td>
-            <td><code>GET /pax-protocol/paxchain/evm/pointer_version</code></td>
-            <td>Get current pointer contract version</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/evm/query.proto</code>
-      </div>
-
-      <h2>Epoch Module Query Service</h2>
-
-      <p>
-        The Epoch module tracks the current chain epoch for time-based operations:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>Epoch</code></td>
-            <td><code>GET /pax-protocol/paxchain/epoch/epoch</code></td>
-            <td>Get current epoch number and metadata</td>
-          </tr>
-          <tr>
-            <td><code>Params</code></td>
-            <td><code>GET /pax-protocol/paxchain/epoch/params</code></td>
-            <td>Get epoch module parameters</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/epoch/query.proto</code>
-      </div>
-
-      <h2>Oracle Module Query Service</h2>
-
-      <p>
-        The Oracle module provides exchange rates, price feeds, and validator vote tracking:
-      </p>
-
-      <h3>Exchange Rates & Prices</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>ExchangeRate</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/{`{denom}`}/exchange_rate</code></td>
-            <td>Get exchange rate for a denom</td>
-          </tr>
-          <tr>
-            <td><code>ExchangeRates</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/exchange_rates</code></td>
-            <td>Get all exchange rates</td>
-          </tr>
-          <tr>
-            <td><code>Actives</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/actives</code></td>
-            <td>List all active denoms</td>
-          </tr>
-          <tr>
-            <td><code>VoteTargets</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/vote_targets</code></td>
-            <td>List vote target denoms</td>
-          </tr>
-          <tr>
-            <td><code>PriceSnapshotHistory</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/price_snapshot_history</code></td>
-            <td>Get historical price snapshots</td>
-          </tr>
-          <tr>
-            <td><code>Twaps</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/denoms/twaps/{`{lookback_seconds}`}</code></td>
-            <td>Get time-weighted average prices</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h3>Validator Vote Tracking</h3>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>FeederDelegation</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/validators/{`{validator_addr}`}/feeder</code></td>
-            <td>Get feeder delegation for validator</td>
-          </tr>
-          <tr>
-            <td><code>VotePenaltyCounter</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/validators/{`{validator_addr}`}/vote_penalty_counter</code></td>
-            <td>Get oracle miss counter</td>
-          </tr>
-          <tr>
-            <td><code>SlashWindow</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/slash_window</code></td>
-            <td>Get slash window information</td>
-          </tr>
-          <tr>
-            <td><code>Params</code></td>
-            <td><code>GET /pax-protocol/pax-chain/oracle/params</code></td>
-            <td>Get oracle module parameters</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/oracle/query.proto</code>
-      </div>
-
-      <h2>TokenFactory Module Query Service</h2>
-
-      <p>
-        The TokenFactory module manages custom token creation and metadata:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>Params</code></td>
-            <td><code>GET /pax-protocol/paxchain/tokenfactory/params</code></td>
-            <td>Get tokenfactory parameters</td>
-          </tr>
-          <tr>
-            <td><code>DenomAuthorityMetadata</code></td>
-            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/{`{denom}`}/authority_metadata</code></td>
-            <td>Get denom authority metadata</td>
-          </tr>
-          <tr>
-            <td><code>DenomMetadata</code></td>
-            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/metadata</code></td>
-            <td>Get denom metadata</td>
-          </tr>
-          <tr>
-            <td><code>DenomsFromCreator</code></td>
-            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms_from_creator/{`{creator}`}</code></td>
-            <td>List denoms created by an address</td>
-          </tr>
-          <tr>
-            <td><code>DenomAllowList</code></td>
-            <td><code>GET /pax-protocol/paxchain/tokenfactory/denoms/allow_list</code></td>
-            <td>Get denom allow list</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/tokenfactory/query.proto</code>
-      </div>
-
-      <h2>Mint Module Query Service</h2>
-
-      <p>
-        The Mint module exposes minting parameters and state:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>REST Endpoint</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>Params</code></td>
-            <td><code>GET /paxchain/mint/v1beta1/params</code></td>
-            <td>Get mint module parameters</td>
-          </tr>
-          <tr>
-            <td><code>Minter</code></td>
-            <td><code>GET /paxchain/mint/v1beta1/minter</code></td>
-            <td>Get minter state (start/end dates, amounts)</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/mint/v1beta1/query.proto</code>
-      </div>
-
-      <h2>Admin gRPC Service</h2>
-
-      <p>
-        The Admin service provides runtime log level control. It runs on a separate loopback-only gRPC server (default <code>127.0.0.1:9095</code>):
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Method</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>SetLogLevel</code></td>
-            <td>Change log level for loggers matching a pattern</td>
-          </tr>
-          <tr>
-            <td><code>GetLogLevel</code></td>
-            <td>Get current log level for a logger</td>
-          </tr>
-          <tr>
-            <td><code>ListLoggers</code></td>
-            <td>List all registered loggers and their levels</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>
-        Enable in <code>app.toml</code>:
-      </p>
-
-      <pre><code>{`[admin_server]
+      <Section id="admin" title="paxprotocol.paxchain.admin.v0.AdminService">
+        <p className={m3.body}>
+          Loopback-only gRPC. Default <code>127.0.0.1:9095</code>. Binding a non-loopback address is rejected at startup. Proto: <code>paxeer-network/api/pax/admin/v0/admin.proto</code>. Implementation: <code>paxeer-network/admin/</code>.
+        </p>
+        <MethodTable
+          columns={['RPC', 'Request', 'Purpose']}
+          rows={[
+            ['SetLogLevel', 'pattern, level', 'Set level for matching loggers; returns affected'],
+            ['GetLogLevel', 'logger', 'Current level for one logger'],
+            ['ListLoggers', 'prefix (optional)', 'Registered loggers and levels'],
+          ]}
+        />
+        <SnippetBlock
+          method="[admin_server]"
+          args="admin_address = 127.0.0.1:9095"
+          source="paxeer-network/admin/config.go"
+          purpose="Enable the loopback admin server in app.toml."
+          code={`[admin_server]
 admin_enabled = true
-admin_address = "127.0.0.1:9095"`}</code></pre>
+admin_address = "127.0.0.1:9095"`}
+        />
+        <Callout label="REST vs admin">
+          Admin is not on the :1317 gateway. Use gRPC on loopback, or see <Link href="/admin-hpx">Admin & HPX</Link>.
+        </Callout>
+      </Section>
 
-      <div className="source-note">
-        <strong>Proto:</strong> <code>paxeer-network/api/pax/admin/v0/admin.proto</code><br />
-        <strong>Implementation:</strong> <code>paxeer-network/admin/</code>
-      </div>
+      <Section id="swagger" title="OpenAPI">
+        <p className={m3.body}>
+          Regen embeds <code>docs/swagger-ui/swagger.yml</code> into <code>docs/swagger/statik.go</code>. Instructions: <code>paxeer-network/docs/README.md</code>.
+        </p>
+        <SnippetBlock
+          method="./scripts/update-swagger-ui-statik.sh"
+          args="swagger = true under [api]"
+          source="paxeer-network/docs/README.md"
+          purpose="Rebuild the embedded Swagger UI and serve it from the API listener."
+          code={`./scripts/update-swagger-ui-statik.sh
 
-      <h2>OpenAPI / Swagger Documentation</h2>
-
-      <p>
-        Paxeer generates OpenAPI documentation from proto annotations. To regenerate:
-      </p>
-
-      <pre><code>{`./scripts/update-swagger-ui-statik.sh`}</code></pre>
-
-      <p>
-        This generates <code>docs/swagger-ui/swagger.yml</code> and embeds it in <code>docs/swagger/statik.go</code>.
-      </p>
-
-      <h3>Serving Swagger UI</h3>
-
-      <p>
-        Enable in <code>app.toml</code>:
-      </p>
-
-      <pre><code>{`[api]
+[api]
 enable = true
-swagger = true`}</code></pre>
+swagger = true
 
-      <p>
-        Access at <code>http://&lt;node-ip&gt;:&lt;port&gt;/swagger/</code>.
-      </p>
+# UI path: http://<node-ip>:<api-port>/swagger/`}
+        />
+        <p className={m3.body}>
+          Msg services in <code>evm/tx.proto</code>, <code>epoch/tx.proto</code>, and the other module <code>tx.proto</code> files are transaction types, not query RPCs. Submit them through Cosmos tx APIs.
+        </p>
+      </Section>
 
-      <div className="source-note">
-        <strong>See:</strong> <code>paxeer-network/docs/README.md</code> for generation instructions
-      </div>
-
-      <h2>gRPC Endpoints</h2>
-
-      <p>
-        gRPC services are exposed on the Cosmos SDK gRPC port (default <code>9090</code>). Use any gRPC client (e.g., <code>grpcurl</code>):
-      </p>
-
-      <pre><code>{`grpcurl -plaintext localhost:9090 list
-grpcurl -plaintext localhost:9090 paxprotocol.paxchain.evm.Query/Pointer`}</code></pre>
-
-      <h2>REST Gateway</h2>
-
-      <p>
-        REST endpoints are served via gRPC-Gateway on the API port (default <code>1317</code>). All gRPC methods have corresponding REST endpoints defined by <code>google.api.http</code> annotations in the proto files.
-      </p>
-
-      <h2>Transaction Services</h2>
-
-      <p>
-        Each module also defines a <code>Msg</code> service for transactions (e.g., <code>evm/tx.proto</code>, <code>epoch/tx.proto</code>). These are not query endpoints but message types for state-changing operations. Submit via standard Cosmos SDK transaction APIs.
-      </p>
-
-      <div className="prev-next">
-        <Link href="/json-rpc-unsupported">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Unsupported Methods</div>
-        </Link>
-        <Link href="/contracts">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Contracts</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/json-rpc-unsupported', title: 'Unsupported Methods' }}
+        next={{ href: '/contracts', title: 'Contracts' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/sdk/page.tsx
+++ b/paxeer-docs/src/app/sdk/page.tsx
@@ -1,326 +1,135 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { Callout, FactChips, JumpNav, MethodTable, PageLead, PageNav, Section, SnippetBlock, m3 } from '@/components/api/ApiPage'
 import Link from 'next/link'
 
 export default function SDK() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Cosmos SDK Fork</h1>
-        <p className="page-description">
-          Paxeer's in-tree Cosmos SDK fork with Paxeer-specific modifications and extensions.
+    <DocsLayout pageTitle="SDK">
+      <PageLead overline="github.com/sidiora-labs/paxeer-network/sdk · in-tree fork" source="paxeer-network/sdk/">
+        <p>
+          In-tree Cosmos SDK fork used by <code>paxd</code>. Not a published Go module. Import path is <code>github.com/sidiora-labs/paxeer-network/sdk</code>.
         </p>
-      </div>
+        <p>
+          It is not drop-in compatible with upstream Cosmos SDK releases. Test CosmJS, Keplr, and other upstream tools against this fork before assuming they work.
+        </p>
+      </PageLead>
 
-      <div className="source-note">
-        <strong>Source:</strong> <code>paxeer-network/sdk/</code>
-      </div>
+      <FactChips
+        items={[
+          { label: 'Module path', value: 'github.com/sidiora-labs/paxeer-network/sdk' },
+          { label: 'Binary', value: 'paxd' },
+          { label: 'gRPC default', value: ':9090' },
+          { label: 'REST default', value: ':1317' },
+        ]}
+      />
 
-      <h2>Overview</h2>
+      <JumpNav
+        items={[
+          { id: 'tree', label: 'Tree' },
+          { id: 'modules', label: 'Modules' },
+          { id: 'baseapp', label: 'BaseApp' },
+          { id: 'store', label: 'Store' },
+          { id: 'build', label: 'Build' },
+          { id: 'fork', label: 'Fork deltas' },
+        ]}
+      />
 
-      <p>
-        Paxeer vendors a fork of the Cosmos SDK directly in the monorepo under <code>paxeer-network/sdk/</code>. This is <strong>not</strong> a published Go module or npm package. It is an in-tree dependency for the <code>paxd</code> binary and Paxeer chain modules.
-      </p>
+      <Section id="tree" title="Directory">
+        <MethodTable
+          columns={['Path', 'Purpose']}
+          rows={[
+            ['baseapp/', 'ABCI, routing, ante handlers'],
+            ['client/', 'CLI and tx builders'],
+            ['server/', 'Node server, gRPC, REST gateway'],
+            ['types/', 'Messages, coins, errors, context'],
+            ['x/', 'Upstream Cosmos modules'],
+            ['proto/', 'SDK protobufs'],
+            ['store/', 'Store abstraction'],
+            ['simapp/', 'Reference app for tests'],
+          ]}
+        />
+      </Section>
 
-      <h3>Why a Fork?</h3>
+      <Section id="modules" title="Modules">
+        <p className={m3.body}>Upstream modules in the fork:</p>
+        <MethodTable
+          columns={['Module', 'Purpose']}
+          rows={[
+            ['x/auth', 'Accounts and signatures'],
+            ['x/bank', 'Transfers and balances'],
+            ['x/staking', 'Validator set and delegation'],
+            ['x/distribution', 'Rewards and fees'],
+            ['x/gov', 'Proposals'],
+            ['x/slashing', 'Validator penalties'],
+            ['x/crisis', 'Invariants and halt'],
+            ['x/evidence', 'Double-sign evidence'],
+            ['x/params', 'Module parameters'],
+            ['x/upgrade', 'Coordinated upgrades'],
+          ]}
+        />
+        <p className={m3.body}>
+          Paxeer modules live under <code>paxeer-network/modules/</code>: <code>evm</code>, <code>epoch</code>, <code>oracle</code>, <code>tokenfactory</code>, <code>mint</code>. Query RPCs: <Link href="/rest-grpc">REST & gRPC</Link>.
+        </p>
+      </Section>
 
-      <p>
-        Paxeer maintains a fork to support:
-      </p>
+      <Section id="baseapp" title="BaseApp, client, server">
+        <p className={m3.body}>
+          <code>baseapp/</code> owns ABCI, message routing, ante (gas, signatures, nonces), commits, and queries. Paxeer extends it for EVM routing and OCC. Client/server expose <code>paxd</code> CLI, module gRPC, REST gateway, and Tendermint RPC.
+        </p>
+      </Section>
 
-      <ul>
-        <li>Custom storage engines (MEMIAVL, Giga)</li>
-        <li>EVM integration and pointer contracts</li>
-        <li>Fast iteration without waiting for upstream releases</li>
-        <li>Paxeer-specific consensus and execution optimizations</li>
-        <li>Co-location with Paxeer modules and WASM runtime</li>
-      </ul>
+      <Section id="store" title="Store">
+        <p className={m3.body}>
+          <code>store/</code> is implemented by Paxeer engines: MEMIAVL (legacy in-memory IAVL) and Giga (flat KV). Details: <Link href="/storage">Storage</Link>.
+        </p>
+      </Section>
 
-      <h2>Upstream Base</h2>
-
-      <p>
-        The fork is based on Cosmos SDK but diverges significantly. It is not compatible with upstream Cosmos SDK releases without careful rebasing and testing.
-      </p>
-
-      <div className="source-note">
-        <strong>Warning:</strong> Do not assume drop-in compatibility with standard Cosmos SDK tooling or libraries. Paxeer's SDK is a custom fork.
-      </div>
-
-      <h2>Directory Structure</h2>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Path</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>baseapp/</code></td>
-            <td>Application framework (ABCI, routing, ante handlers)</td>
-          </tr>
-          <tr>
-            <td><code>client/</code></td>
-            <td>CLI framework and transaction builders</td>
-          </tr>
-          <tr>
-            <td><code>server/</code></td>
-            <td>Node server, gRPC, REST gateway</td>
-          </tr>
-          <tr>
-            <td><code>types/</code></td>
-            <td>Core SDK types (messages, coins, errors, context)</td>
-          </tr>
-          <tr>
-            <td><code>x/</code></td>
-            <td>Standard Cosmos modules (bank, auth, staking, gov, etc.)</td>
-          </tr>
-          <tr>
-            <td><code>proto/</code></td>
-            <td>Protobuf definitions for SDK modules</td>
-          </tr>
-          <tr>
-            <td><code>store/</code></td>
-            <td>State store abstraction and implementations</td>
-          </tr>
-          <tr>
-            <td><code>simapp/</code></td>
-            <td>Reference application for testing</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <h2>Key Modules</h2>
-
-      <p>
-        Paxeer's SDK includes standard Cosmos modules:
-      </p>
-
-      <table>
-        <thead>
-          <tr>
-            <th>Module</th>
-            <th>Purpose</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>x/auth</code></td>
-            <td>Account authentication and transaction signing</td>
-          </tr>
-          <tr>
-            <td><code>x/bank</code></td>
-            <td>Token transfers and balance management</td>
-          </tr>
-          <tr>
-            <td><code>x/staking</code></td>
-            <td>Proof-of-Stake validator set and delegation</td>
-          </tr>
-          <tr>
-            <td><code>x/distribution</code></td>
-            <td>Staking rewards and fee distribution</td>
-          </tr>
-          <tr>
-            <td><code>x/gov</code></td>
-            <td>On-chain governance and proposals</td>
-          </tr>
-          <tr>
-            <td><code>x/slashing</code></td>
-            <td>Validator penalties for misbehavior</td>
-          </tr>
-          <tr>
-            <td><code>x/crisis</code></td>
-            <td>Invariant checking and chain halts</td>
-          </tr>
-          <tr>
-            <td><code>x/evidence</code></td>
-            <td>Double-sign evidence submission</td>
-          </tr>
-          <tr>
-            <td><code>x/params</code></td>
-            <td>Module parameter management</td>
-          </tr>
-          <tr>
-            <td><code>x/upgrade</code></td>
-            <td>Coordinated chain upgrades</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <p>
-        Plus Paxeer-specific modules under <code>paxeer-network/modules/</code>:
-      </p>
-
-      <ul>
-        <li><code>evm</code> — EVM execution and JSON-RPC</li>
-        <li><code>epoch</code> — Epoch tracking</li>
-        <li><code>oracle</code> — Price feeds</li>
-        <li><code>tokenfactory</code> — Custom token creation</li>
-        <li><code>mint</code> — Token minting</li>
-      </ul>
-
-      <h2>BaseApp</h2>
-
-      <p>
-        The core application framework (<code>baseapp/</code>) handles:
-      </p>
-
-      <ul>
-        <li>ABCI interface to Tendermint consensus</li>
-        <li>Message routing to module handlers</li>
-        <li>Ante handlers (gas, signatures, nonces)</li>
-        <li>Transaction execution and state commits</li>
-        <li>Query routing</li>
-      </ul>
-
-      <p>
-        Paxeer extends BaseApp for EVM transaction routing and concurrent execution (OCC).
-      </p>
-
-      <h2>Client & Server</h2>
-
-      <p>
-        The SDK provides:
-      </p>
-
-      <ul>
-        <li><strong>CLI:</strong> <code>paxd</code> command-line interface (transaction builders, queries)</li>
-        <li><strong>gRPC:</strong> Module query and transaction services</li>
-        <li><strong>REST:</strong> HTTP gateway (gRPC-Gateway)</li>
-        <li><strong>Tendermint RPC:</strong> Block and transaction queries</li>
-      </ul>
-
-      <p>
-        See <Link href="/rest-grpc">REST & gRPC</Link> for API documentation.
-      </p>
-
-      <h2>State Store</h2>
-
-      <p>
-        The SDK's <code>store/</code> abstraction is implemented by Paxeer's custom storage engines:
-      </p>
-
-      <ul>
-        <li><strong>MEMIAVL:</strong> In-memory IAVL tree (legacy)</li>
-        <li><strong>Giga:</strong> High-performance flat key-value store</li>
-      </ul>
-
-      <p>
-        See <Link href="/storage">Storage</Link> for engine details.
-      </p>
-
-      <h2>Protobuf Definitions</h2>
-
-      <p>
-        SDK types are defined in <code>sdk/proto/</code>. Regenerate Go code with:
-      </p>
-
-      <pre><code>{`cd paxeer-network
-ignite generate proto-go`}</code></pre>
-
-      <p>
-        Requires Ignite CLI v0.23.0. See <code>paxeer-network/api/README.md</code>.
-      </p>
-
-      <h2>Building Against the SDK</h2>
-
-      <p>
-        Paxeer modules import the SDK from the in-tree path:
-      </p>
-
-      <pre><code>{`import (
+      <Section id="build" title="Build against the fork">
+        <SnippetBlock
+          method="github.com/sidiora-labs/paxeer-network/sdk"
+          args="no go.mod replace"
+          source="paxeer-network/sdk/"
+          purpose="Import the in-tree SDK. The monorepo already contains the module."
+          code={`import (
     sdk "github.com/sidiora-labs/paxeer-network/sdk/types"
     "github.com/sidiora-labs/paxeer-network/sdk/store"
-)`}</code></pre>
-
-      <p>
-        No <code>go.mod</code> replacement directives are needed because the SDK is part of the monorepo.
-      </p>
-
-      <h2>Makefile Targets</h2>
-
-      <p>
-        The repository Makefile includes SDK-related targets:
-      </p>
-
-      <pre><code>{`# Build paxd
-make build
-
-# Run tests
+)`}
+        />
+        <SnippetBlock
+          method="make build"
+          args="paxd → ./build/paxd"
+          source="paxeer-network/Makefile, paxeer-network/api/README.md"
+          purpose="Build paxd, run tests, and regenerate protos from the network tree."
+          code={`make build
 make test
+make proto-gen
 
-# Generate proto
-make proto-gen`}</code></pre>
+cd paxeer-network
+ignite generate proto-go`}
+        />
+        <p className={m3.body}>
+          Ignite CLI v0.23.0. SDK docs under <code>sdk/docs/</code> are upstream text and may omit Paxeer deltas. Upstream cosmos.network docs describe the public SDK, not this fork.
+        </p>
+      </Section>
 
-      <h2>Documentation</h2>
+      <Section id="fork" title="Fork deltas">
+        <ul>
+          <li>Storage backends: MEMIAVL, Giga</li>
+          <li>EVM module and pointer contracts</li>
+          <li>OCC parallel execution</li>
+          <li>Receipt indexing and synthetic transactions</li>
+          <li>Paxeer ante handlers and gas metering</li>
+          <li>Chain-specific upgrade logic</li>
+        </ul>
+        <Callout label="Changes in sdk/">
+          Edit, <code>make build</code>, <code>make test</code>, Docker cluster (<Link href="/docker">Docker</Link>), then <code>make test-integration</code>. A fork change hits every <code>paxd</code> path.
+        </Callout>
+      </Section>
 
-      <p>
-        The SDK fork includes upstream Cosmos SDK documentation under <code>sdk/docs/</code>. Note that Paxeer-specific modifications may not be fully reflected in those docs.
-      </p>
-
-      <h3>Upstream Resources</h3>
-
-      <ul>
-        <li><a href="https://docs.cosmos.network/">Cosmos SDK Docs</a> (upstream, may diverge from Paxeer)</li>
-        <li><a href="https://tutorials.cosmos.network/">Cosmos Tutorials</a> (upstream concepts apply)</li>
-        <li><a href="https://pkg.go.dev/github.com/cosmos/cosmos-sdk">GoDoc</a> (upstream SDK, not Paxeer's fork)</li>
-      </ul>
-
-      <div className="source-note">
-        <strong>Warning:</strong> Upstream documentation describes the standard Cosmos SDK, not Paxeer's fork. Treat it as reference only.
-      </div>
-
-      <h2>Contributing to the Fork</h2>
-
-      <p>
-        Changes to <code>paxeer-network/sdk/</code> affect the entire Paxeer chain. Test thoroughly:
-      </p>
-
-      <ol>
-        <li>Edit code under <code>sdk/</code></li>
-        <li>Rebuild <code>paxd</code>: <code>make build</code></li>
-        <li>Run unit tests: <code>make test</code></li>
-        <li>Test with <Link href="/docker">Docker cluster</Link>: <code>make docker-cluster-start</code></li>
-        <li>Run integration tests: <code>make test-integration</code></li>
-      </ol>
-
-      <h2>Differences from Upstream Cosmos SDK</h2>
-
-      <p>
-        Paxeer's SDK fork diverges from upstream in several areas:
-      </p>
-
-      <ul>
-        <li>Custom storage backends (MEMIAVL, Giga)</li>
-        <li>EVM module integration and pointer contracts</li>
-        <li>Optimistic concurrency control (OCC) for parallel execution</li>
-        <li>Receipt indexing and synthetic transactions</li>
-        <li>Paxeer-specific ante handlers and gas metering</li>
-        <li>Chain-specific upgrade logic</li>
-      </ul>
-
-      <p>
-        Do not assume compatibility with standard Cosmos SDK tooling (e.g., CosmJS, Keplr) without testing.
-      </p>
-
-      <h2>Go Module Path</h2>
-
-      <pre><code>{`github.com/sidiora-labs/paxeer-network/sdk`}</code></pre>
-
-      <p>
-        This is an internal module within the Paxeer monorepo, not a standalone published module.
-      </p>
-
-      <div className="prev-next">
-        <Link href="/docker">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Docker</div>
-        </Link>
-        <Link href="/interchain">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Interchain</div>
-        </Link>
-      </div>
+      <PageNav
+        prev={{ href: '/docker', title: 'Docker' }}
+        next={{ href: '/interchain', title: 'Interchain' }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/components/api/ApiPage.tsx
+++ b/paxeer-docs/src/components/api/ApiPage.tsx
@@ -1,0 +1,184 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+import { SnippetBlock } from './SnippetBlock'
+import { m3 } from './tokens'
+
+export { SnippetBlock, m3 }
+
+export function PageLead({
+  overline,
+  children,
+  source,
+}: {
+  overline: string
+  children: ReactNode
+  source: string
+}) {
+  return (
+    <header className="mb-10">
+      <p className={`${m3.overline} mb-4`}>{overline}</p>
+      <div className={`${m3.body} space-y-4`}>{children}</div>
+      <div className="mt-6 rounded-lg bg-surface-low px-4 py-3">
+        <div className={m3.label}>Source</div>
+        <code className="text-sm">{source}</code>
+      </div>
+    </header>
+  )
+}
+
+export function FactChips({ items }: { items: { label: string; value: string }[] }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 mb-10">
+      {items.map((item) => (
+        <div key={item.label} className="rounded-lg bg-surface-low px-4 py-4 shadow-1">
+          <div className={`${m3.label} mb-2`}>{item.label}</div>
+          <div className="font-mono text-sm font-medium text-on-surface">{item.value}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function JumpNav({ items }: { items: { id: string; label: string }[] }) {
+  return (
+    <nav className="mb-10" aria-label="On this page">
+      <div className={`${m3.label} mb-3`}>On this page</div>
+      <div className="flex flex-wrap gap-2">
+        {items.map((item) => (
+          <a
+            key={item.id}
+            href={`#${item.id}`}
+            className="inline-flex items-center min-h-9 px-3 rounded-full bg-surface-low text-sm text-on-surface-variant hover:text-on-surface hover:bg-surface-high transition-all duration-150"
+          >
+            {item.label}
+          </a>
+        ))}
+      </div>
+    </nav>
+  )
+}
+
+export function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="mb-14">
+      <h2
+        id={id}
+        className={`${m3.headline} scroll-mt-8 !mt-0 !mb-3 !border-0 !pb-0`}
+        style={{ borderBottom: 'none', paddingBottom: 0, marginTop: 0 }}
+      >
+        {title}
+      </h2>
+      <div className="h-px bg-outline-variant mb-6" />
+      {children}
+    </section>
+  )
+}
+
+export function Subhead({
+  id,
+  children,
+}: {
+  id?: string
+  children: ReactNode
+}) {
+  return (
+    <h3
+      id={id}
+      className={`${m3.title} scroll-mt-8 !mt-8 !mb-3`}
+      style={{ marginTop: '2rem' }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+export function MethodTable({
+  columns,
+  rows,
+}: {
+  columns: string[]
+  rows: string[][]
+}) {
+  return (
+    <div className="my-6 rounded-lg bg-surface-container shadow-1 overflow-hidden">
+      <div
+        className="grid gap-3 px-4 py-3 bg-surface-low"
+        style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}
+      >
+        {columns.map((column) => (
+          <div key={column} className={`${m3.label} text-on-surface`}>
+            {column}
+          </div>
+        ))}
+      </div>
+      {rows.map((row, index) => (
+        <div
+          key={`${row[0]}-${index}`}
+          className={`grid gap-3 px-4 py-3 ${index % 2 === 0 ? 'bg-surface-container' : 'bg-surface-low'}`}
+          style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}
+        >
+          {row.map((cell, cellIndex) => (
+            <div
+              key={`${index}-${cellIndex}`}
+              className={cellIndex === 0 ? 'font-mono text-sm text-on-surface break-all' : `${m3.body} text-sm`}
+            >
+              {cell}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function Callout({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className="my-6 rounded-lg bg-surface-low px-4 py-3 shadow-1">
+      <div className={`${m3.label} mb-1`}>{label}</div>
+      <div className={m3.body}>{children}</div>
+    </div>
+  )
+}
+
+export function PageNav({
+  prev,
+  next,
+}: {
+  prev?: { href: string; title: string }
+  next?: { href: string; title: string }
+}) {
+  return (
+    <div className="mt-16 grid grid-cols-2 gap-3">
+      {prev ? (
+        <Link href={prev.href} className="rounded-lg bg-surface-container shadow-1 px-5 py-4 hover:bg-surface-high transition-all duration-150">
+          <div className={m3.label}>Previous</div>
+          <div className={`${m3.title} mt-1`}>{prev.title}</div>
+        </Link>
+      ) : (
+        <div />
+      )}
+      {next ? (
+        <Link href={next.href} className="rounded-lg bg-surface-container shadow-1 px-5 py-4 text-right hover:bg-surface-high transition-all duration-150">
+          <div className={m3.label}>Next</div>
+          <div className={`${m3.title} mt-1`}>{next.title}</div>
+        </Link>
+      ) : (
+        <div />
+      )}
+    </div>
+  )
+}

--- a/paxeer-docs/src/components/api/SnippetBlock.tsx
+++ b/paxeer-docs/src/components/api/SnippetBlock.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+import { m3 } from './tokens'
+
+export type SnippetMeta = {
+  method: string
+  args: string
+  source: string
+  purpose: string
+  code: string
+}
+
+function copyText(text: string) {
+  return navigator.clipboard.writeText(text).catch(() => {
+    const field = document.createElement('textarea')
+    field.value = text
+    field.style.position = 'fixed'
+    field.style.opacity = '0'
+    document.body.appendChild(field)
+    field.select()
+    document.execCommand('copy')
+    field.remove()
+  })
+}
+
+function ActionButton({
+  label,
+  doneLabel,
+  onCopy,
+}: {
+  label: string
+  doneLabel: string
+  onCopy: () => Promise<void> | void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        await onCopy()
+        setCopied(true)
+        setTimeout(() => setCopied(false), 2000)
+      }}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-surface-high text-on-surface-variant hover:text-on-surface text-xs font-medium transition-all duration-150"
+    >
+      {copied ? doneLabel : label}
+    </button>
+  )
+}
+
+export function SnippetBlock({ method, args, source, purpose, code }: SnippetMeta) {
+  const agentText = [
+    `method: ${method}`,
+    `args: ${args}`,
+    `source: ${source}`,
+    `purpose: ${purpose}`,
+  ].join('\n')
+
+  return (
+    <div className="my-6 rounded-lg bg-surface-container shadow-1 overflow-hidden">
+      <div className="flex flex-wrap items-start justify-between gap-3 px-4 py-3 bg-surface-low">
+        <div className="min-w-0">
+          <div className={m3.overline}>{method}</div>
+          <p className={`${m3.label} mt-1`}>{purpose}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <ActionButton label="Copy" doneLabel="Copied" onCopy={() => copyText(code)} />
+          <ActionButton label="Agent copy" doneLabel="Copied" onCopy={() => copyText(agentText)} />
+        </div>
+      </div>
+      <div className="px-4 py-3 font-mono text-sm text-on-surface overflow-x-auto whitespace-pre">{code}</div>
+      <div className="px-4 py-2 bg-surface-low">
+        <span className={m3.label}>
+          {source}
+          {args ? ` · ${args}` : ''}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/paxeer-docs/src/components/api/tokens.ts
+++ b/paxeer-docs/src/components/api/tokens.ts
@@ -1,0 +1,8 @@
+export const m3 = {
+  display: 'm3-display text-5xl font-light tracking-[-0.02em] text-on-surface',
+  headline: 'm3-headline text-[2rem] font-normal tracking-[-0.02em] text-on-surface',
+  title: 'm3-title text-xl font-medium text-on-surface',
+  body: 'm3-body text-base text-on-surface-variant leading-relaxed',
+  label: 'm3-label text-xs text-on-surface-variant tracking-wide',
+  overline: 'm3-overline font-mono text-xs text-ink-text uppercase tracking-[0.14em]',
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to PR #89 (M3 chrome on `cursor/paxeer-docs-site-8735`). Restyles Gideon's eight API docs pages so they use the existing M3 tokens and type scale already in the shell. Landing, sidebar, search, and the global copy / agent-copy chrome are untouched — Jarvis owns those.

This is documentation markup only. No protocol, wire, or contract ABI change. Do not merge.

## Pages

- `/json-rpc` — `paxeer-docs/src/app/json-rpc/`
- `/json-rpc-unsupported` — `paxeer-docs/src/app/json-rpc-unsupported/`
- `/rest-grpc` — `paxeer-docs/src/app/rest-grpc/`
- `/contracts` — `paxeer-docs/src/app/contracts/`
- `/docker` — `paxeer-docs/src/app/docker/`
- `/sdk` — `paxeer-docs/src/app/sdk/`
- `/interchain` — `paxeer-docs/src/app/interchain/`
- `/admin-hpx` — `paxeer-docs/src/app/admin-hpx/`

Shared primitives live in `paxeer-docs/src/components/api/` (jump nav, method tables as surfaces, per-snippet copy + tight agent-copy). Pages pass `pageTitle` into the existing `DocsLayout` so the global Copy for agent control still mounts.

## Claim lock

- Chain ID 125 / `hyperpax_125-1`
- No public LayerX RPC
- LayerX fee 5,000 µUSDX/activity, not zero
- PAX is gas
- LayerX settlement contracts are repo-root `contracts/`
- File cites stay under `paxeer-network/` (plus root `contracts/` for settlement)

## Specification

- Requirement clause(s): documentation restyle only; not a protocol task
- Codify task: n/a
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI: none

## Verification

- `cd paxeer-docs && npm install && npm run build` — Next.js 14.2.35 compiled; 32 static routes generated, including all eight pages above.
- Static export served from `paxeer-docs/out`; all eight routes returned HTTP 200.
- Browser pass: each page shows the existing sidebar + search chrome, a display title with Copy for agent, on-page jump pills, surface method tables (not 1px boxed `<table>`s), and snippet Copy / Agent copy controls. Landing `/` is unchanged.
- `make public-audit` and native/Solidity suites: not run (docs-only).

[JSON-RPC namespaces](https://cursor.com/agents/bc-43380dcf-4095-4f40-9389-020de8717fbc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fjson_rpc_namespaces.webp)
[REST gRPC evm.Query table](https://cursor.com/agents/bc-43380dcf-4095-4f40-9389-020de8717fbc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Frest_grpc_evm_query.webp)
[Docker host ports](https://cursor.com/agents/bc-43380dcf-4095-4f40-9389-020de8717fbc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocker_host_ports.webp)
[Admin HPX snippet](https://cursor.com/agents/bc-43380dcf-4095-4f40-9389-020de8717fbc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fadmin_hpx_snippet.webp)

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. (no KVX change; page sources only)
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants.
- [ ] I added real positive, negative, and adversarial coverage appropriate to the change.
- [ ] I ran `make public-audit` and the affected native or Solidity suites.
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43380dcf-4095-4f40-9389-020de8717fbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43380dcf-4095-4f40-9389-020de8717fbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

