### PR TITLE
Custody funding: protocol-3 credit path, Anvil evidence, funded SEND integration test

### DIFF
--- a/human/crates/layerx-paxeer-client/tests/account_vectors.rs
+++ b/human/crates/layerx-paxeer-client/tests/account_vectors.rs
@@ -1,0 +1,41 @@
+use layerx_paxeer_client::{account_address, account_address_for_protocol};
+use layerx_types::account::AccountId;
+
+#[test]
+fn protocol_three_matches_native_ledger_account_vectors() {
+    for (name, expected) in [
+        (
+            "agent:did:key:alice:main",
+            "efc9802f76722dfc48ebfed35bfd8b20dbc2775fe2f027d6cbd595aff1307454",
+        ),
+        (
+            "system:paxeer-reserve",
+            "6e0e5cca5cfaa1b20ddd1c6174321eeaf00dd74bce2adcd78b61e15aa9e26f7c",
+        ),
+        (
+            "system:paxeer-withdrawals",
+            "36e5bfab4a0143c723aaac6a61d6eae554e684f94cfff2a24f5fdf0574c468f7",
+        ),
+    ] {
+        let account = AccountId::parse(name).unwrap_or_else(|error| panic!("{error:?}"));
+        let actual =
+            account_address_for_protocol(&account, 3).unwrap_or_else(|error| panic!("{error:?}"));
+        let expected_bytes: Vec<u8> = (0..expected.len())
+            .step_by(2)
+            .map(|offset| {
+                u8::from_str_radix(&expected[offset..offset + 2], 16)
+                    .unwrap_or_else(|error| panic!("{error}"))
+            })
+            .collect();
+        assert_eq!(
+            actual.as_slice(),
+            expected_bytes,
+            "native tests/ledger/test_account_id.c: {name}"
+        );
+        assert_ne!(actual, account_address(&account));
+        assert_eq!(
+            account_address_for_protocol(&account, 2),
+            Ok(account_address(&account))
+        );
+    }
+}

--- a/human/crates/layerx-paxeer-client/tests/custody_evidence.rs
+++ b/human/crates/layerx-paxeer-client/tests/custody_evidence.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn real_weth_protocol_three_custody_evidence() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap_or_else(|| panic!("repository root"));
+    let output = root
+        .join("qual-logs")
+        .join(format!("custody-evidence-{}", std::process::id()));
+    let status = Command::new("python3")
+        .arg(root.join("tests/bridge/local_credit_evidence.py"))
+        .arg("--output")
+        .arg(&output)
+        .status()
+        .unwrap_or_else(|error| panic!("custody evidence producer: {error}"));
+    assert!(status.success(), "real custody evidence failed: {status}");
+    let read = |name| std::fs::read(output.join(name)).unwrap_or_else(|error| panic!("{error}"));
+    let profile = read("custody.profile");
+    let credit = read("custody.credit");
+    assert_eq!(profile.len(), 207);
+    assert_eq!(credit.len(), 427);
+    let identity =
+        String::from_utf8(read("identity.json")).unwrap_or_else(|error| panic!("{error}"));
+    let identity =
+        layerx_paxeer_client::parse_json(&identity).unwrap_or_else(|error| panic!("{error:?}"));
+    let did = identity
+        .member("did")
+        .and_then(layerx_paxeer_client::Json::as_text)
+        .unwrap_or_else(|| panic!("actor DID"));
+    let account = layerx_types::account::AccountId::parse(&format!("agent:{did}:main"))
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    let beneficiary = layerx_paxeer_client::account_address_for_protocol(&account, 3)
+        .unwrap_or_else(|error| panic!("{error:?}"));
+    assert_eq!(&credit[107..139], beneficiary.as_slice());
+    let public: [u8; 32] = profile[65..97]
+        .try_into()
+        .unwrap_or_else(|error| panic!("{error}"));
+    let authority =
+        ed25519_dalek::VerifyingKey::from_bytes(&public).unwrap_or_else(|error| panic!("{error}"));
+    let signature = ed25519_dalek::Signature::from_slice(&credit[363..])
+        .unwrap_or_else(|error| panic!("{error}"));
+    let mut message = b"LX:CUSTODY:CREDIT:v1".to_vec();
+    message.extend_from_slice(&credit[..363]);
+    authority
+        .verify_strict(&message, &signature)
+        .unwrap_or_else(|error| panic!("{error}"));
+    message[20] ^= 1;
+    assert!(authority.verify_strict(&message, &signature).is_err());
+}

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1042,3 +1042,19 @@ symbol = "lxp_daemon_process_batch"
 observed = "Protocol-2 NativeProgramCall publication attempted composite account-evidence validation against the legacy receipt-transition root and could terminate after publishing a genuine batch. Live and recovery publication now gate composite account evidence on explicit protocol 3. Protocol 2 advertises no account_read capability and returns typed ModuleDisabled for account reads and account proof bundles; canonical receipt and batch evidence remain available. Native build, make check and test-layerxd plus test-daemon-lni-admission exit 0: /tmp/layerx-native-protocol2-evidence-build.log, /tmp/layerx-native-protocol2-evidence-check.log and /tmp/layerx-native-protocol2-evidence-daemon-tests.log. Stable daemon SHA256 d0056c4ac48f0f68c834b93ec41ee5cf97422c9d9e95c58a803024e760a8965c. The protocol-3 recheck passes five real Programs boundary tests, one artifact unit test, two authority tests and four of five core tests. One core receipt lookup failed with handshake PeerShutdown under concurrent compilation; rerunning exactly boundary_serves_the_real_sequencer_over_the_lni after the image compilation passes unchanged, 1/1 in 24.84 seconds. Logs /tmp/layerx-protocol-profile-boundaries-test.log and /tmp/layerx-core-stable-profile-rerun.log."
 assumption = "No assertion, timeout, signature or state-proof rule was weakened. The transient handshake failure is retained; load as its cause is unconfirmed. Protocol-2 restart evidence and full agentd aggregate qualification are still pending."
 severity = "note"
