### PR TITLE
docs(paxeer): restyle Ultron intro/install/config/operators onto M3

### DIFF
--- a/paxeer-docs/src/app/configuration/page.tsx
+++ b/paxeer-docs/src/app/configuration/page.tsx
@@ -1,17 +1,14 @@
 import { DocsLayout } from '@/components/DocsLayout'
-import Link from 'next/link'
+import { PrevNext } from '@/components/PrevNext'
 
 export default function Configuration() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Configuration</h1>
-        <p className="page-description">
-          Configuring paxd through config.toml, app.toml, node modes, and environment variables.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Configuration">
+      <p className="text-on-surface-variant mb-6">
+        Configuring paxd through config.toml, app.toml, node modes, and environment variables.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/node/params/config.go</code>, <code>docker/localnode/config/</code>, <code>config.yml</code>
       </div>
 
@@ -91,7 +88,7 @@ export default function Configuration() {
         </tbody>
       </table>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Implementation:</strong> <code>node/params/config.go</code> — <code>SetTendermintConfigByMode</code>, <code>SetAppConfigByMode</code>
       </div>
 
@@ -160,7 +157,7 @@ size = 5000
 # Max transaction bytes
 max-txs-bytes = 1073741824`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Template:</strong> <code>docker/localnode/config/config.toml</code>
       </div>
 
@@ -191,7 +188,7 @@ concurrency-workers = 4
 # Optimistic Concurrency Control (OCC)
 occ-enabled = true`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>OCC:</strong> Enables parallel transaction execution with conflict detection
       </div>
 
@@ -281,7 +278,7 @@ enabled-legacy-pax-apis = [
   "pax_getEVMInfo"
 ]`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>docker/localnode/config/app.toml</code>, <code>rpc/config</code>
       </div>
 
@@ -351,7 +348,7 @@ min-retain-blocks = 0  # Keep all Tendermint blocks
 
 pruning = "nothing"  # Keep all state`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Implementation:</strong> <code>node/params/config.go:180-196</code>
       </div>
 
@@ -367,7 +364,7 @@ pruning = "nothing"  # Keep all state`}</code></pre>
         <li><strong>Consensus node:</strong> <code>paxvalcons...</code></li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>node/params/config.go:20-39</code>
       </div>
 
@@ -399,7 +396,7 @@ pruning = "nothing"  # Keep all state`}</code></pre>
         1 hpx = 1,000,000 uhpx
       </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>node/params/config.go:13-18</code>
       </div>
 
@@ -430,7 +427,7 @@ HPX_MIRROR=https://node.hyperpaxeer.com
 # Runtime config source
 HPX_RUNTIME_CONFIG_DIR=/root/.paxeer/config`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>hpx/README.md</code>
       </div>
 
@@ -455,16 +452,10 @@ HPX_RUNTIME_CONFIG_DIR=/root/.paxeer/config`}</code></pre>
         This checks configuration syntax and module initialization without starting the node.
       </p>
 
