### PR TITLE
Fix the post-upgrade Programs CALL callback failure

### DIFF
--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1081,6 +1081,20 @@ file = "tests/bridge/custody_genesis.py"
 symbol = "custody-credit-profile/v1"
 observed = "The produced profile pins local chain 31337 and its genesis hash, a locally deployed vault runtime, and a freshly generated custody attestor. It cannot authorize credit on the persistent Paxeer chain. No persistent-chain deposit or transaction was performed."
 assumption = "Persistent funding requires a real Paxeer deposit, the owner-authorized custody attestor key, matching external chain identity and vault pins, and a newly signed custody-enabled genesis with matching settlement registration. The existing marker-free genesis cannot acquire Bridge retroactively. Activation must satisfy the selected deployment's governance and finalization conditions; local time advancement is not evidence of persistent activation."
+[observation.6.4.20]
+task = "6.4"
+file = "programs/crates/layerx-programs-runtime/src/ffi_call.rs"
+symbol = "settle_call_occupancy"
+observed = "A real protocol-3 deploy/call/upgrade/call sequence fails after crossing occupancy batch boundaries. build/tests/programs_call_activity --post-upgrade-batch exits 1 with sequence 4 receipt -736; the original same-batch fixture and make programs-core-test exit 0. The regression preserves the success assertions and exact upgraded artifact checks. LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-emulator --test gateway lifecycle_routes_execute_and_replay_real_native_state_receipts exits 101 at sequence 3 with authenticated Failure(Callback { stage: 5, status: -3 }). Logs: qual-logs/post-upgrade-native.log, qual-logs/programs-core.log, qual-logs/emulator-before.log. OccupancyLedger::prepare_positions requires batch == last_finalized_batch + 1; CALL settlement does not finalize that cursor, and the daemon does not invoke batch occupancy finalization."
+assumption = "Completion requires native-owned atomic maintenance preparation, signed receipt-tree inclusion, durable sequence reservation, WAL recovery and replica publication for every applicable batch. Calling finalization after publication or relaxing the runtime batch check would violate the existing state-root and sequence contracts. The reduced native regression uses the existing generated guest; SDK escrow guest execution is not established by this evidence."
+severity = "blocker"
+
+[observation.6.4.21]
+task = "6.4"
+file = "programs/vendor/binaryen-sys-0.12.0/binaryen/third_party/llvm-project/include/llvm/Config/config.h"
+symbol = "programs-test"
+observed = "make programs-test exits 2 after its prerequisites reach the cargo test --locked --workspace recipe. Cargo exits 101 because the vendored Binaryen config.h file is absent and its checksum cannot be calculated. Log: qual-logs/programs-test-rerun.log. The initial aggregate run also encountered an absent asc executable; installing the locked AssemblyScript dependencies resolves that setup failure and make programs-sdk-assemblyscript exits 0, qual-logs/assemblyscript-gate.log. make programs-core-test and the address-sanitized test-program-artifacts gate exit 0, qual-logs/programs-core.log and qual-logs/program-artifacts-asan.log."
+assumption = "Restore the exact vendor input under its existing checksum contract before rerunning the workspace aggregate. No vendor file or checksum was changed. Passing prerequisite gates do not establish an aggregate pass."
 severity = "blocker"
 [observation.6.11.11]
 task = "6.11"

--- a/tests/programs/test_call_activity.c
+++ b/tests/programs/test_call_activity.c
@@ -13,6 +13,7 @@
 #include <openssl/evp.h>
 
 static bool dump_executed_v3;
+static bool post_upgrade_batch_regression;
 static const uint8_t executed_sequencer_seed[32] = {0x45U};
 static int lifecycle_vector_signature(lxp_activity *activity,
                                       uint8_t public_key[32], uint8_t signature[64]);