+
+[observation.custody.protocol3_account_vectors]
+task = "6.1"
+file = "human/crates/layerx-paxeer-client/tests/account_vectors.rs"
+symbol = "account_address_for_protocol lx_account_id_from_string"
+observed = "Protocol 3 derives beneficiary accounts through the native LX:ACCOUNT:v1 domain, a four-byte big-endian name length and the canonical name. Fixed C suite vectors from tests/ledger/test_account_id.c for agent:did:key:alice:main, system:paxeer-reserve and system:paxeer-withdrawals are cross-checked by the Rust client. The legacy LXP/v1/account-id\\0 derivation is superseded for protocol 3 only; the explicit protocol-2 result remains unchanged. cargo check -p layerx-paxeer-client, package cargo fmt --check, package all-target clippy with -D warnings and the original complete package test suite pass; logs are qual-logs/item1-check.log, item1-fmt-check.log, item1-clippy-final.log and item1-test.log."
+assumption = "The existing signed-root proof is not the 427-byte authenticated custody credit; its complete-proof ingress refusal remains intact. Account derivation qualification does not establish funded execution."
+severity = "info"
+
+[observation.custody.human_qualification_dependency]
+task = "6.1"
+file = "human/apps/web/package.json"
+symbol = "human-lint-copy"
+observed = "make human-lint human-test-unit reaches npm --prefix human/apps/web run typecheck and fails because tsc is not installed, with command exit 127 at Makefile:2001. Evidence is qual-logs/item1-human-gates.log."
+assumption = "Install the locked web dependencies in the qualification environment and rerun the unchanged aggregate gate. No assertion, dependency policy or lint is disabled."
+severity = "blocker"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1066,3 +1066,19 @@ symbol = "real_weth_protocol_three_custody_evidence"
 observed = "A fresh chain 31337 wraps actual ETH in the repository WETH contract and deposits the resulting tokens in the real LayerXVault, configured through the real timelock and AssetRegistry. A second Anvil forks the exact deposited chain state. custody_credit.py verifies both origins, header ancestry, eth_getProof runtime accounts and complete receipt/transaction trie reconstruction, emits a 207-byte profile and 427-byte attestor credit, and test_evidence.py passes its real-evidence tamper and divergent-finality checks. The Rust integration independently checks the attestor signature and native beneficiary derivation. Final complete package tests including the WETH integration pass with the worktree Python virtual environment on PATH; qual-logs/final-test.log. Package formatting and strict all-target clippy pass; qual-logs/final-fmt-check.log and qual-logs/final-clippy.log. make human-test-unit passes; qual-logs/human-unit.log."
 assumption = "The fork observer shares its upstream trust source; distinct origins are local replication evidence, not independent production quorum or production finality. Generated actor and attestor seeds and chain artifacts remain untracked. Local-chain deployment refuses chain 125 and port 18545. The aggregate human-lint dependency failure remains open."
 severity = "info"