-      <div className="prev-next">
-        <Link href="/run-node">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Run a Node</div>
-        </Link>
-        <Link href="/operators">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Operators Guide</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/run-node", title: "Run a Node" }}
+        next={{ href: "/operators", title: "Operators Guide" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/installation/page.tsx
+++ b/paxeer-docs/src/app/installation/page.tsx
@@ -1,4 +1,5 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function Installation() {
@@ -9,7 +10,7 @@ export default function Installation() {
       </p>
 
       <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
-        <strong className="text-on-surface">Source:</strong> <code>paxeer-network/Makefile</code> and <code>paxeer-network/README.md</code>
+        <strong>Source:</strong> <code>paxeer-network/Makefile</code> and <code>paxeer-network/README.md</code>
       </div>
 
       <h2>Prerequisites</h2>
@@ -137,7 +138,7 @@ make ci       # Lint + test`}</code></pre>
 
 go 1.23`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Note:</strong> Paxeer maintains its own <code>go.mod</code>, <code>go.sum</code>, and dependency tree separate from the LayerX monorepo root.
       </div>
 
@@ -155,7 +156,7 @@ forge build`}</code></pre>
         See <code>paxeer-network/contracts/README.md</code> for contract-specific instructions.
       </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Important:</strong> <code>paxeer-network/contracts/</code> contains Paxeer-native contracts (WPAX, pointers, precompile interfaces). LayerX settlement contracts are at <code>contracts/</code> in the repository root.
       </div>
 
@@ -173,9 +174,9 @@ forge build`}</code></pre>
 
       <h2>Development vs Production</h2>
 
-      <div className="source-note">
-        <span className="badge badge-warning">Development Only</span>
-        <p style={{ marginTop: '0.5rem' }}>
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
+        <span className="inline-block px-2 py-0.5 rounded-xs text-xs font-medium uppercase tracking-wider bg-warning/20 text-warning">Development Only</span>
+        <p className="mt-2 mb-0">
           A successful local build is development evidence. It is <strong>not authorization</strong> to deploy validators, move custody, or handle real assets.
         </p>
       </div>
@@ -188,16 +189,10 @@ forge build`}</code></pre>
         <li><Link href="/docker">Use Docker for local testing</Link></li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/network-parameters">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Network Parameters</div>
-        </Link>
-        <Link href="/run-node">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Run a Node</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/network-parameters", title: "Network Parameters" }}
+        next={{ href: "/run-node", title: "Run a Node" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/network-parameters/page.tsx
+++ b/paxeer-docs/src/app/network-parameters/page.tsx
@@ -1,15 +1,13 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function NetworkParameters() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Network Parameters</h1>
-        <p className="page-description">
-          Key parameters and configuration for Paxeer Network chain ID 125.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Network Parameters">
+      <p className="text-on-surface-variant mb-6">
+        Key parameters and configuration for Paxeer Network chain ID 125.
+      </p>
 
       <h2>Chain Identifiers</h2>
 
@@ -127,7 +125,7 @@ export default function NetworkParameters() {
         </tbody>
       </table>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Important:</strong> LayerX does <strong>not</strong> have zero fees. The paxeer.app marketing site incorrectly states "zero LayerX fees." LayerX charges 5,000 µUSDX base fee with congestion multiplier.
       </div>
 
@@ -143,7 +141,7 @@ export default function NetworkParameters() {
         <li><strong>Module basics:</strong> EVM, epoch, mint, oracle, store, tokenfactory</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/node/genesis.go</code>
       </div>
 
@@ -161,7 +159,7 @@ export default function NetworkParameters() {
         <li><strong>No pending state:</strong> Transactions finalize immediately</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/consensus/</code>
       </div>
 
@@ -198,15 +196,15 @@ export default function NetworkParameters() {
         <li><strong><Link href="/modules/tokenfactory">tokenfactory</Link>:</strong> Permissioned creation and management of native token denominations</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/modules/</code>
       </div>
 
       <h2>Public Endpoints</h2>
 
-      <div className="source-note">
-        <span className="badge badge-warning">Limited Beta</span>
-        <p style={{ marginTop: '0.5rem' }}>
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
+        <span className="inline-block px-2 py-0.5 rounded-xs text-xs font-medium uppercase tracking-wider bg-warning/20 text-warning">Limited Beta</span>
+        <p className="mt-2 mb-0">
           LayerX limited beta opens September 7, 2026. Public RPC endpoints are not yet available. Do not invent or document public LayerX RPC URLs.
         </p>
       </div>
@@ -226,16 +224,10 @@ export default function NetworkParameters() {
         <li><strong>Chain ID:</strong> 125</li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/paxeer-vs-layerx">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Paxeer vs LayerX</div>
-        </Link>
-        <Link href="/installation">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Installation & Build</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/paxeer-vs-layerx", title: "Paxeer vs LayerX" }}
+        next={{ href: "/installation", title: "Installation & Build" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/operators/page.tsx
+++ b/paxeer-docs/src/app/operators/page.tsx
@@ -1,17 +1,14 @@
 import { DocsLayout } from '@/components/DocsLayout'
-import Link from 'next/link'
+import { PrevNext } from '@/components/PrevNext'
 
 export default function Operators() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Operators Guide</h1>
-        <p className="page-description">
-          Production best practices for running Paxeer validators and full nodes.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Operators Guide">
+      <p className="text-on-surface-variant mb-6">
+        Production best practices for running Paxeer validators and full nodes.
+      </p>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>paxeer-network/docker/README.md</code>, <code>hpx/README.md</code>, <code>Makefile</code>
       </div>
 
@@ -104,7 +101,7 @@ hpx register        # Register node in public peer registry
 hpx statesync       # Get state-sync parameters
 hpx remove          # Uninstall node`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>hpx/README.md:10-31</code>
       </div>
 
@@ -161,7 +158,7 @@ docker exec -it pax-node-0 /bin/bash`}</code></pre>
 
       <pre><code>{`make build-docker-node && make run-local-node`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>docker/README.md:23-54</code>
       </div>
 
@@ -198,7 +195,7 @@ docker exec -it pax-node-0 /bin/bash`}</code></pre>
 ./docker/monitornode/scripts/stop-prometheus.sh
 ./docker/monitornode/scripts/stop-grafana.sh`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>docker/README.md:55-82</code>
       </div>
 
@@ -226,7 +223,7 @@ paxd status | jq
 # Start state sync node
 make run-rpc-node`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Source:</strong> <code>docker/README.md:84-95</code>
       </div>
 
@@ -466,16 +463,10 @@ paxd tx slashing unjail --from=validator`}</code></pre>
         <li>Reduce <code>cache-size</code> settings</li>
       </ul>
 
-      <div className="prev-next">
-        <Link href="/configuration">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Configuration</div>
-        </Link>
-        <Link href="/consensus">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Consensus</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/configuration", title: "Configuration" }}
+        next={{ href: "/consensus", title: "Consensus" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/paxeer-vs-layerx/page.tsx
+++ b/paxeer-docs/src/app/paxeer-vs-layerx/page.tsx
@@ -1,15 +1,12 @@
 import { DocsLayout } from '@/components/DocsLayout'
-import Link from 'next/link'
+import { PrevNext } from '@/components/PrevNext'
 
 export default function PaxeerVsLayerX() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Paxeer vs LayerX</h1>
-        <p className="page-description">
-          Understanding the relationship and boundaries between Paxeer L1 and the LayerX agent channel.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Paxeer vs LayerX">
+      <p className="text-on-surface-variant mb-6">
+        Understanding the relationship and boundaries between Paxeer L1 and the LayerX agent channel.
+      </p>
 
       <h2>Two Distinct Systems</h2>
 
@@ -31,7 +28,7 @@ export default function PaxeerVsLayerX() {
         <li><strong>Standard finality:</strong> Block-based Byzantine Fault Tolerant consensus</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Repository path:</strong> <code>paxeer-network/</code> (this documentation)
       </div>
 
@@ -49,7 +46,7 @@ export default function PaxeerVsLayerX() {
         <li><strong>Settlement unit:</strong> USDX (backed by USDL on Paxeer L1)</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Repository paths:</strong> Root directories <code>src/</code>, <code>include/</code>, <code>agent/</code>, <code>human/</code>, <code>platform/</code>, <code>programs/</code>, <code>interop/</code>
       </div>
 
@@ -122,7 +119,7 @@ export default function PaxeerVsLayerX() {
         <li><strong>Emergency exits:</strong> Protocol-level safety when LayerX is degraded</li>
       </ul>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Contracts path:</strong> <code>contracts/</code> at repository root (not <code>paxeer-network/contracts/</code>)
       </div>
 
@@ -168,16 +165,10 @@ export default function PaxeerVsLayerX() {
         Ethereum and Solana mirrors in <code>interop/</code> are <strong>archives</strong>, not settlement venues or custody domains. They publish batch commitments for independent verification but hold no vaults, portals, or custody semantics. <strong>Paxeer remains the exclusive custody and withdrawal guarantee.</strong>
       </p>
 
-      <div className="prev-next">
-        <Link href="/">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Introduction</div>
-        </Link>
-        <Link href="/network-parameters">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Network Parameters</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/", title: "Introduction" }}
+        next={{ href: "/network-parameters", title: "Network Parameters" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/app/run-node/page.tsx
+++ b/paxeer-docs/src/app/run-node/page.tsx
@@ -1,19 +1,17 @@
 import { DocsLayout } from '@/components/DocsLayout'
+import { PrevNext } from '@/components/PrevNext'
 import Link from 'next/link'
 
 export default function RunNode() {
   return (
-    <DocsLayout>
-      <div className="page-header">
-        <h1 className="page-title">Run a Node</h1>
-        <p className="page-description">
-          How to run a Paxeer node (paxd) for validation, archiving, or RPC.
-        </p>
-      </div>
+    <DocsLayout pageTitle="Run a Node">
+      <p className="text-on-surface-variant mb-6">
+        How to run a Paxeer node (paxd) for validation, archiving, or RPC.
+      </p>
 
-      <div className="source-note">
-        <span className="badge badge-warning">Limited Beta</span>
-        <p style={{ marginTop: '0.5rem' }}>
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
+        <span className="inline-block px-2 py-0.5 rounded-xs text-xs font-medium uppercase tracking-wider bg-warning/20 text-warning">Limited Beta</span>
+        <p className="mt-2 mb-0">
           LayerX limited beta opens September 7, 2026. Validator onboarding and public endpoints not yet available.
         </p>
       </div>
@@ -93,7 +91,7 @@ export default function RunNode() {
       <pre><code>{`# Mainnet genesis (when available)
 curl -o ~/.paxd/config/genesis.json https://...`}</code></pre>
 
-      <div className="source-note">
+      <div className="bg-surface-high border border-outline-variant rounded-lg px-4 py-3 mb-6">
         <strong>Note:</strong> Genesis URL will be published when mainnet launches.
       </div>
 
@@ -234,16 +232,10 @@ make docker-cluster-start`}</code></pre>
         See <Link href="/docker">Docker documentation</Link> for compose configurations.
       </p>
 
-      <div className="prev-next">
-        <Link href="/installation">
-          <div className="prev-next-label">Previous</div>
-          <div className="prev-next-title">Installation & Build</div>
-        </Link>
-        <Link href="/configuration">
-          <div className="prev-next-label">Next</div>
-          <div className="prev-next-title">Configuration</div>
-        </Link>
-      </div>
+      <PrevNext
+        prev={{ href: "/installation", title: "Installation & Build" }}
+        next={{ href: "/configuration", title: "Configuration" }}
+      />
     </DocsLayout>
   )
 }

--- a/paxeer-docs/src/components/PrevNext.tsx
+++ b/paxeer-docs/src/components/PrevNext.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export function PrevNext({
+  prev,
+  next,
+}: {
+  prev: { href: string; title: string }
+  next: { href: string; title: string }
+}) {
+  return (
+    <nav className="grid grid-cols-2 gap-3 mt-12 pt-8 border-t border-outline-variant">
+      <Link
+        href={prev.href}
+        className="bg-surface-high rounded-lg p-5 border border-outline-variant hover:border-ink-text transition-all duration-150 hover:translate-y-[-2px]"
+      >
+        <div className="text-xs text-on-surface-variant uppercase tracking-wider mb-2">Previous</div>
+        <div className="text-lg font-medium text-on-surface">{prev.title}</div>
+      </Link>
+      <Link
+        href={next.href}
+        className="bg-surface-high rounded-lg p-5 border border-outline-variant hover:border-ink-text transition-all duration-150 hover:translate-y-[-2px] text-right"
+      >
+        <div className="text-xs text-on-surface-variant uppercase tracking-wider mb-2">Next</div>
+        <div className="text-lg font-medium text-on-surface">{next.title}</div>
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sibling of #90 against the same #89 base (`cursor/paxeer-docs-m3-ui-86ef`). Restyles Ultron Getting Started / Running Nodes pages onto the existing M3 chrome: `DocsLayout pageTitle` (Copy-for-agent), surface-high / outline-variant source cards, warning chips, and `PrevNext` cards. Technical facts are unchanged.

Do not merge. Do not target main.

## Specification

- Requirement clause(s): docs restyle only; no protocol / wire / ABI change
- Codify task: n/a (continuation of #89 M3 chrome; sibling of #90)
- Compatibility impact on wire encoding, result codes, state roots, storage, or contract ABI: none

## Files changed

- `paxeer-docs/src/app/paxeer-vs-layerx/page.tsx`
- `paxeer-docs/src/app/network-parameters/page.tsx`
- `paxeer-docs/src/app/installation/page.tsx`
- `paxeer-docs/src/app/run-node/page.tsx`
- `paxeer-docs/src/app/configuration/page.tsx`
- `paxeer-docs/src/app/operators/page.tsx`
- `paxeer-docs/src/components/PrevNext.tsx` (shared prev/next cards used only by these pages)

No `/intro` route exists. Nav "Introduction" is `/` (landing), which is Jarvis #89 and was left alone.

## Files left alone

- Landing / home `paxeer-docs/src/app/page.tsx`
- Search, copy, copy-for-agent, `DocsLayout`, sidebar, `layout.tsx`, `globals.css`, M3 tokens, fonts
- Jarvis core: consensus, engine, evm, modules, storage, precompiles, wasm, wasm-runtime, wasmbinding, epoch, mint, oracle, store, tokenfactory
- Gideon API: json-rpc, json-rpc-unsupported, rest-grpc, contracts, docker, sdk, interchain, admin-hpx
- `paxeer-network/` source
- `main`

These pages speak #89 M3 tokens directly. They do not depend on #90 leftover-class remaps in layout CSS. Snippet copy buttons are #89 chrome and were not changed.

## Fee lock (unchanged)

- LayerX base fee is 5,000 µUSDX per activity (~½¢), congestion 1×–64×
- Never "zero fees"
- Paxeer is EVM L1 chain ID 125, Cosmos id `hyperpax_125-1`
- PAX = Paxeer gas; USDX = LayerX unit
- Limited beta September 7, 2026
- No new RPC, TPS, or endpoints invented

## Verification

`npm run build` in `paxeer-docs/` succeeded on this branch: Next.js 14.2.35 compiled, 32/32 static pages generated, including the six Ultron routes.

## Checklist

- [x] I changed KVX/source documents rather than generated specification mirrors. (n/a — docs site only)
- [x] I preserved canonical encoding, deterministic replay, and 402LXP sole-writer invariants.
- [ ] I added real positive, negative, and adversarial coverage appropriate to the change.
- [ ] I ran `make public-audit` and the affected native or Solidity suites.
- [x] I introduced no credentials, local artifacts, private infrastructure identifiers, mocks, stubs, or placeholders.
- [x] I am not representing local verification as production certification or deployment authorization.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4943d2b9-71fe-424e-9c13-7a8791af577d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4943d2b9-71fe-424e-9c13-7a8791af577d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

