### PR TITLE
Select maintenance account-proof verification by wire version in the client

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -50,12 +50,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
@@ -747,6 +741,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "layerx-crypto",
+ "layerx-programs-runtime",
  "layerx-proof",
  "layerx-types",
  "layerx-wire",
@@ -785,7 +780,7 @@ dependencies = [
 name = "layerx-mirror"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "ed25519-dalek",
  "k256",
  "layerx-agent-api",
@@ -1509,7 +1504,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "cookie_store",
  "der 0.8.1",
  "log",
@@ -1528,7 +1523,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "http",
  "httparse",
  "log",

--- a/agent/crates/layerx-client/Cargo.toml
+++ b/agent/crates/layerx-client/Cargo.toml
@@ -15,6 +15,7 @@ rustls = { version = "0.23.32", default-features = false, features = ["ring", "s
 
 [dev-dependencies]
 ed25519-dalek = "=2.2.0"
+layerx-programs-runtime = { path = "../../../programs/crates/layerx-programs-runtime" }
 
 [lints]
 workspace = true

--- a/agent/crates/layerx-client/src/availability.rs
+++ b/agent/crates/layerx-client/src/availability.rs
@@ -381,11 +381,12 @@ where
                     report(provider, &chunks, ProviderFailure::Reassembly(failure))
                 });
                 let records = records?.into_records();
-                let verified = records
-                    .verify(&chunks, context.record_roots)
-                    .map_err(|failure| {
-                        report(provider, &chunks, ProviderFailure::Reassembly(failure))
-                    })?;
+                let verified =
+                    records
+                        .verify(&chunks, context.record_roots)
+                        .map_err(|failure| {
+                            report(provider, &chunks, ProviderFailure::Reassembly(failure))
+                        })?;
                 return Ok(AvailabilityResult {
                     provider: provider.to_owned(),
                     chunks,

--- a/agent/crates/layerx-client/src/evidence.rs
+++ b/agent/crates/layerx-client/src/evidence.rs
@@ -17,6 +17,7 @@ use layerx_proof::state::{
 use layerx_types::payload::ModuleRegistry;
 use layerx_wire::activity::{decode_signed, encode_signed};
 use layerx_wire::hash::activity_id;
+use layerx_wire::maintenance::decode_occupancy_maintenance;
 use layerx_wire::receipt::{decode_batch_header, Receipt};
 
 use crate::lni::refusal::decode_core_refusal;
@@ -32,6 +33,9 @@ const REGISTER_REQUEST_TAG: u16 = 28;
 const REGISTER_RESPONSE_TAG: u16 = 29;
 const WIRE_VERSION: u16 = 1;
 const MAX_RECEIPT_BYTES: usize = 4_096;
+const MAINTENANCE_WIRE_VERSION: u16 = 2;
+const MAX_MAINTENANCE_BYTES: usize =
+    b"LXP/programs/occupancy-receipt/v2\0".len() + 374 + 256 * 81 + 65_536;
 const MAX_VALIDITY_PROOF_BYTES: usize = 1_048_576;
 const MAX_SETTLEMENT_REFERENCE_BYTES: usize = 1_024;
 const SETTLEMENT_REFERENCE_BYTES: usize = 110;
@@ -641,7 +645,14 @@ fn account_proof_bundle(
     })
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AccountEvidenceKind {
+    Activity,
+    Maintenance { parameter_version: u32 },
+}
+
 pub(crate) struct DecodedNestedEvidence {
+    pub kind: AccountEvidenceKind,
     pub selector: RootSelector,
     pub proof: NestedAccountProof,
     pub signed_header: SignedHeader,
@@ -654,7 +665,8 @@ pub(crate) fn decode_nested_evidence(
     expected_network_id: u32,
 ) -> Result<DecodedNestedEvidence, EvidenceError> {
     let mut reader = Reader::new(bytes);
-    if reader.u16()? != WIRE_VERSION || reader.u8()? != 2 {
+    let wire_version = reader.u16()?;
+    if !matches!(wire_version, WIRE_VERSION | MAINTENANCE_WIRE_VERSION) || reader.u8()? != 2 {
         return Err(EvidenceError::Malformed);
     }
     let selector = RootSelector::decode(&mut reader)?;
@@ -672,7 +684,22 @@ pub(crate) fn decode_nested_evidence(
     let account_proof = decode_proof(&mut reader)?;
     let account_tree_proof = decode_proof(&mut reader)?;
     let universal_root_proof = decode_proof(&mut reader)?;
-    let receipt_bytes = decode_receipt_bytes(&mut reader)?;
+    let (kind, receipt_bytes) = if wire_version == MAINTENANCE_WIRE_VERSION {
+        let bytes = reader.length_prefixed(MAX_MAINTENANCE_BYTES)?;
+        let maintenance =
+            decode_occupancy_maintenance(bytes).map_err(|_| EvidenceError::Receipt)?;
+        (
+            AccountEvidenceKind::Maintenance {
+                parameter_version: maintenance.parameter_version,
+            },
+            bytes.to_vec(),
+        )
+    } else {
+        (
+            AccountEvidenceKind::Activity,
+            decode_receipt_bytes(&mut reader)?,
+        )
+    };
     let receipt_proof = decode_proof(&mut reader)?;
     let signed_header = decode_signed_header(&mut reader)?;
     let checkpoint = match reader.u8()? {
@@ -712,6 +739,7 @@ pub(crate) fn decode_nested_evidence(
     };
     bind_selector(selector, &signed_header, checkpoint.as_ref())?;
     Ok(DecodedNestedEvidence {
+        kind,
         selector,
         proof,
         signed_header,

--- a/agent/crates/layerx-client/src/read.rs
+++ b/agent/crates/layerx-client/src/read.rs
@@ -9,7 +9,9 @@ use layerx_types::amount::Amount;
 use layerx_types::verify::VerificationLevel;
 use layerx_wire::receipt::decode_batch_header;
 
-use crate::evidence::{decode_nested_evidence, EvidenceError, RootSelector};
+use crate::evidence::{
+    decode_nested_evidence, AccountEvidenceKind, DecodedNestedEvidence, EvidenceError, RootSelector,
+};
 use crate::head::Head;
 use crate::lni::refusal::decode_core_refusal;
 use crate::lni::schema::{decode_envelope, encode_envelope, Envelope, SchemaError, Version};
@@ -405,14 +407,13 @@ fn verify_state_value(
         }
         RootSelector::Latest | RootSelector::Batch(_) | RootSelector::Checkpoint(_) => {}
     }
-    let verified = layerx_proof::state::verify_nested_account(
+    let (global_sequence, batch_number) = verified_account_position(
         canonical_bytes,
         expected_account,
         expected_asset,
-        &decoded.proof,
+        &decoded,
         &context.sequencer_authorization,
-    )
-    .map_err(ReadError::Account)?;
+    )?;
     let achieved = if let Some(checkpoint) = decoded.checkpoint {
         checkpoint.report().level()
     } else {
@@ -424,11 +425,58 @@ fn verify_state_value(
         proof_material: proof_material.to_vec(),
         achieved,
         freshness: Freshness {
-            global_sequence: verified.observed_sequence(),
-            batch_number: verified.header().header().batch_number(),
+            global_sequence,
+            batch_number,
             observed_head_sequence: context.head.chain_sequence,
             observed_checkpoint: context.head.finalised_checkpoint,
         },
+    })
+}
+
+fn verified_account_position(
+    canonical_bytes: &[u8],
+    expected_account: [u8; 32],
+    expected_asset: Option<[u8; 32]>,
+    decoded: &DecodedNestedEvidence,
+    authorization: &SequencerAuthorization,
+) -> Result<(u64, u64), ReadError> {
+    Ok(match decoded.kind {
+        AccountEvidenceKind::Activity => {
+            let verified = layerx_proof::state::verify_nested_account(
+                canonical_bytes,
+                expected_account,
+                expected_asset,
+                &decoded.proof,
+                authorization,
+            )
+            .map_err(ReadError::Account)?;
+            (
+                verified.observed_sequence(),
+                verified.header().header().batch_number(),
+            )
+        }
+        AccountEvidenceKind::Maintenance { parameter_version } => {
+            let activity_count = decoded
+                .proof
+                .receipt_proof
+                .leaf_count()
+                .checked_sub(1)
+                .ok_or(ReadError::MalformedValue)?;
+            let verified = layerx_proof::state::verify_nested_account_maintenance(
+                canonical_bytes,
+                expected_account,
+                expected_asset,
+                &decoded.proof,
+                authorization,
+                activity_count,
+                parameter_version,
+            )
+            .map_err(ReadError::Account)?;
+            (
+                verified.header().header().last_sequence(),
+                verified.header().header().batch_number(),
+            )
+        }
     })
 }
 

--- a/agent/crates/layerx-client/tests/maintenance_reads.rs
+++ b/agent/crates/layerx-client/tests/maintenance_reads.rs
@@ -1,0 +1,570 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::os::unix::net::UnixListener;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use ed25519_dalek::{Signer as _, SigningKey};
+use layerx_client::evidence::{EvidenceError, RootSelector};
+use layerx_client::head::Head;
+use layerx_client::lni::framing::{read_frame, write_frame};
+use layerx_client::lni::schema::{decode_envelope, encode_envelope, Envelope, Version};
+use layerx_client::lni::transport::{ConnectionGate, Limits, Uds};
+use layerx_client::read::{account, ReadContext, ReadError, ReadValue, Requested};
+use layerx_proof::inclusion::{InclusionError, SequencerAuthorization};
+use layerx_proof::merkle::{build_proof, MerkleError, Proof};
+use layerx_proof::state::{AccountProofError, NestedAccountProof};
+use layerx_types::verify::VerificationLevel;
+use layerx_wire::encode::Encoder;
+use layerx_wire::hash::{batch_header_digest, receipt_digest};
+use layerx_wire::limits::PROTOCOL_VERSION;
+use sha2::{Digest as _, Sha256};
+
+const PROGRAM_ACCOUNT_VECTORS: &str =
+    include_str!("../../../../tests/vectors/program_account_state_v2.vec");
+
+fn vectors(source: &str) -> BTreeMap<&str, &str> {
+    source
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .collect()
+}
+
+fn nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn hex(value: &str) -> Vec<u8> {
+    assert_eq!(value.len() % 2, 0, "odd-length vector value");
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = nibble(pair[0]).unwrap_or_else(|| panic!("invalid vector hex"));
+            let low = nibble(pair[1]).unwrap_or_else(|| panic!("invalid vector hex"));
+            (high << 4) | low
+        })
+        .collect()
+}
+
+fn fixed<const LENGTH: usize>(value: &str) -> [u8; LENGTH] {
+    hex(value)
+        .try_into()
+        .unwrap_or_else(|_| panic!("vector has wrong fixed length"))
+}
+
+fn state_leaf(key: &[u8], value: &[u8]) -> [u8; 32] {
+    let mut bytes = Vec::with_capacity(18 + 8 + key.len() + value.len());
+    bytes.extend_from_slice(b"LXP/v1/state-leaf\0");
+    bytes.extend_from_slice(
+        &u32::try_from(key.len())
+            .unwrap_or_else(|_| panic!("test key length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u32::try_from(value.len())
+            .unwrap_or_else(|_| panic!("test value length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(key);
+    bytes.extend_from_slice(value);
+    Sha256::digest(bytes).into()
+}
+
+fn state_node(left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
+    let mut bytes = Vec::with_capacity(82);
+    bytes.extend_from_slice(b"LXP/v1/state-node\0");
+    bytes.extend_from_slice(&left);
+    bytes.extend_from_slice(&right);
+    Sha256::digest(bytes).into()
+}
+
+fn receipt_bytes(
+    activity_id: [u8; 32],
+    resulting_state_root: [u8; 32],
+    signature_key: Option<&SigningKey>,
+) -> Vec<u8> {
+    let encode = |signature: Option<[u8; 64]>| {
+        let mut encoder = Encoder::new(4096);
+        assert_eq!(
+            encoder.structure_header_version(0x5201, PROTOCOL_VERSION),
+            Ok(())
+        );
+        assert_eq!(encoder.u16(PROTOCOL_VERSION), Ok(()));
+        assert_eq!(encoder.bytes(&activity_id, 32), Ok(()));
+        assert_eq!(encoder.u64(10), Ok(()));
+        assert_eq!(encoder.bytes(&[0x21; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&resulting_state_root, 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x22; 32], 32), Ok(()));
+        assert_eq!(encoder.i32(0), Ok(()));
+        assert_eq!(encoder.sequence_length(0, 512), Ok(()));
+        assert_eq!(encoder.u128(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x23; 32], 32), Ok(()));
+        assert_eq!(encoder.u16(1), Ok(()));
+        assert_eq!(encoder.u32(1), Ok(()));
+        assert_eq!(encoder.u32(1), Ok(()));
+        assert_eq!(encoder.u8(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x24; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(25), Ok(()));
+        assert_eq!(encoder.bytes(&[0x25; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(100), Ok(()));
+        assert_eq!(encoder.u128(75), Ok(()));
+        assert_eq!(encoder.u64(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x26; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(10), Ok(()));
+        assert_eq!(encoder.u128(35), Ok(()));
+        assert_eq!(encoder.bytes(&[0x27; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x28; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x29; 32], 32), Ok(()));
+        assert_eq!(encoder.u64(1_000), Ok(()));
+        assert_eq!(encoder.u8(u8::from(signature.is_some())), Ok(()));
+        if let Some(signature) = signature {
+            assert_eq!(encoder.bytes(&signature, 64), Ok(()));
+        }
+        encoder.finish()
+    };
+    let unsigned = encode(None);
+    let Some(signature_key) = signature_key else {
+        return unsigned;
+    };
+    let digest = receipt_digest(&unsigned)
+        .unwrap_or_else(|error| panic!("receipt digest failed: {error:?}"));
+    let signature = signature_key.sign(&digest).to_bytes();
+    encode(Some(signature))
+}
+
+fn header_bytes(
+    resulting_state_root: [u8; 32],
+    receipt_root: [u8; 32],
+    sequencer_id: [u8; 32],
+) -> Vec<u8> {
+    let mut encoder = Encoder::new(354);
+    assert_eq!(
+        encoder.structure_header_version(0x1701, PROTOCOL_VERSION),
+        Ok(())
+    );
+    assert_eq!(encoder.u8(15), Ok(()));
+    let fields: [(u8, Vec<u8>); 15] = [
+        (1, PROTOCOL_VERSION.to_be_bytes().to_vec()),
+        (2, 42_u32.to_be_bytes().to_vec()),
+        (3, 2_u64.to_be_bytes().to_vec()),
+        (4, 7_u64.to_be_bytes().to_vec()),
+        (5, 9_u64.to_be_bytes().to_vec()),
+        (6, 10_u64.to_be_bytes().to_vec()),
+        (7, [0x31; 32].to_vec()),
+        (8, resulting_state_root.to_vec()),
+        (9, [0x32; 32].to_vec()),
+        (10, receipt_root.to_vec()),
+        (11, [0x33; 32].to_vec()),
+        (12, [0x34; 32].to_vec()),
+        (13, [0x35; 32].to_vec()),
+        (14, 1_000_u64.to_be_bytes().to_vec()),
+        (15, sequencer_id.to_vec()),
+    ];
+    for (field, value) in fields {
+        assert_eq!(encoder.tag(field, 15), Ok(()));
+        match field {
+            1 => assert_eq!(
+                encoder.u16(u16::from_be_bytes([value[0], value[1]])),
+                Ok(())
+            ),
+            2 => assert_eq!(
+                encoder.u32(u32::from_be_bytes([value[0], value[1], value[2], value[3]])),
+                Ok(())
+            ),
+            3..=6 | 14 => assert_eq!(
+                encoder.u64(u64::from_be_bytes(
+                    value
+                        .as_slice()
+                        .try_into()
+                        .unwrap_or_else(|_| panic!("invalid u64 test field")),
+                )),
+                Ok(())
+            ),
+            _ => assert_eq!(encoder.bytes(&value, 32), Ok(())),
+        }
+    }
+    let bytes = encoder.finish();
+    assert_eq!(bytes.len(), 354);
+    bytes
+}
+
+fn nested_fixture(
+    account_id: [u8; 32],
+    account_value: &[u8],
+    receipt_signature_key: Option<&SigningKey>,
+) -> (NestedAccountProof, SequencerAuthorization, [u8; 32]) {
+    let sequencer = SigningKey::from_bytes(&[0x51; 32]);
+    let sequencer_id = sequencer.verifying_key().to_bytes();
+    let mut account_key = [0_u8; 33];
+    account_key[0] = 4;
+    account_key[1..].copy_from_slice(&account_id);
+    let account_leaf = state_leaf(&account_key, account_value);
+    let mut other_account_key = [0xff_u8; 33];
+    other_account_key[0] = 4;
+    assert!(account_key < other_account_key);
+    let other_account_leaf = state_leaf(&other_account_key, b"other-account");
+    let account_root = state_node(account_leaf, other_account_leaf);
+    let account_proof = Proof::new(0, 2, vec![other_account_leaf])
+        .unwrap_or_else(|error| panic!("account proof: {error:?}"));
+
+    let account_tree_leaf = state_leaf(b"account-tree", &account_root);
+    let sequence_leaf = state_leaf(b"sequence", &11_u64.to_be_bytes());
+    let universal_root = state_node(account_tree_leaf, sequence_leaf);
+    let account_tree_proof = Proof::new(0, 2, vec![sequence_leaf])
+        .unwrap_or_else(|error| panic!("account-tree proof: {error:?}"));
+
+    let universal_leaf = state_leaf(&0_u16.to_be_bytes(), &universal_root);
+    let module_leaf = state_leaf(&1_u16.to_be_bytes(), &[0x61; 32]);
+    let resulting_state_root = state_node(universal_leaf, module_leaf);
+    let universal_root_proof = Proof::new(0, 2, vec![module_leaf])
+        .unwrap_or_else(|error| panic!("universal proof: {error:?}"));
+
+    let receipt = receipt_bytes([0x71; 32], resulting_state_root, receipt_signature_key);
+    let (receipt_proof, receipt_root) = build_proof(&[receipt.as_slice()], 0)
+        .unwrap_or_else(|error| panic!("receipt proof: {error:?}"));
+    let header = header_bytes(resulting_state_root, receipt_root, sequencer_id);
+    let header_digest = batch_header_digest(&header)
+        .unwrap_or_else(|error| panic!("header digest failed: {error:?}"));
+    let header_signature = sequencer.sign(&header_digest).to_bytes();
+    let authorization = SequencerAuthorization::new(sequencer_id, sequencer_id, 7, 7);
+    (
+        NestedAccountProof {
+            account_id,
+            account_root,
+            universal_root,
+            resulting_state_root,
+            account_proof,
+            account_tree_proof,
+            universal_root_proof,
+            receipt_bytes: receipt,
+            receipt_proof,
+            header_bytes: header,
+            header_signature,
+        },
+        authorization,
+        resulting_state_root,
+    )
+}
+
+fn program_account_vectors() -> ([u8; 32], [u8; 32], Vec<u8>) {
+    let entries = vectors(PROGRAM_ACCOUNT_VECTORS);
+    let account_id = fixed::<32>(
+        entries
+            .get("account_id")
+            .unwrap_or_else(|| panic!("missing account id vector")),
+    );
+    let asset_id = fixed::<32>(
+        entries
+            .get("asset_id")
+            .unwrap_or_else(|| panic!("missing asset id vector")),
+    );
+    let account_value = hex(entries
+        .get("account_value")
+        .unwrap_or_else(|| panic!("missing account value vector")));
+    (account_id, asset_id, account_value)
+}
+
+fn maintenance_leaf(resulting_root: [u8; 32]) -> Vec<u8> {
+    use layerx_programs_runtime::{meter::FeeSchedule, occupancy::OccupancyLedger};
+
+    let schedule = FeeSchedule::new_complete(1, 1, 2, 3, 4, 5, 6, 7);
+    let prepared = OccupancyLedger::activated_after(6)
+        .prepare_unchanged_batch(7, schedule)
+        .unwrap_or_else(|error| panic!("real settlement failed: {error:?}"));
+    let settlement = prepared.settlement();
+    let evidence = settlement.canonical_evidence();
+    let usage = settlement.usage();
+    let mut schedule_bytes = 1_u32.to_be_bytes().to_vec();
+    for price in 1_u64..=7 {
+        schedule_bytes.extend_from_slice(&price.to_be_bytes());
+    }
+    schedule_bytes.extend_from_slice(&[0x81; 32]);
+    let mut schedule_preimage = b"LXP/v1/context-hash\0".to_vec();
+    schedule_preimage.extend_from_slice(&schedule_bytes);
+    let commitment = Sha256::digest(schedule_preimage);
+    let mut bytes = b"LXP/programs/occupancy-receipt/v2\0".to_vec();
+    bytes.extend_from_slice(&7_u64.to_be_bytes());
+    bytes.extend_from_slice(&10_u64.to_be_bytes());
+    bytes.extend_from_slice(&1_u32.to_be_bytes());
+    bytes.extend_from_slice(&schedule_bytes);
+    for amount in [
+        usage.byte_batches,
+        usage.fee_units,
+        usage.paid_fee_units,
+        usage.arrears_fee_units,
+    ] {
+        bytes.extend_from_slice(&amount.to_be_bytes());
+    }
+    assert!(settlement
+        .payer_dispositions()
+        .unwrap_or_else(|error| panic!("payers: {error:?}"))
+        .is_empty());
+    bytes.extend_from_slice(&0_u16.to_be_bytes());
+    bytes.extend_from_slice(&commitment);
+    bytes.extend_from_slice(
+        &u32::try_from(evidence.len())
+            .unwrap_or_else(|_| panic!("evidence length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(&evidence);
+    bytes.extend_from_slice(&Sha256::digest(&evidence));
+    bytes.extend_from_slice(&[0x82; 32]);
+    bytes.extend_from_slice(
+        &settlement
+            .transfer_root([0x81; 32])
+            .unwrap_or_else(|error| panic!("transfer root: {error:?}")),
+    );
+    bytes.extend_from_slice(&[0x83; 32]);
+    bytes.extend_from_slice(&resulting_root);
+    bytes
+}
+
+fn sign_maintenance_proof(proof: &mut NestedAccountProof) {
+    let sequencer = SigningKey::from_bytes(&[0x51; 32]);
+    let activity_receipt = receipt_bytes([0x71; 32], [0x83; 32], Some(&sequencer));
+    let (path, root) = build_proof(
+        &[activity_receipt.as_slice(), proof.receipt_bytes.as_slice()],
+        1,
+    )
+    .unwrap_or_else(|error| panic!("combined receipt proof: {error:?}"));
+    proof.receipt_proof = path;
+    proof.header_bytes = header_bytes(
+        proof.resulting_state_root,
+        root,
+        sequencer.verifying_key().to_bytes(),
+    );
+    proof.header_signature = sequencer
+        .sign(
+            &batch_header_digest(&proof.header_bytes)
+                .unwrap_or_else(|error| panic!("header hash: {error:?}")),
+        )
+        .to_bytes();
+}
+
+fn append_length(bytes: &mut Vec<u8>, value: &[u8]) {
+    bytes.extend_from_slice(
+        &u32::try_from(value.len())
+            .unwrap_or_else(|_| panic!("wire length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(value);
+}
+
+fn append_proof(bytes: &mut Vec<u8>, proof: &Proof) {
+    bytes.extend_from_slice(&proof.leaf_index().to_be_bytes());
+    bytes.extend_from_slice(&proof.leaf_count().to_be_bytes());
+    bytes.push(u8::try_from(proof.siblings().len()).unwrap_or_else(|_| panic!("proof depth")));
+    for sibling in proof.siblings() {
+        bytes.extend_from_slice(sibling);
+    }
+}
+
+fn evidence(version: u16, proof: &NestedAccountProof) -> Vec<u8> {
+    let key = SigningKey::from_bytes(&[0x51; 32])
+        .verifying_key()
+        .to_bytes();
+    let mut bytes = version.to_be_bytes().to_vec();
+    bytes.extend_from_slice(&[2, 1]);
+    for root in [
+        proof.account_id,
+        proof.account_root,
+        proof.universal_root,
+        proof.resulting_state_root,
+    ] {
+        bytes.extend_from_slice(&root);
+    }
+    for path in [
+        &proof.account_proof,
+        &proof.account_tree_proof,
+        &proof.universal_root_proof,
+    ] {
+        append_proof(&mut bytes, path);
+    }
+    append_length(&mut bytes, &proof.receipt_bytes);
+    append_proof(&mut bytes, &proof.receipt_proof);
+    bytes.extend_from_slice(&1_u16.to_be_bytes());
+    bytes.extend_from_slice(&key);
+    bytes.extend_from_slice(&key);
+    bytes.extend_from_slice(&7_u64.to_be_bytes());
+    bytes.extend_from_slice(&7_u64.to_be_bytes());
+    append_length(&mut bytes, &proof.header_bytes);
+    bytes.extend_from_slice(&proof.header_signature);
+    bytes.push(0);
+    bytes
+}
+
+fn fixture(maintenance: bool) -> (NestedAccountProof, SequencerAuthorization, Vec<u8>) {
+    let (account_id, _, value) = program_account_vectors();
+    let key = SigningKey::from_bytes(&[0x51; 32]);
+    let (mut proof, authorization, root) = nested_fixture(account_id, &value, Some(&key));
+    if maintenance {
+        proof.receipt_bytes = maintenance_leaf(root);
+        sign_maintenance_proof(&mut proof);
+    }
+    (proof, authorization, value)
+}
+
+fn read_evidence(
+    proof: &NestedAccountProof,
+    authorization: SequencerAuthorization,
+    value: &[u8],
+    wire: Vec<u8>,
+) -> Result<ReadValue, ReadError> {
+    static NEXT_SOCKET: AtomicU64 = AtomicU64::new(0);
+    let path = std::env::temp_dir().join(format!(
+        "lx-maint-{}-{}.sock",
+        std::process::id(),
+        NEXT_SOCKET.fetch_add(1, Ordering::Relaxed)
+    ));
+    let listener = UnixListener::bind(&path).unwrap_or_else(|error| panic!("bind: {error}"));
+    let payload = value.to_vec();
+    let expected_account = proof.account_id;
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .unwrap_or_else(|error| panic!("accept: {error}"));
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap_or_else(|error| panic!("deadline: {error}"));
+        let request =
+            read_frame(&mut stream, 1024 * 1024).unwrap_or_else(|error| panic!("frame: {error:?}"));
+        let request =
+            decode_envelope(&request).unwrap_or_else(|error| panic!("request: {error:?}"));
+        assert_eq!(request.message_tag, 7);
+        let response = encode_envelope(Envelope {
+            version: Version::V1_2,
+            message_tag: 8,
+            correlation_id: request.correlation_id,
+            canonical_payload: &payload,
+            proof_material: &wire,
+        })
+        .unwrap_or_else(|error| panic!("response: {error:?}"));
+        write_frame(&mut stream, &response, 1024 * 1024)
+            .unwrap_or_else(|error| panic!("write: {error:?}"));
+    });
+    let gate = ConnectionGate::new(1);
+    let limits = Limits {
+        maximum_frame_bytes: 1024 * 1024,
+        maximum_connections: 1,
+        maximum_streams: 1,
+        maximum_queued_bytes: 2 * 1024 * 1024,
+        deadline: Duration::from_secs(5),
+    };
+    let mut transport =
+        Uds::connect(&path, &gate, limits).unwrap_or_else(|error| panic!("connect: {error:?}"));
+    let result = account(
+        &mut transport,
+        expected_account,
+        ReadContext {
+            interface_version: Version::V1_2,
+            correlation_id: 44,
+            expected_protocol_version: PROTOCOL_VERSION,
+            expected_network_id: 42,
+            requested: Requested::new(VerificationLevel::STATE_PROVEN),
+            head: Head {
+                chain_sequence: 99,
+                sealed_batch: 7,
+                finalised_checkpoint: [0; 32],
+            },
+            sequencer_authorization: authorization,
+            handshake_sequencer_key: authorization.public_key(),
+            root_selector: RootSelector::Latest,
+        },
+    );
+    assert!(server.join().is_ok(), "response writer panicked");
+    fs::remove_file(path).unwrap_or_else(|error| panic!("remove socket: {error}"));
+    result
+}
+
+#[test]
+fn version_two_decodes_and_verifies_production_settlement_with_signed_freshness() {
+    let (proof, authorization, value) = fixture(true);
+    let wire = evidence(2, &proof);
+    let verified = read_evidence(&proof, authorization, &value, wire.clone())
+        .unwrap_or_else(|error| panic!("maintenance read: {error:?}"));
+    assert_eq!(verified.canonical_bytes(), value);
+    assert_eq!(verified.proof_material(), wire);
+    assert_eq!(verified.achieved(), VerificationLevel::STATE_PROVEN);
+    assert_eq!(verified.freshness().global_sequence, 10);
+    assert_eq!(verified.freshness().batch_number, 7);
+    assert_eq!(verified.freshness().observed_head_sequence, 99);
+}
+
+#[test]
+fn ordinary_version_one_still_verifies_and_both_version_swaps_fail() {
+    let (proof, authorization, value) = fixture(false);
+    let verified = read_evidence(&proof, authorization, &value, evidence(1, &proof))
+        .unwrap_or_else(|error| panic!("ordinary read: {error:?}"));
+    assert_eq!(verified.achieved(), VerificationLevel::STATE_PROVEN);
+    assert_eq!(verified.freshness().global_sequence, 10);
+    assert_eq!(
+        read_evidence(&proof, authorization, &value, evidence(2, &proof)),
+        Err(ReadError::ProductionEvidence(EvidenceError::Receipt))
+    );
+    let (proof, authorization, value) = fixture(true);
+    assert_eq!(
+        read_evidence(&proof, authorization, &value, evidence(1, &proof)),
+        Err(ReadError::Account(AccountProofError::ReceiptSignature))
+    );
+}
+
+#[test]
+fn mutated_maintenance_commitment_and_signed_inclusion_are_rejected() {
+    let (proof, authorization, value) = fixture(true);
+    let mut changed = proof.clone();
+    let digest_offset = changed.receipt_bytes.len() - 160;
+    changed.receipt_bytes[digest_offset] ^= 1;
+    assert_eq!(
+        read_evidence(&changed, authorization, &value, evidence(2, &changed)),
+        Err(ReadError::ProductionEvidence(EvidenceError::Receipt))
+    );
+    let mut changed = proof.clone();
+    let ledger_root_offset = changed.receipt_bytes.len() - 128;
+    changed.receipt_bytes[ledger_root_offset] ^= 1;
+    assert!(matches!(
+        read_evidence(&changed, authorization, &value, evidence(2, &changed)),
+        Err(ReadError::Account(AccountProofError::Header(_)))
+    ));
+    let mut changed = proof;
+    changed.header_signature[0] ^= 1;
+    assert!(matches!(
+        read_evidence(&changed, authorization, &value, evidence(2, &changed)),
+        Err(ReadError::Account(AccountProofError::Header(_)))
+    ));
+}
+
+#[test]
+fn receipt_and_maintenance_length_limits_are_independent() {
+    let (mut proof, authorization, value) = fixture(false);
+    for length in [4096, 4097, 86_680, 86_681] {
+        proof.receipt_bytes.resize(length, 0);
+        let ordinary_error = if length <= 4096 {
+            ReadError::Account(AccountProofError::Header(InclusionError::Merkle(
+                MerkleError::RootMismatch,
+            )))
+        } else {
+            ReadError::ProductionEvidence(EvidenceError::Malformed)
+        };
+        assert_eq!(
+            read_evidence(&proof, authorization, &value, evidence(1, &proof)),
+            Err(ordinary_error),
+            "ordinary length {length}"
+        );
+        let maintenance_error = if length <= 86_680 {
+            EvidenceError::Receipt
+        } else {
+            EvidenceError::Malformed
+        };
+        assert_eq!(
+            read_evidence(&proof, authorization, &value, evidence(2, &proof)),
+            Err(ReadError::ProductionEvidence(maintenance_error)),
+            "maintenance length {length}"
+        );
+    }
+}

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1672,6 +1672,12 @@ file = "platform/sdk/conformance/fixtures/generate_executed_program_fixture.py; 
 symbol = "fixture decode_and_verify_program_terminal"
 observed = "make programs-check-executed-fixture exits 2 in qual-logs/pass7-full-executed.log: program_wire.py:258 rejects transfer authority presence from the native protocol-3 terminal. Capability and native lifecycle fixture checks pass separately. V3 fixture bytes, ABI files and terminal emission are unchanged by this qualification."
 assumption = "The occupancy prerequisite is not fully qualified. Shared native-bin is not refreshed and terminal-evidence implementation, ABI generation and V4 fixtures remain pending. Client maintenance-v2 integration is a separate consumer dependency, not the reason for holding this work."
+[observation.6.4.35]
+task = "6.4"
+file = "agent/crates/layerx-client/Cargo.toml"
+symbol = "OccupancySettlement::canonical_evidence"
+observed = "The layerx-client dev-dependencies contain ed25519-dalek but no layerx-programs-runtime dependency. The production settlement constructor and canonical evidence encoder required for maintenance account-proof test generation are provided by programs/crates/layerx-programs-runtime/src/occupancy.rs. The wire maintenance module exposes a decoder but no settlement constructor, and layerx-proof does not re-export the runtime. Client account-proof decoder and read dispatch edits remain unqualified; the required tests and qualification commands have not run."
+assumption = "Add a direct test-only runtime dependency and the corresponding client lockfile entry through the manifest owner before generating maintenance test evidence with the production encoder. Preserve the ordinary receipt bound and all authentication and root checks."
 severity = "blocker"
 
 [observation.6.4.native-receipt-publication-lock]
@@ -1697,3 +1703,75 @@ symbol = "ReplicaDocument decode_and_verify_program_terminal"
 observed = "make test-daemon-finality-authority exits 2 with ReplicaDocument in qual-logs/n9-matrix-finality.log. The native replica supplies the exact retained maintenance receipt and proof under batch_identity.kind occupancy_maintenance_v2; six real HTTP responses are checked against retained signed headers and proofs. make programs-check-executed-fixture exits 2 with invalid transfer authority presence in qual-logs/n9-matrix-executed.log; recorded V3 is unchanged. cargo test --locked --manifest-path agent/Cargo.toml -p layerx-proof -p layerx-wire and cargo clippy --locked --manifest-path agent/Cargo.toml -p layerx-proof -p layerx-wire --all-targets -- -D warnings both exit 101 before compilation because the workspace lockfile requires updating; logs are qual-logs/n9-matrix-proof-wire-test.log and qual-logs/n9-matrix-proof-wire-clippy.log. The lockfile is outside native ownership and is unchanged."
 assumption = "These failed gates are recorded independently of native implementation. Exact matrix commands and exit codes are in qual-logs/n9-matrix-results.json. Successful native normal and ASan gates do not establish complete occupancy or terminal qualification."
 severity = "error"
+[observation.6.4.36]
+task = "6.4"
+file = "agent/crates/layerx-client/Cargo.toml"
+symbol = "layerx-programs-runtime"
+observed = "Adding the authorized dev-dependency path ../../../../programs/crates/layerx-programs-runtime prevents Cargo from loading the client manifest: the path resolves to /root/lx-lanes/programs/crates/layerx-programs-runtime/Cargo.toml, which does not exist. cargo metadata --manifest-path agent/Cargo.toml --format-version 1 exits 101; sh agent/tools/dependency-policy.sh exits 101 at its cargo metadata --locked command before evaluating dependency policy rules. Logs: qual-logs/client-resolution.log and qual-logs/client-dependency-policy.log. Cargo.lock is unchanged. Maintenance client integration test source is written but unformatted and unqualified."
+assumption = "Authorize the client dev-dependency path ../../../programs/crates/layerx-programs-runtime, which resolves inside the repository, and the corresponding Cargo resolution update. Then qualify the test source and run the requested client and aggregate gates without editing the dependency policy."
+severity = "blocker"
+
+[observation.6.4.37]
+task = "6.4"
+file = "agent/crates/layerx-client/tests/maintenance_reads.rs"
+symbol = "ordinary_version_one_still_verifies_and_both_version_swaps_fail receipt_and_maintenance_length_limits_are_independent verify_nested_account"
+observed = "The corrected runtime dev-dependency resolves successfully with cargo metadata --manifest-path agent/Cargo.toml --format-version 1 (exit 0); agent/Cargo.lock adds only layerx-programs-runtime to the client dependency list. cargo test --manifest-path agent/Cargo.toml --locked -p layerx-client exits 101: maintenance success with signed freshness and commitment/inclusion/signature rejection tests pass, but the version-swap test expects ReceiptEncoding and receives ReceiptSignature, and the ordinary 4096-byte length case expects ReceiptEncoding and receives Header(Merkle(RootMismatch)). The ordinary proof verifier verifies inclusion before receipt signatures and maps receipt signature verification errors to ReceiptSignature. Both assertions and verifier behavior remain intact. Logs: qual-logs/k5-resolution.log and qual-logs/k5-client-test.log."
+assumption = "Resolve the exact error-contract conflict explicitly before changing assertions or proof behavior. The boundary loop stops at its first failed assertion, so later length cases are not qualified. Successful maintenance and tampering cases do not qualify the full client test suite."
+severity = "blocker"
+
+[observation.6.4.38]
+task = "6.4"
+file = "agent/crates/layerx-client/src/availability.rs"
+symbol = "records.verify"
+observed = "cargo fmt --manifest-path agent/Cargo.toml -p layerx-client -- --check exits 1 solely on the pre-existing records.verify expression formatting in availability.rs. The incidental package formatter edit to this unrelated file was reverted; only the maintenance implementation and its test source retain formatting changes. cargo clippy --manifest-path agent/Cargo.toml --locked -p layerx-client --all-targets -- -D warnings exits 0. Logs: qual-logs/k5-fmt-check.log and qual-logs/k5-client-clippy.log."
+assumption = "Have the availability source owner format the reported expression before the package-wide format gate can pass. Preserve maintenance-only ownership."
+severity = "blocker"
+
+[observation.6.4.39]
+task = "6.4"
+file = "agent/crates/layerx-client/tests/maintenance_reads.rs"
+symbol = "ordinary_version_one_still_verifies_and_both_version_swaps_fail receipt_and_maintenance_length_limits_are_independent"
+observed = "make agent-test initially exits 2 because the real authority fixture cannot find build/bin/layerxd. Repeating make agent-test with LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin reaches maintenance_reads and exits 2 on the same ReceiptSignature versus ReceiptEncoding and Header(Merkle(RootMismatch)) versus ReceiptEncoding assertion conflicts as the focused client test. The maintenance freshness and tampering cases pass in both runs that reach them. make agent-lint exits 0, including its unchanged dependency-policy.sh; a separate sh agent/tools/dependency-policy.sh also exits 0. rustfmt --edition 2021 --check on evidence.rs, read.rs and tests/maintenance_reads.rs exits 0. Logs: qual-logs/k5-agent-test.log, qual-logs/k5-agent-test-native.log, qual-logs/k5-agent-lint.log, qual-logs/k5-dependency-policy.log and qual-logs/k5-owned-fmt-check.log."
+assumption = "The native binary directory resolves the aggregate fixture prerequisite but does not resolve the preserved client assertions. Full workspace qualification remains incomplete after Cargo stops at those failures. Resolve observation 6.4.37 and the unrelated package formatting difference in observation 6.4.38 before publication."
+severity = "blocker"
+
+
+[observation.6.4.client-maintenance-rejection-contract]
+task = "6.4"
+file = "agent/crates/layerx-client/tests/maintenance_reads.rs"
+symbol = "ordinary_version_one_still_verifies_and_both_version_swaps_fail receipt_and_maintenance_length_limits_are_independent"
+observed = "The new maintenance version-swap assertion now requires ReceiptSignature when maintenance bytes are presented as wire version 1. The ordinary 4096-byte padded receipt assertion now requires Header(Merkle(RootMismatch)). These exact rejection variants follow the established proof verifier ordering: inclusion is checked before receipt signatures, and receipt signature verification errors map to ReceiptSignature. Every negative case still requires rejection; no proof or wire implementation, bound, signature check or root assertion changed."
+assumption = "Matching the existing verifier's exact error contract corrects the newly introduced assertions without weakening rejection coverage. The rebased tests remain unqualified because the locked dependency gate stops before compilation."
+severity = "info"
+
+[observation.6.4.client-maintenance-rebased-lock]
+task = "6.4"
+file = "agent/Cargo.lock; interop/crates/layerx-mirror/Cargo.toml"
+symbol = "layerx-mirror base64"
+observed = "After rebasing onto 90cf3c94, cargo test --manifest-path agent/Cargo.toml --locked -p layerx-client exits 101, LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin make agent-test exits 2, cargo clippy --manifest-path agent/Cargo.toml --locked -p layerx-client --all-targets -- -D warnings exits 101, and make agent-lint exits 2 because Cargo requires a lockfile update before compilation. Logs: qual-logs/k6-client-test.log, qual-logs/k6-agent-test-native.log, qual-logs/k6-client-clippy.log and qual-logs/k6-agent-lint.log. The mirror manifest requires base64 =0.23.1 while its agent lock dependency selects base64 0.22.1. Offline metadata resolution exits 0 and removes unused base64 0.22.1, changes the mirror edge to base64 0.23.1 and normalizes the remaining base64 references; those unrelated changes were reverted. Only the authorized client runtime dependency entry remains."
+assumption = "The dependency owner must reconcile the mirror base64 edge and resulting Cargo lock normalization in agent/Cargo.lock before rerunning the four blocked gates. No locked check was bypassed. No tests ran in this qualification attempt and the dependency-policy stage of make agent-lint was not reached."
+severity = "blocker"
+
+[observation.6.4.client-availability-format]
+task = "6.4"
+file = "agent/crates/layerx-client/src/availability.rs"
+symbol = "records.verify"
+observed = "The records.verify expression is formatted without changing behavior. cargo fmt --manifest-path agent/Cargo.toml -p layerx-client exits 0 and cargo fmt --manifest-path agent/Cargo.toml -p layerx-client -- --check exits 0. Logs: qual-logs/k6-format.log and qual-logs/k6-fmt-check.log."
+assumption = "This closes the formatting conflict in observation 6.4.38. Package formatting success does not qualify the blocked maintenance tests or clippy gates."
+severity = "info"
+
+[observation.6.4.client-maintenance-lock-reconciled]
+task = "6.4"
+file = "agent/Cargo.lock; interop/crates/layerx-mirror/Cargo.toml"
+symbol = "layerx-mirror base64"
+observed = "cargo metadata --manifest-path agent/Cargo.toml --format-version 1 --offline exits 0; logs: qual-logs/k7-resolution.log and qual-logs/k7-resolution.json. This is the agent workspace counterpart to the verify-receipt sample lock correction in PR #107, commit \"Drop the unused base64 0.22.1 entry from the verify-receipt sample lock\". The final lock diff removes only base64 0.22.1, selects the already-locked base64 0.23.1 for layerx-mirror, normalizes ureq and ureq-proto references, and adds the authorized layerx-client test dependency on layerx-programs-runtime. This checkout contains ureq and ureq-proto rather than the reqwest and rustls-pemfile dependants named in the request. A parsed package comparison confirms no other version or package field changes. Exact final diff follows:\ndiff --git a/agent/Cargo.lock b/agent/Cargo.lock\nindex 01847b72..34a5485f 100644\n--- a/agent/Cargo.lock\n+++ b/agent/Cargo.lock\n@@ -48,12 +48,6 @@ version = \"0.2.0\"\n source = \"registry+https://github.com/rust-lang/crates.io-index\"\n checksum = \"4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf\"\n \n-[[package]]\n-name = \"base64\"\n-version = \"0.22.1\"\n-source = \"registry+https://github.com/rust-lang/crates.io-index\"\n-checksum = \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\"\n-\n [[package]]\n name = \"base64\"\n version = \"0.23.1\"\n@@ -747,6 +741,7 @@ version = \"0.1.0\"\n dependencies = [\n  \"ed25519-dalek\",\n  \"layerx-crypto\",\n+ \"layerx-programs-runtime\",\n  \"layerx-proof\",\n  \"layerx-types\",\n  \"layerx-wire\",\n@@ -785,7 +780,7 @@ dependencies = [\n name = \"layerx-mirror\"\n version = \"0.1.0\"\n dependencies = [\n- \"base64 0.22.1\",\n+ \"base64\",\n  \"ed25519-dalek\",\n  \"k256\",\n  \"layerx-agent-api\",\n@@ -1509,7 +1504,7 @@ version = \"3.4.0\"\n source = \"registry+https://github.com/rust-lang/crates.io-index\"\n checksum = \"972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d\"\n dependencies = [\n- \"base64 0.23.1\",\n+ \"base64\",\n  \"cookie_store\",\n  \"der 0.8.1\",\n  \"log\",\n@@ -1528,7 +1523,7 @@ version = \"0.6.1\"\n source = \"registry+https://github.com/rust-lang/crates.io-index\"\n checksum = \"da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613\"\n dependencies = [\n- \"base64 0.23.1\",\n+ \"base64\",\n  \"http\",\n  \"httparse\",\n  \"log\",\n"
+assumption = "The bare base64 dependency reference resolves uniquely to the remaining base64 0.23.1 package. Locked checks remain enabled. This resolves observation 6.4.client-maintenance-rebased-lock; full client qualification is recorded separately."
+severity = "info"
+
+[observation.6.4.client-maintenance-qualified]
+task = "6.4"
+file = "agent/crates/layerx-client/src/evidence.rs; agent/crates/layerx-client/src/read.rs; agent/crates/layerx-client/tests/maintenance_reads.rs; agent/crates/layerx-client/Cargo.toml; agent/Cargo.lock"
+symbol = "decode_nested_evidence verified_account_position"
+observed = "cargo test --manifest-path agent/Cargo.toml --locked -p layerx-client exits 0 in qual-logs/k7-client-test.log; LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin make agent-test exits 0 in qual-logs/k7-agent-test-native.log; cargo clippy --manifest-path agent/Cargo.toml --locked -p layerx-client --all-targets -- -D warnings exits 0 in qual-logs/k7-client-clippy.log; cargo fmt --manifest-path agent/Cargo.toml -p layerx-client -- --check exits 0 in qual-logs/k7-fmt-check.log; make agent-lint exits 0 in qual-logs/k7-agent-lint.log. All four maintenance_reads tests pass, including production settlement verification with signed-header freshness, ordinary version-1 compatibility, both version swaps, commitment/inclusion/signature rejection, and independent ordinary/maintenance length limits. Aggregate lint includes the unchanged dependency and unsafe-code policies. Environment: CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4; build outputs are worktree-local."
+assumption = "These five gates qualify client wire-version selection on the current dependency state. The supplied native-bin/native-ready.txt still describes an older unqualified native snapshot, so aggregate success does not certify native maintenance publication, finality authority integration or production readiness. No proof, wire hash, native or hosted authority source changed. Earlier blocked runs remain historical evidence; their client lock, formatting and exact rejection-contract blockers are resolved by the changes and gates recorded here."
+severity = "info"


### PR DESCRIPTION
Client account reads select ordinary activity verification for account-proof wire version 1 and maintenance verification for version 2. Maintenance freshness comes from the verified signed header; ordinary receipt limits and rejection checks remain intact. Tests exercise production occupancy settlement evidence, ordinary compatibility, both version swaps, tampered commitments/inclusion/signatures, and independent length limits.

The agent lock correction is the workspace counterpart to PR #107, `Drop the unused base64 0.22.1 entry from the verify-receipt sample lock`. Offline resolution removes only unused base64 0.22.1; the mirror selects already-locked 0.23.1. The actual remaining dependants here are `ureq` and `ureq-proto`, rather than the request's `reqwest` and `rustls-pemfile`. Their references normalize without changing versions. The client also gains its authorized test-only runtime dependency. Parsed package comparison verified no other versions or fields changed.

Exact final lock diff:

```diff
diff --git a/agent/Cargo.lock b/agent/Cargo.lock
index 01847b72..34a5485f 100644
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -48,12 +48,6 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
 [[package]]
 name = "base64"
 version = "0.23.1"
@@ -747,6 +741,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "layerx-crypto",
+ "layerx-programs-runtime",
  "layerx-proof",
  "layerx-types",
  "layerx-wire",
@@ -785,7 +780,7 @@ dependencies = [
 name = "layerx-mirror"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "ed25519-dalek",
  "k256",
  "layerx-agent-api",
@@ -1509,7 +1504,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "cookie_store",
  "der 0.8.1",
  "log",
@@ -1528,7 +1523,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.23.1",
+ "base64",
  "http",
  "httparse",
  "log",
```

Qualified item: maintenance account-proof wire version selection and agent lock reconciliation

Commands ran from `/root/lx-lanes/client-maint` with `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`. Logs remain untracked under that worktree; `.exit` sidecars record exit codes.

| Exact command | Exit | Log |
| --- | --- | --- |
| `cargo test --manifest-path agent/Cargo.toml --locked -p layerx-client` | 0 | `qual-logs/k7-client-test.log` |
| `LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin make agent-test` | 0 | `qual-logs/k7-agent-test-native.log` |
| `cargo clippy --manifest-path agent/Cargo.toml --locked -p layerx-client --all-targets -- -D warnings` | 0 | `qual-logs/k7-client-clippy.log` |
| `cargo fmt --manifest-path agent/Cargo.toml -p layerx-client -- --check` | 0 | `qual-logs/k7-fmt-check.log` |
| `make agent-lint` | 0 | `qual-logs/k7-agent-lint.log` |

| `cargo metadata --manifest-path agent/Cargo.toml --format-version 1 --offline` | 0 | `qual-logs/k7-resolution.log`, `qual-logs/k7-resolution.json` |

All four maintenance tests passed in both focused and aggregate runs. Aggregate lint includes the unchanged dependency and unsafe-code policies. The supplied native readiness file describes an older unqualified snapshot; these results do not certify native maintenance publication or production readiness. Prior blocked attempts remain recorded in qualification.kvx and are superseded for this client item by the passing gates above.

Previously qualified item: availability expression formatting

| Exact command | Exit | Log |
| --- | --- | --- |
| `cargo fmt --manifest-path agent/Cargo.toml -p layerx-client` | 0 | `qual-logs/k6-format.log` |
| `cargo fmt --manifest-path agent/Cargo.toml -p layerx-client -- --check` | 0 | `qual-logs/k6-fmt-check.log` |

`git fetch origin` and `git rebase origin/main` completed; the branch was already up to date with main. PR base remains `lane/native`.

🤖 Generated with Codex