+
+[observation.custody.genesis_and_funded_send_gap]
+task = "6.1"
+file = "tests/bridge/custody_genesis.py"
+symbol = "lxp_genesis_build_fresh_custody"
+observed = "custody_genesis.py builds a canonical 395-byte protocol-3 request from the produced custody profile with a fresh sequencer key. The supplied /root/Layerx-protocol/build/bin/layerx-genesis-build accepts the profile and emits signed genesis artifacts; exit 0 in qual-logs/item3-genesis-final.log. The guide delegates external registration to the normal external registration flow. deploy_local_custody.py deploys WETH, LayerXVault, AssetRegistry and LayerXTimelock, but no GuarantorBond or CheckpointRegistry. platform/hosted/node/bootstrap.sh generates ordinary genesis and has no custody-profile input. No local daemon credit submission, funded SEND, Rust SEND receipt verification or binary-path-gated funded integration test has been completed. Observation 6.1.1 remains open for funded execution."
+assumption = "Complete a real isolated settlement registration and daemon bootstrap for the exact signed custody genesis before submitting credit and SEND. Do not fabricate registration confirmation, substitute ordinary genesis or interpret an acknowledgement as a receipt. The native-ready artifact handoff is absent; only the existing genesis builder was exercised."
+severity = "blocker"
+
+[observation.custody.persistent_chain_requirements]
+task = "6.1"
+file = "tests/bridge/custody_genesis.py"
+symbol = "custody-credit-profile/v1"
+observed = "The produced profile pins local chain 31337 and its genesis hash, a locally deployed vault runtime, and a freshly generated custody attestor. It cannot authorize credit on the persistent Paxeer chain. No persistent-chain deposit or transaction was performed."
+assumption = "Persistent funding requires a real Paxeer deposit, the owner-authorized custody attestor key, matching external chain identity and vault pins, and a newly signed custody-enabled genesis with matching settlement registration. The existing marker-free genesis cannot acquire Bridge retroactively. Activation must satisfy the selected deployment's governance and finalization conditions; local time advancement is not evidence of persistent activation."
+severity = "blocker"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1058,3 +1058,11 @@ symbol = "human-lint-copy"
 observed = "make human-lint human-test-unit reaches npm --prefix human/apps/web run typecheck and fails because tsc is not installed, with command exit 127 at Makefile:2001. Evidence is qual-logs/item1-human-gates.log."
 assumption = "Install the locked web dependencies in the qualification environment and rerun the unchanged aggregate gate. No assertion, dependency policy or lint is disabled."
 severity = "blocker"