@@ -1482,6 +1483,7 @@ static int deploy_and_upgrade_artifacts_case(uint16_t protocol_version,
     activity.protocol_version = protocol_version;
     activity.account_sequence = 2U;
     activity.idempotency_key[31] = 3U;
+    if (post_upgrade_batch_regression) execution.batch_number = 2U;
     activity.fee_limit = (lxp_u128){0U, 0U};
     execution.global_sequence = 3U;
     if (lxp_arena_reset(&arena, 0U) != LXP_OK ||
@@ -1515,6 +1517,7 @@ static int deploy_and_upgrade_artifacts_case(uint16_t protocol_version,
     activity.protocol_version = protocol_version;
     activity.account_sequence = 3U;
     activity.idempotency_key[31] = 4U;
+    if (post_upgrade_batch_regression) execution.batch_number = 3U;
     activity.fee_limit = actor->balance;
     execution.fee_balance = actor->balance;
     execution.global_sequence = 4U;
@@ -1968,6 +1971,11 @@ static int dump_lifecycle_vectors(void)
 
 int main(int argc, char **argv)
 {
+    if (argc == 2 && strcmp(argv[1], "--post-upgrade-batch") == 0) {
+        post_upgrade_batch_regression = true;
+        return deploy_and_upgrade_artifacts_case(
+            LXP_PROTOCOL_VERSION_STATE_COMMITMENT, false);
+    }
     if (argc == 2 && strcmp(argv[1], "--dump-executed-v3") == 0) {
         dump_executed_v3 = true;
         return deploy_and_upgrade_artifacts_case(LXP_PROTOCOL_VERSION_STATE_COMMITMENT, true);


### PR DESCRIPTION
This draft is blocked: it contains a native reproducer and qualification observations, not a production fix.

After DEPLOY → CALL → UPGRADE, a CALL in a later batch fails with -736. The runtime occupancy ledger requires the next batch after its last finalized batch, but the daemon does not publish occupancy batch maintenance. The new `--post-upgrade-batch` mode preserves the existing fixture's success assertions and upgraded artifact checks while moving UPGRADE and the following CALL to batches 2 and 3. The original same-batch fixture passes. The emulator independently reproduces authenticated `Failure(Callback { stage: 5, status: -3 })`.

Completion requires native-owned atomic maintenance preparation, signed receipt-tree inclusion, durable sequence reservation, WAL recovery and replica publication. Runtime bounds and refusal mapping remain unchanged. This reduced test uses the existing generated Wasm guest; SDK escrow deploy/call/upgrade/call qualification and a complete native patch remain outstanding. Local `NEEDS.md` and `STATUS.md` contain the handoff and are intentionally untracked.

Validation for this item, from `/root/lx-lanes/exec`, with `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`:

| Exact command | Exit | Log under `/root/lx-lanes/exec/qual-logs/` |
| --- | --- | --- |
| `make programs-core-test` | 0 | `programs-core.log` |
| `build/tests/programs_call_activity --post-upgrade-batch` | 1, success assertion fails with -736 | `post-upgrade-native.log` |
| `LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-emulator --test gateway lifecycle_routes_execute_and_replay_real_native_state_receipts` | 101, callback stage 5 status -3 | `emulator-before.log` |
| `ASAN_OPTIONS=abort_on_error=1:detect_leaks=1:strict_string_checks=1 make --no-print-directory BUILD_DIR=build/asan-program-artifacts EXTRA_CFLAGS='-O1 -g -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address' EXTRA_LDFLAGS=-fsanitize=address test-program-artifacts` | 0 | `program-artifacts-asan.log` |
| `make programs-test` | 2, missing asc | `programs-test.log` |
| `npm --prefix programs/sdk/assemblyscript ci --ignore-scripts --no-audit --no-fund` | 1, ECONNRESET; retry 0 | `assemblyscript-dependencies.log`, `assemblyscript-dependencies-retry.log` |
| `npm --prefix programs/sdk/assemblyscript/examples/paid-counter ci --ignore-scripts --no-audit --no-fund` | 0 | `paid-counter-dependencies.log` |
| `make programs-sdk-assemblyscript` | 0 | `assemblyscript-gate.log` |
| `make programs-test` after dependency setup | 2, final Cargo workspace command exits 101 | `programs-test-rerun.log` |
| `cg review` | 1, no initialized graph | `cg-review.log` |
| `cg guard tests/programs/test_call_activity.c spec/layerx-beta/qualification.kvx` | 1, no initialized graph | `cg-guard.log` |
| `git diff --check` | 0 | `diff-check.log` |

The aggregate rerun fails because `programs/vendor/binaryen-sys-0.12.0/binaryen/third_party/llvm-project/include/llvm/Config/config.h` is missing under the existing checksum contract. No vendor file or checksum was changed. Passing prerequisites are not an aggregate pass. Shared native binaries were not modified.

🤖 Generated with Codex