+
+[observation.custody.local_weth_evidence]
+task = "6.1"
+file = "tests/bridge/local_credit_evidence.py"
+symbol = "real_weth_protocol_three_custody_evidence"
+observed = "A fresh chain 31337 wraps actual ETH in the repository WETH contract and deposits the resulting tokens in the real LayerXVault, configured through the real timelock and AssetRegistry. A second Anvil forks the exact deposited chain state. custody_credit.py verifies both origins, header ancestry, eth_getProof runtime accounts and complete receipt/transaction trie reconstruction, emits a 207-byte profile and 427-byte attestor credit, and test_evidence.py passes its real-evidence tamper and divergent-finality checks. The Rust integration independently checks the attestor signature and native beneficiary derivation. Final complete package tests including the WETH integration pass with the worktree Python virtual environment on PATH; qual-logs/final-test.log. Package formatting and strict all-target clippy pass; qual-logs/final-fmt-check.log and qual-logs/final-clippy.log. make human-test-unit passes; qual-logs/human-unit.log."
+assumption = "The fork observer shares its upstream trust source; distinct origins are local replication evidence, not independent production quorum or production finality. Generated actor and attestor seeds and chain artifacts remain untracked. Local-chain deployment refuses chain 125 and port 18545. The aggregate human-lint dependency failure remains open."
+severity = "info"

--- a/tests/bridge/custody_genesis.py
+++ b/tests/bridge/custody_genesis.py
@@ -1,0 +1,44 @@
+import argparse
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from custody_credit import big, require, sha, write_new
+from deploy_local_custody import command
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--profile', required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--builder', required=True)
+    args = parser.parse_args()
+    profile = Path(args.profile).read_bytes()
+    require(len(profile) == 207 and profile[:5] == b'LXBC1' and profile[205:] == big(3, 2),
+            'protocol-three custody profile required')
+    require(int.from_bytes(profile[5:13], "big") != 125, "persistent chain ID refused")
+    directory = Path(args.output).resolve()
+    directory.mkdir(mode=0o700, parents=True, exist_ok=False)
+    key = Ed25519PrivateKey.generate()
+    public = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    write_new(directory / 'sequencer.key', key.private_bytes_raw())
+    write_new(directory / 'sequencer.pub', public)
+    request = (b'LXGB\x01' + big(3, 2) + profile[201:205] + big(int(time.time() * 1000), 8)
+               + big(1, 2) + big(7, 2) + b'parameter-version'.ljust(32, b'\0') + big(1, 32)
+               + big(1, 2) + sha(b'layerx-beta-guarantor:' + public.hex().encode())
+               + b'\x02' + public + big(0, 16) + profile[97:129] + big(1, 4))
+    request += b''.join(big(value, 8) for value in (1, 1, 1, 1, 1, 8, 8, 64, 8))
+    request += big(1, 8) + b'\x01' + big(1, 4)
+    request += b''.join(big(value, 8) for value in (1, 1, 2, 4, 1, 1, 100, 100, 1, 1, 10, 1, 1000))
+    require(len(request) == 395, 'genesis request length')
+    write_new(directory / 'request.lxgb', request)
+    command(args.builder, str(directory / 'request.lxgb'), str(directory / 'sequencer.key'),
+            str(directory / 'artifacts'), '--custody-profile', str(Path(args.profile).resolve()))
+    require((directory / 'artifacts/genesis.manifest').is_file(), 'signed manifest required')
+    print('Signed custody genesis artifacts built; external registration still required')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/bridge/deploy_local_custody.py
+++ b/tests/bridge/deploy_local_custody.py
@@ -108,6 +108,7 @@ def main():
     parsed = urllib.parse.urlsplit(args.rpc)
     require(parsed.hostname in ("127.0.0.1", "::1") and parsed.port != 18545, "isolated loopback chain only")
     require("anvil" in rpc.call("web3_clientVersion", []).lower(), "Anvil required")
+    require(quantity(rpc.call("eth_chainId", [])) != 125, "persistent chain ID refused")
     require(0 < args.amount < 2 ** 128, "amount bound")
     unhex(args.asset, 32)
     unhex(args.beneficiary, 32)

--- a/tests/bridge/local_credit_evidence.py
+++ b/tests/bridge/local_credit_evidence.py
@@ -1,0 +1,105 @@
+import argparse
+import json
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from custody_credit import Rpc, require, sha, write_new
+from deploy_local_custody import ROOT, command
+
+
+def port():
+    with socket.socket() as listener:
+        listener.bind(('127.0.0.1', 0))
+        return listener.getsockname()[1]
+
+
+def launch(directory, name, extra):
+    selected = port()
+    log = open(directory / (name + '.log'), 'wb')
+    process = subprocess.Popen(['anvil', '--silent', '--host', '127.0.0.1',
+                                '--port', str(selected), '--chain-id', '31337', '--mnemonic-random', '12', *extra],
+                               stdout=log, stderr=log)
+    log.close()
+    rpc = Rpc('http://127.0.0.1:' + str(selected))
+    try:
+        for _ in range(200):
+            require(process.poll() is None, 'Anvil exited before readiness')
+            try:
+                require(int(rpc.call('eth_chainId', []), 16) == 31337, 'chain identity')
+                return process, rpc
+            except (OSError, ValueError):
+                time.sleep(0.05)
+        raise ValueError('Anvil readiness timeout')
+    except BaseException:
+        process.terminate()
+        process.wait(timeout=10)
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+    directory = Path(args.output).resolve()
+    directory.mkdir(mode=0o700, parents=True, exist_ok=False)
+    actor = Ed25519PrivateKey.generate()
+    public = actor.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    did = 'did:layerx:' + public.hex()
+    name = ('agent:' + did + ':main').encode()
+    beneficiary = '0x' + sha(b'LX:ACCOUNT:v1' + len(name).to_bytes(4, 'big') + name).hex()
+    asset = '0x' + sha(b'LayerX/local-custody/fee-asset/v1').hex()
+    write_new(directory / 'actor.key', actor.private_bytes_raw())
+    write_new(directory / 'attestor.key', Ed25519PrivateKey.generate().private_bytes_raw())
+    amount = 1000000000000000000
+    processes = []
+    try:
+        process, primary = launch(directory, 'primary', [])
+        processes.append(process)
+        command('python3', str(ROOT / 'tests/bridge/deploy_local_custody.py'),
+                '--allow-local-chain', '--rpc', primary.url, '--asset', asset,
+                '--beneficiary', beneficiary, '--amount', str(amount),
+                '--output', str(directory / 'custody.json'))
+        custody = json.loads((directory / 'custody.json').read_text())
+        process, observer = launch(directory, 'observer', [
+            '--fork-url', primary.url, '--fork-block-number', str(custody['fork_block'])])
+        processes.append(process)
+        script = str(ROOT / 'tests/bridge/custody_credit.py')
+        pair = ['--rpc', primary.url, '--rpc', observer.url]
+        profile = str(directory / 'custody.profile')
+        attestor = str(directory / 'attestor.key')
+        command('python3', script, 'profile', *pair, '--chain-id', '31337',
+                '--network-id', '17', '--vault', custody['vault'],
+                '--runtime-sha256', custody['runtime_sha256'], '--asset', asset,
+                '--confirmations', '2', '--attestor-key', attestor, '--output', profile)
+        credit = str(directory / 'custody.credit')
+        evidence = [*pair, '--profile', profile, '--network-id', '17',
+                    '--transaction', custody['transaction'], '--beneficiary', beneficiary,
+                    '--beneficiary-key', '0x' + public.hex(), '--attestor-key', attestor,
+                    '--expected-amount', str(amount)]
+        command('python3', script, 'attest', *evidence, '--output', credit)
+        command('python3', str(ROOT / 'tests/bridge/test_evidence.py'), *evidence)
+        require(len(Path(profile).read_bytes()) == 207, 'profile length')
+        require(len(Path(credit).read_bytes()) == 427, 'credit length')
+        write_new(directory / 'identity.json', json.dumps({
+            'did': did, 'public_key': public.hex(), 'beneficiary': beneficiary,
+            'asset': asset, 'amount': str(amount), 'network_id': 17,
+            'protocol_version': 3,
+        }).encode())
+        print('Real WETH custody, replicated Anvil evidence, profile and credit verified')
+    finally:
+        for process in reversed(processes):
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The protocol-3 custody beneficiary is pinned to native C account vectors. The legacy protocol-2 derivation and signed-root ingress refusal remain unchanged.

This draft is partial: no funded SEND receipt has been produced and observation 6.1.1 remains open. Aggregate Human lint is blocked by the missing web TypeScript installation.

Item 1 — native beneficiary cross-check (commands from the worktree root):

- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 cargo check --manifest-path human/Cargo.toml -p layerx-paxeer-client` — exit 0; `qual-logs/item1-check.log`.
- `cargo fmt --manifest-path human/Cargo.toml -p layerx-paxeer-client --check` — exit 0; `qual-logs/item1-fmt-check.log`.
- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 cargo clippy --manifest-path human/Cargo.toml -p layerx-paxeer-client --all-targets -- -D warnings` — exit 0 after repairing the new test's formatting lint; `qual-logs/item1-clippy-final.log`. Initial test lint failure: exit 101, `qual-logs/item1-clippy.log`.
- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 cargo test --manifest-path human/Cargo.toml -p layerx-paxeer-client` — exit 0; `qual-logs/item1-test.log` (before the new WETH evidence test).
- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 make human-lint human-test-unit` — exit 2; `qual-logs/item1-human-gates.log`. The web `typecheck` subprocess exits 127 because `tsc` is absent. No gate is disabled.

Logs are untracked under `/root/lx-lanes/custody-funding/qual-logs/`. Only explicitly staged source paths are published.

Item 2 — real WETH custody evidence through two Anvil origins:

- `python3 -m venv qual-logs/venv` and `qual-logs/venv/bin/pip install -r tests/bridge/requirements.txt` — exit 0; `qual-logs/python-dependencies.log`.
- With `PATH="$PWD/qual-logs/venv/bin:$PATH"`: `python3 tests/bridge/local_credit_evidence.py --output qual-logs/evidence-direct` — exit 0; `qual-logs/item2-python.log`.
- With the same PATH and `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`: `cargo test --manifest-path human/Cargo.toml -p layerx-paxeer-client --test custody_evidence -- --nocapture` — exit 0; `qual-logs/item2-evidence.log`.
- With the same PATH and resource limits: `cargo test --manifest-path human/Cargo.toml -p layerx-paxeer-client` — exit 0, including the new WETH integration and the existing Anvil suites; `qual-logs/final-test.log`.
- `cargo fmt --manifest-path human/Cargo.toml -p layerx-paxeer-client --check` — exit 0; `qual-logs/final-fmt-check.log`.
- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 cargo clippy --manifest-path human/Cargo.toml -p layerx-paxeer-client --all-targets -- -D warnings` — exit 0; `qual-logs/final-clippy.log`.
- `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 make human-test-unit` — exit 0; `qual-logs/human-unit.log`.

The observer is a real Anvil fork sharing the upstream trust source, not an independent production quorum. The deployment helper refuses chain 125 and port 18545. Secrets and generated artifacts are untracked.

Item 3 — signed genesis tooling only; funded SEND remains incomplete:

- With `PATH="$PWD/qual-logs/venv/bin:$PATH"`: `python3 tests/bridge/custody_genesis.py --profile qual-logs/evidence-direct/custody.profile --output qual-logs/genesis-final --builder /root/Layerx-protocol/build/bin/layerx-genesis-build` — exit 0; `qual-logs/item3-genesis-final.log`.
- `qual-logs/venv/bin/python3 -m py_compile tests/bridge/custody_genesis.py tests/bridge/local_credit_evidence.py tests/bridge/deploy_local_custody.py` — exit 0; `qual-logs/python-compile.log`.

The local deployment helper does not deploy settlement contracts. The node bootstrap generates ordinary genesis and accepts no custody-profile input. A matching real settlement registration and daemon startup still need integration. No daemon credit submission, funded SEND receipt, or binary-path-gated funded SEND test is delivered. Observation 6.1.1 remains open. `/root/lx-lanes/native-bin/native-ready.txt` was absent.

Item 4 — technical observations record the persistent-chain gap: genuine Paxeer deposit, owner-authorized attestor, matching chain/genesis/vault pins, newly signed custody genesis and settlement registration, and governance/finalization activation conditions. No persistent chain was accessed.

🤖 Generated with Codex
