### PR TITLE
Repair Programs runtime linkage for bridge deposit and native tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -389,10 +389,11 @@ test-ledger-receipt: $(BUILD_DIR)/tests/test_receipt
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_asset_registry: tests/modules/test_asset_registry.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 $(BUILD_DIR)/tests/test_state_commitment_transition: tests/test_state_commitment_transition.c \
 		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
@@ -407,10 +408,12 @@ test-state-commitment-transition: $(BUILD_DIR)/tests/test_state_commitment_trans
 test-asset-registry: $(BUILD_DIR)/tests/test_asset_registry
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_asset_registry
 
-$(BUILD_DIR)/tests/test_asset_state: tests/modules/test_asset_state.c $(LIBRARY)
+$(BUILD_DIR)/tests/test_asset_state: tests/modules/test_asset_state.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-asset-balance: $(BUILD_DIR)/tests/test_asset_state
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_asset_state
@@ -426,10 +429,11 @@ test-asset-transfer: $(BUILD_DIR)/tests/test_asset_transfer
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_asset_deposit: tests/modules/test_asset_deposit.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-asset-deposit: $(BUILD_DIR)/tests/test_asset_deposit
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_asset_deposit
@@ -444,39 +448,43 @@ test-asset-withdraw: $(BUILD_DIR)/tests/test_asset_withdraw
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_asset_withdraw
 
 $(BUILD_DIR)/tests/test_asset_reserve: tests/modules/test_asset_reserve.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-asset-reserve: $(BUILD_DIR)/tests/test_asset_reserve
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_asset_reserve
 
 $(BUILD_DIR)/tests/test_escrow_open: tests/modules/test_escrow_open.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-escrow-open: $(BUILD_DIR)/tests/test_escrow_open
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_escrow_open
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_escrow_capture: tests/modules/test_escrow_capture.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-escrow-capture: $(BUILD_DIR)/tests/test_escrow_capture
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_escrow_capture
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_escrow_timeout: tests/modules/test_escrow_timeout.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-escrow-timeout: $(BUILD_DIR)/tests/test_escrow_timeout
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_escrow_timeout
@@ -493,69 +501,77 @@ test-escrow-dispute: $(BUILD_DIR)/tests/test_escrow_dispute
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_escrow_invariants: \
-		tests/modules/test_escrow_invariants.c $(LIBRARY)
+		tests/modules/test_escrow_invariants.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-escrow-invariants: $(BUILD_DIR)/tests/test_escrow_invariants
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_escrow_invariants
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_budget_create: tests/modules/test_budget_create.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-budget-create: $(BUILD_DIR)/tests/test_budget_create
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_budget_create
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_budget_period: tests/modules/test_budget_period.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-budget-period: $(BUILD_DIR)/tests/test_budget_period
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_budget_period
 
 $(BUILD_DIR)/tests/test_budget_spend: tests/modules/test_budget_spend.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-budget-spend: $(BUILD_DIR)/tests/test_budget_spend
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_budget_spend
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_budget_delegate: tests/modules/test_budget_delegate.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-budget-delegate: $(BUILD_DIR)/tests/test_budget_delegate
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_budget_delegate
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_budget_close: tests/modules/test_budget_close.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-budget-revoke: $(BUILD_DIR)/tests/test_budget_close
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_budget_close
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_stream_open: tests/modules/test_stream_open.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-stream-open: $(BUILD_DIR)/tests/test_stream_open
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_stream_open
@@ -580,10 +596,11 @@ test-stream-meter: $(BUILD_DIR)/tests/test_stream_meter
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_stream_meter
 
 $(BUILD_DIR)/tests/test_stream_settle: tests/modules/test_stream_settle.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-stream-settle: $(BUILD_DIR)/tests/test_stream_settle
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_stream_settle
@@ -600,60 +617,68 @@ test-stream-lifecycle: $(BUILD_DIR)/tests/test_stream_lifecycle
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_offer: tests/modules/test_service_offer.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-offer: $(BUILD_DIR)/tests/test_service_offer
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_offer
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_commit: tests/modules/test_service_commit.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-commit: $(BUILD_DIR)/tests/test_service_commit
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_commit
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_attest: tests/modules/test_service_attest.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-attest: $(BUILD_DIR)/tests/test_service_attest
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_attest
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_deliver: tests/modules/test_service_deliver.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-deliver: $(BUILD_DIR)/tests/test_service_deliver
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_deliver
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_acceptance: \
-		tests/modules/test_service_acceptance.c $(LIBRARY)
+		tests/modules/test_service_acceptance.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-acceptance: $(BUILD_DIR)/tests/test_service_acceptance
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_acceptance
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_service_dispute: \
-		tests/modules/test_service_dispute.c $(LIBRARY)
+		tests/modules/test_service_dispute.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-service-dispute: $(BUILD_DIR)/tests/test_service_dispute
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_service_dispute
@@ -680,10 +705,11 @@ test-oracle-adapter: $(BUILD_DIR)/tests/test_oracle_adapter \
 	sh tools/lx_oracle_adapter_isolation.sh
 
 $(BUILD_DIR)/tests/test_oracle_intake: tests/modules/test_oracle_intake.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-oracle-intake: $(BUILD_DIR)/tests/test_oracle_intake
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_oracle_intake
@@ -691,89 +717,100 @@ test-oracle-intake: $(BUILD_DIR)/tests/test_oracle_intake
 	sh tools/lx_oracle_adapter_isolation.sh
 
 $(BUILD_DIR)/tests/test_oracle_checks: tests/modules/test_oracle_checks.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-oracle-bounds: $(BUILD_DIR)/tests/test_oracle_checks
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_oracle_checks
 	sh tools/lx_oracle_adapter_isolation.sh
 
 $(BUILD_DIR)/tests/test_oracle_root: tests/sequencer/test_oracle_root.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-oracle-root: $(BUILD_DIR)/tests/test_oracle_root
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_oracle_root
 
 $(BUILD_DIR)/tests/test_oracle_halt: tests/modules/test_oracle_halt.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-oracle-failclosed: $(BUILD_DIR)/tests/test_oracle_halt
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_oracle_halt
 	sh tools/lx_oracle_adapter_isolation.sh
 
 $(BUILD_DIR)/tests/test_perps_market: tests/modules/test_perps_market.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-market: $(BUILD_DIR)/tests/test_perps_market
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_market
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_perps_book: tests/modules/test_perps_book.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-book: $(BUILD_DIR)/tests/test_perps_book
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_book
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_perps_position: tests/modules/test_perps_position.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-margin: $(BUILD_DIR)/tests/test_perps_position
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_position
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_perps_funding: tests/modules/test_perps_funding.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-funding: $(BUILD_DIR)/tests/test_perps_funding
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_funding
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_perps_liquidate: \
-		tests/modules/test_perps_liquidate.c $(LIBRARY)
+		tests/modules/test_perps_liquidate.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-liquidation: $(BUILD_DIR)/tests/test_perps_liquidate
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_liquidate
 	tools/lxp_check_sole_writer.sh
 
 $(BUILD_DIR)/tests/test_perps_insurance: \
-		tests/modules/test_perps_insurance.c $(LIBRARY)
+		tests/modules/test_perps_insurance.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-perps-insurance: $(BUILD_DIR)/tests/test_perps_insurance
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_perps_insurance
@@ -995,19 +1032,22 @@ $(BUILD_DIR)/tests/test_governance_emergency: \
 test-governance-emergency: $(BUILD_DIR)/tests/test_governance_emergency
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_governance_emergency
 
-$(BUILD_DIR)/tests/test_fees: tests/test_fees.c $(LIBRARY)
+$(BUILD_DIR)/tests/test_fees: tests/test_fees.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-fees: $(BUILD_DIR)/tests/test_fees
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_fees
 
 $(BUILD_DIR)/tests/test_metering: tests/test_metering.c fuzz/fuzz_meter.c \
-		$(LIBRARY)
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/test_metering.c fuzz/fuzz_meter.c \
-		$(LIBRARY) $(EXTRA_LDFLAGS) -lcrypto -o $@
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) -lcrypto -pthread -ldl -lm -o $@
 
 test-metering: $(BUILD_DIR)/tests/test_metering
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_metering
@@ -1050,10 +1090,11 @@ test-paxeer-bond: $(BUILD_DIR)/tests/test_paxeer_bond \
 		$(BUILD_DIR)/contracts/.paxeer-built
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_paxeer_bond
 
-$(BUILD_DIR)/tests/test_bridge_deposit: tests/test_bridge_deposit.c $(LIBRARY)
+$(BUILD_DIR)/tests/test_bridge_deposit: tests/test_bridge_deposit.c \
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) -lcrypto -pthread -ldl -lm -o $@
 
 test-bridge-deposit: $(BUILD_DIR)/tests/test_bridge_deposit test-contracts
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_bridge_deposit
@@ -1079,19 +1120,22 @@ $(BUILD_DIR)/tests/test_bridge_withdraw: tests/test_bridge_withdraw.c \
 test-bridge-withdraw: $(BUILD_DIR)/tests/test_bridge_withdraw test-contracts
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_bridge_withdraw
 
-$(BUILD_DIR)/tests/test_emergency_exit: tests/test_emergency_exit.c $(LIBRARY)
+$(BUILD_DIR)/tests/test_emergency_exit: tests/test_emergency_exit.c $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-emergency-exit: $(BUILD_DIR)/tests/test_emergency_exit test-contracts
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_emergency_exit
 
 $(BUILD_DIR)/tests/test_reserve_reconcile: \
-		tests/test_reserve_reconcile.c $(LIBRARY)
+		tests/test_reserve_reconcile.c $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 $(BUILD_DIR)/tools/lxp-reserve-report: tools/lxp_reserve_report.c
 	@mkdir -p $(@D)
@@ -1334,24 +1378,26 @@ qualify-replay:
 $(BUILD_DIR)/tests/test_qual_recovery: tests/test_qual_recovery.c \
 		tests/qualification/lxp_qual_faults.c \
 		src/storage/lxp_projection.c $(LIBRARY) \
-		migrations/0001_projection.sql
+		migrations/0001_projection.sql $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/test_qual_recovery.c \
 		tests/qualification/lxp_qual_faults.c \
-		src/storage/lxp_projection.c $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -lsqlite3 -pthread -o $@
+		src/storage/lxp_projection.c $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -lsqlite3 -pthread -ldl -lm -o $@
 
 qualify-faults: $(BUILD_DIR)/tests/test_qual_recovery
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_qual_recovery
 
 $(BUILD_DIR)/tests/test_fuzz_smoke: tests/test_fuzz_smoke.c \
 		fuzz/fuzz_activity.c fuzz/fuzz_signature.c \
-		fuzz/fuzz_transfer_set.c $(LIBRARY)
+		fuzz/fuzz_transfer_set.c $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)
 	$(CC) $(CPPFLAGS) $(CFLAGS) tests/test_fuzz_smoke.c \
 		fuzz/fuzz_activity.c fuzz/fuzz_signature.c \
-		fuzz/fuzz_transfer_set.c $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -pthread -o $@
+		fuzz/fuzz_transfer_set.c $(LIBRARY) $(PROGRAMS_RUNTIME_LIB) \
+		$(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 qualify-fuzz-run: $(BUILD_DIR)/tests/test_fuzz_smoke
 	test -r "$(QUALIFICATION_CORPUS)"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -1838,6 +1838,20 @@ file = "platform/emulator/tests/gateway.rs"
 symbol = "lifecycle_routes_execute_and_replay_real_native_state_receipts"
 observed = "CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin LAYERX_BETA_CLUSTER_NAME=layerx-cluster-lane make platform-test-tooling exits 2. The emulator gateway suite passes ten tests and fails ordinal 3 sequence 3 at line 719: -736 versus 0, callback stage 5/status -3. Later tooling recipe steps are not reached. Supplied native-bin metadata reports source 7bc94bf775e8a59b458076ae8415cee7cb0e0417 and partial authority qualification. make test-bridge-deposit exits 2 at Makefile:1055 with unresolved Programs runtime symbols including layerx_programs_interface_validate. The same commands exit 2 again after rebase, with the same callback and linkage failures. Logs: qual-logs/pass5/tooling.log, final-tooling.log, native-ready.txt, bridge-deposit.log and final-bridge-deposit.log. Final cg spec lint exits 0 in qual-logs/pass5/final-spec-lint.log."
 assumption = "Native runtime and Makefile repairs are outside the cluster wiring and custody helper ownership. No assertion, bound or gate is changed. These aggregate gates do not qualify the hosted stack."
+[observation.6.11.native-test-programs-link]
+task = "6.11"
+file = "Makefile"
+symbol = "test_bridge_deposit test_paxeer_bond programs-build"
+observed = "The native test recipe audit identifies 37 sibling binaries with unresolved layerx_programs symbols, 77 clean-link siblings and four unrelated failures. Bridge deposit and the 37 proven failing siblings now use the existing Programs static archive ordering, runtime system libraries and programs-build order-only prerequisite. All 38 repaired binary build commands exit 0. make build/tests/test_paxeer_bond and build/tests/test_paxeer_bond exit 0; its recipe remains unchanged because it links cleanly. The complete command, exit and log inventory is retained in qual-logs/bridge-link/audit-table.md and gates.jsonl; clean recipes are listed in clean-targets.txt."
+assumption = "Link qualification does not establish runtime correctness of every repaired binary. No test source, assertion, bound, compiler check or clean-link sibling recipe changes."
+severity = "note"
+
+[observation.6.11.native-test-unrelated-gate-failures]
+task = "6.11"
+file = "Makefile tests/test_fee_replay.c include/layerx/lxp_fee.h src/ledger/lx_account_registry.c tests/test_bridge_deposit.c"
+symbol = "test_account_id lxp_test_journal lxp_test_idempotency lxp_test_journal_tsan test_fee_replay test_bridge_deposit"
+observed = "The sibling audit finds missing OpenSSL EVP linkage in test_account_id, lxp_test_journal and lxp_test_idempotency. test_fee_replay.c:358-361 fails -Werror=missing-field-initializers for exact_program_fee_present before linkage. timeout 300 make check exits 2 on journal EVP linkage and journal_tsan missing lxp_ed25519_pubkey_is_canonical from lx_account_registry.c:332. timeout 600 make test-bridge-deposit exits 2 after all 145 Foundry tests pass and the native bridge binary exits 1. Direct build/tests/test_bridge_deposit also exits 1 without diagnostics. Evidence: qual-logs/bridge-link/audit-test_account_id.log, audit-lxp_test_journal.log, audit-lxp_test_idempotency.log, audit-test_fee_replay.log, check.log, bridge-test.log and bridge-native.log."
+assumption = "These failures are outside the Programs-link recipe repair. The bridge test has no compile error and remains unchanged. Existing assertions, source and compiler checks are retained; successful binary linkage does not qualify the full bridge or aggregate native gate."
 severity = "blocker"
 
 [observation.6.4.interop-grouped-store-qualification]


### PR DESCRIPTION
Bridge deposit and 37 sibling native test binaries failed to resolve Programs runtime symbols. Their recipes now use the established archive ordering, runtime system libraries and `programs-build` order-only prerequisite. All 38 repaired build targets pass. No test source or assertion changed.

`test_paxeer_bond` already links cleanly: its recipe is unchanged, and its build and native execution pass. All 77 clean-link sibling recipes remain unchanged. The requested commit title mentions bond; the actual change scope is the 38 proven failing recipes listed below.

Rebased commit: `c8d6e956b459f8e4078f86b63111f542eed8c69d` on `origin/main`; branch `lane/dependency-gates` (the branch actually checked out in this worktree).

Qualification remains partial: `make test-bridge-deposit` exits 2 after 145 Foundry tests pass and the native bridge test exits 1 without diagnostics. The initial `make check` exits 2 on journal EVP linkage and journal-TSan's missing `lxp_ed25519_pubkey_is_canonical`; the rebased run again exits 2 on journal EVP linkage. The audit also records missing EVP linkage for account ID/idempotency and missing fee-meter field initializers in `test_fee_replay.c`. These are recorded in `spec/layerx-beta/qualification.kvx` and untracked `NEEDS.md` without changing checks.

Environment for all make commands: `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`. Commands prefixed with `timeout` finished with make exit 2, not timeout exit 124. Logs are untracked under `/root/lx-lanes/depgates/qual-logs/bridge-link/`.

Rebased qualification commands:

| Command | Exit | Log |
|---|---:|---|
| `git diff --exit-code c660abb4 HEAD -- Makefile src include :(glob)tests/**/*.c programs/Cargo.toml programs/Cargo.lock programs/crates/layerx-programs-runtime programs/crates/layerx-programs-sandbox programs/vendor programs/sdk` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-inputs.log` |
| `python3 qual-logs/bridge-link/verify-scope.py` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-scope.log` |
| `make build/tests/test_bridge_deposit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_bridge_deposit.log` |
| `make build/tests/test_asset_registry` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_asset_registry.log` |
| `make build/tests/test_asset_state` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_asset_state.log` |
| `make build/tests/test_asset_deposit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_asset_deposit.log` |
| `make build/tests/test_asset_reserve` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_asset_reserve.log` |
| `make build/tests/test_escrow_open` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_escrow_open.log` |
| `make build/tests/test_escrow_capture` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_escrow_capture.log` |
| `make build/tests/test_escrow_timeout` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_escrow_timeout.log` |
| `make build/tests/test_escrow_invariants` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_escrow_invariants.log` |
| `make build/tests/test_budget_create` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_budget_create.log` |
| `make build/tests/test_budget_period` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_budget_period.log` |
| `make build/tests/test_budget_spend` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_budget_spend.log` |
| `make build/tests/test_budget_delegate` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_budget_delegate.log` |
| `make build/tests/test_budget_close` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_budget_close.log` |
| `make build/tests/test_stream_open` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_stream_open.log` |
| `make build/tests/test_stream_settle` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_stream_settle.log` |
| `make build/tests/test_service_offer` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_offer.log` |
| `make build/tests/test_service_commit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_commit.log` |
| `make build/tests/test_service_attest` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_attest.log` |
| `make build/tests/test_service_deliver` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_deliver.log` |
| `make build/tests/test_service_acceptance` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_acceptance.log` |
| `make build/tests/test_service_dispute` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_service_dispute.log` |
| `make build/tests/test_oracle_intake` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_oracle_intake.log` |
| `make build/tests/test_oracle_checks` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_oracle_checks.log` |
| `make build/tests/test_oracle_root` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_oracle_root.log` |
| `make build/tests/test_oracle_halt` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_oracle_halt.log` |
| `make build/tests/test_perps_market` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_market.log` |
| `make build/tests/test_perps_book` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_book.log` |
| `make build/tests/test_perps_position` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_position.log` |
| `make build/tests/test_perps_funding` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_funding.log` |
| `make build/tests/test_perps_liquidate` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_liquidate.log` |
| `make build/tests/test_perps_insurance` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_perps_insurance.log` |
| `make build/tests/test_fees` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_fees.log` |
| `make build/tests/test_metering` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_metering.log` |
| `make build/tests/test_emergency_exit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_emergency_exit.log` |
| `make build/tests/test_reserve_reconcile` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_reserve_reconcile.log` |
| `make build/tests/test_qual_recovery` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_qual_recovery.log` |
| `make build/tests/test_fuzz_smoke` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_fuzz_smoke.log` |
| `make build/tests/test_paxeer_bond` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-test_paxeer_bond.log` |
| `timeout 600 make test-bridge-deposit` | 2 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-bridge-test.log` |
| `build/tests/test_paxeer_bond` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-bond-native.log` |
| `timeout 300 make check` | 2 | `/root/lx-lanes/depgates/qual-logs/bridge-link/rebased-check.log` |

<details>
<summary>Initial qualification commands</summary>

| Command | Exit | Log |
|---|---:|---|
| `make build/tests/test_bridge_deposit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_bridge_deposit.log` |
| `make build/tests/test_asset_registry` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_asset_registry.log` |
| `make build/tests/test_asset_state` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_asset_state.log` |
| `make build/tests/test_asset_deposit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_asset_deposit.log` |
| `timeout 300 make check` | 2 | `/root/lx-lanes/depgates/qual-logs/bridge-link/check.log` |
| `build/tests/test_bridge_deposit` | 1 | `/root/lx-lanes/depgates/qual-logs/bridge-link/bridge-native.log` |
| `make build/tests/test_asset_reserve` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_asset_reserve.log` |
| `make build/tests/test_escrow_open` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_escrow_open.log` |
| `make build/tests/test_escrow_capture` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_escrow_capture.log` |
| `make build/tests/test_escrow_timeout` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_escrow_timeout.log` |
| `make build/tests/test_escrow_invariants` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_escrow_invariants.log` |
| `make build/tests/test_budget_create` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_budget_create.log` |
| `make build/tests/test_budget_period` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_budget_period.log` |
| `make build/tests/test_budget_spend` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_budget_spend.log` |
| `make build/tests/test_budget_delegate` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_budget_delegate.log` |
| `make build/tests/test_budget_close` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_budget_close.log` |
| `make build/tests/test_stream_open` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_stream_open.log` |
| `make build/tests/test_stream_settle` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_stream_settle.log` |
| `make build/tests/test_service_offer` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_offer.log` |
| `git diff --check` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/diff-check.log` |
| `make build/tests/test_service_commit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_commit.log` |
| `make build/tests/test_service_attest` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_attest.log` |
| `make build/tests/test_service_deliver` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_deliver.log` |
| `make build/tests/test_service_acceptance` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_acceptance.log` |
| `make build/tests/test_service_dispute` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_service_dispute.log` |
| `make build/tests/test_oracle_intake` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_oracle_intake.log` |
| `make build/tests/test_oracle_checks` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_oracle_checks.log` |
| `make build/tests/test_oracle_root` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_oracle_root.log` |
| `make build/tests/test_oracle_halt` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_oracle_halt.log` |
| `make build/tests/test_perps_market` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_market.log` |
| `make build/tests/test_perps_book` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_book.log` |
| `make build/tests/test_perps_position` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_position.log` |
| `make build/tests/test_perps_funding` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_funding.log` |
| `make build/tests/test_perps_liquidate` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_liquidate.log` |
| `make build/tests/test_perps_insurance` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_perps_insurance.log` |
| `make build/tests/test_fees` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_fees.log` |
| `make build/tests/test_metering` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_metering.log` |
| `make build/tests/test_emergency_exit` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_emergency_exit.log` |
| `make build/tests/test_reserve_reconcile` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_reserve_reconcile.log` |
| `make build/tests/test_qual_recovery` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_qual_recovery.log` |
| `make build/tests/test_fuzz_smoke` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/repaired-test_fuzz_smoke.log` |
| `make build/tests/test_paxeer_bond` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/bond-build.log` |
| `build/tests/test_paxeer_bond` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/bond-native.log` |
| `python3 qual-logs/bridge-link/verify-scope.py` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/scope.log` |
| `timeout 600 make test-bridge-deposit` | 2 | `/root/lx-lanes/depgates/qual-logs/bridge-link/bridge-test.log` |
| `git diff --check` | 0 | `/root/lx-lanes/depgates/qual-logs/bridge-link/final-diff-check.log` |

</details>

<details>
<summary>Complete sibling audit: exact commands, exits and logs</summary>

| Command | Exit | Result | Log |
|---|---:|---|---|
| `make build/tests/lxp_test_result` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_result.log` |
| `make build/tests/lxp_test_protocol` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_protocol.log` |
| `make build/tests/lxp_test_arena` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_arena.log` |
| `make build/tests/lxp_test_harness` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_harness.log` |
| `make build/tests/lxp_test_receipts` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_receipts.log` |
| `make build/tests/test_account_id` | 2 | other-failure | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_account_id.log` |
| `make build/tests/test_receipt` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_receipt.log` |
| `make build/tests/test_asset_registry` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_asset_registry.log` |
| `make build/tests/test_asset_state` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_asset_state.log` |
| `make build/tests/test_asset_deposit` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_asset_deposit.log` |
| `make build/tests/test_asset_reserve` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_asset_reserve.log` |
| `make build/tests/test_escrow_open` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_escrow_open.log` |
| `make build/tests/test_escrow_capture` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_escrow_capture.log` |
| `make build/tests/test_escrow_timeout` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_escrow_timeout.log` |
| `make build/tests/test_escrow_invariants` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_escrow_invariants.log` |
| `make build/tests/test_budget_create` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_budget_create.log` |
| `make build/tests/test_budget_period` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_budget_period.log` |
| `make build/tests/test_budget_spend` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_budget_spend.log` |
| `make build/tests/test_budget_delegate` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_budget_delegate.log` |
| `make build/tests/test_budget_close` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_budget_close.log` |
| `make build/tests/test_stream_open` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_stream_open.log` |
| `make build/tests/test_stream_accrue` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_stream_accrue.log` |
| `make build/tests/test_stream_meter` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_stream_meter.log` |
| `make build/tests/test_stream_settle` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_stream_settle.log` |
| `make build/tests/test_service_offer` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_offer.log` |
| `make build/tests/test_service_commit` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_commit.log` |
| `make build/tests/test_service_attest` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_attest.log` |
| `make build/tests/test_service_deliver` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_deliver.log` |
| `make build/tests/test_service_acceptance` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_acceptance.log` |
| `make build/tests/test_service_dispute` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_service_dispute.log` |
| `make build/tests/test_oracle_adapter` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_adapter.log` |
| `make build/tests/test_oracle_replay_absent` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_replay_absent.log` |
| `make build/tests/test_oracle_intake` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_intake.log` |
| `make build/tests/test_oracle_checks` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_checks.log` |
| `make build/tests/test_oracle_root` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_root.log` |
| `make build/tests/test_oracle_halt` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_oracle_halt.log` |
| `make build/tests/test_perps_market` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_market.log` |
| `make build/tests/test_perps_book` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_book.log` |
| `make build/tests/test_perps_position` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_position.log` |
| `make build/tests/test_perps_funding` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_funding.log` |
| `make build/tests/test_perps_liquidate` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_liquidate.log` |
| `make build/tests/test_perps_insurance` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_perps_insurance.log` |
| `make build/tests/test_batch_header` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_batch_header.log` |
| `make build/tests/test_sequencer_sequence` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_sequencer_sequence.log` |
| `make build/tests/test_batch_time` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_batch_time.log` |
| `make build/tests/test_batch_seal` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_batch_seal.log` |
| `make build/tests/test_batch_publish` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_batch_publish.log` |
| `make build/tests/test_sequencer_recovery` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_sequencer_recovery.log` |
| `make build/tests/test_replica_ingest` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_replica_ingest.log` |
| `make build/tests/test_replica_replay` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_replica_replay.log` |
| `make build/tests/test_replica_divergence` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_replica_divergence.log` |
| `make build/tests/test_history_query` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_history_query.log` |
| `make build/tests/test_guarantor_duties` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_guarantor_duties.log` |
| `make build/tests/test_guarantor_cert` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_guarantor_cert.log` |
| `make build/tests/test_guarantor_bond` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_guarantor_bond.log` |
| `make build/tests/test_equivocation` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_equivocation.log` |
| `make build/tests/test_guarantor_disagreement` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_guarantor_disagreement.log` |
| `make build/tests/test_da_bundle` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_da_bundle.log` |
| `make build/tests/test_da_possession` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_da_possession.log` |
| `make build/tests/test_da_retrieval` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_da_retrieval.log` |
| `make build/tests/test_da_challenge` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_da_challenge.log` |
| `make build/tests/test_da_unavailable` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_da_unavailable.log` |
| `make build/tests/test_governance_params` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_governance_params.log` |
| `make build/tests/test_governance_activation` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_governance_activation.log` |
| `make build/tests/test_governance_emergency` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_governance_emergency.log` |
| `make build/tests/test_fees` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_fees.log` |
| `make build/tests/test_metering` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_metering.log` |
| `make build/tests/test_fee_replay` | 2 | other-failure | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_fee_replay.log` |
| `make build/tests/test_paxeer_custody` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_paxeer_custody.log` |
| `make build/tests/test_paxeer_bond` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_paxeer_bond.log` |
| `make build/tests/test_emergency_exit` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_emergency_exit.log` |
| `make build/tests/test_reserve_reconcile` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_reserve_reconcile.log` |
| `make build/tests/test_gateway_requirement` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_gateway_requirement.log` |
| `make build/tests/test_receipt_offline` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_receipt_offline.log` |
| `make build/tests/explorer_fixture` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-explorer_fixture.log` |
| `make build/tests/test_tools` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_tools.log` |
| `make build/tests/test_daemon_bootstrap_artifact` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_daemon_bootstrap_artifact.log` |
| `make build/tests/test_genesis_import` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_genesis_import.log` |
| `make build/tests/test_genesis_reconcile` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_genesis_reconcile.log` |
| `make build/tests/test_legacy_readonly` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_legacy_readonly.log` |
| `make build/tests/test_shadow_replay` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_shadow_replay.log` |
| `make build/tests/test_qual_recovery` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_qual_recovery.log` |
| `make build/tests/test_fuzz_smoke` | 2 | programs-link | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-test_fuzz_smoke.log` |
| `make build/tests/lxp_test_codec_primitives` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_codec_primitives.log` |
| `make build/tests/lxp_test_codec_composite` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_codec_composite.log` |
| `make build/tests/lxp_test_codec_strict` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_codec_strict.log` |
| `make build/tests/lxp_test_codec_vectors` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_codec_vectors.log` |
| `make build/tests/lxp_test_hash` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_hash.log` |
| `make build/tests/lxp_test_ed25519` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_ed25519.log` |
| `make build/tests/lxp_test_secp256k1` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_secp256k1.log` |
| `make build/tests/lxp_test_merkle` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_merkle.log` |
| `make build/tests/lxp_test_merkle_proof` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_merkle_proof.log` |
| `make build/tests/lxp_test_ct` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_ct.log` |
| `make build/tests/lxp_test_u128` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_u128.log` |
| `make build/tests/lxp_test_u256` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_u256.log` |
| `make build/tests/lxp_test_rounding` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_rounding.log` |
| `make build/tests/lxp_test_arith_property` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_arith_property.log` |
| `make build/tests/lxp_test_nofloat` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_nofloat.log` |
| `make build/tests/lxp_test_log` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_log.log` |
| `make build/tests/lxp_test_log_durability` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_log_durability.log` |
| `make build/tests/lxp_test_recovery` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_recovery.log` |
| `make build/tests/lxp_test_projection` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_projection.log` |
| `make build/tests/lxp_test_rebuild` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_rebuild.log` |
| `make build/tests/lxp_test_daemon_finality_authority` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_daemon_finality_authority.log` |
| `make build/tests/lxp_test_finality_json` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_finality_json.log` |
| `make build/tests/lxp_test_journal` | 2 | other-failure | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_journal.log` |
| `make build/tests/lxp_test_activity_codec` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_activity_codec.log` |
| `make build/tests/lxp_test_envelope` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_envelope.log` |
| `make build/tests/lxp_test_verify_pool` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_verify_pool.log` |
| `make build/tests/lxp_test_admission` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_admission.log` |
| `make build/tests/lxp_test_idempotency` | 2 | other-failure | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_idempotency.log` |
| `make build/tests/lxp_test_identity` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_identity.log` |
| `make build/tests/lxp_test_grants` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_grants.log` |
| `make build/tests/lxp_test_authority_resolve` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_authority_resolve.log` |
| `make build/tests/lxp_test_allowance` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_allowance.log` |
| `make build/tests/lxp_test_revocation` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_revocation.log` |
| `make build/tests/lxp_test_rotation` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_rotation.log` |
| `make build/tests/lxp_test_sanitizer_smoke` | 0 | clean | `/root/lx-lanes/depgates/qual-logs/bridge-link/audit-lxp_test_sanitizer_smoke.log` |

</details>

<details>
<summary>77 clean-link targets left unchanged</summary>

- `build/tests/lxp_test_result`
- `build/tests/lxp_test_protocol`
- `build/tests/lxp_test_arena`
- `build/tests/lxp_test_harness`
- `build/tests/lxp_test_receipts`
- `build/tests/test_receipt`
- `build/tests/test_stream_accrue`
- `build/tests/test_stream_meter`
- `build/tests/test_oracle_adapter`
- `build/tests/test_oracle_replay_absent`
- `build/tests/test_batch_header`
- `build/tests/test_sequencer_sequence`
- `build/tests/test_batch_time`
- `build/tests/test_batch_seal`
- `build/tests/test_batch_publish`
- `build/tests/test_sequencer_recovery`
- `build/tests/test_replica_ingest`
- `build/tests/test_replica_replay`
- `build/tests/test_replica_divergence`
- `build/tests/test_history_query`
- `build/tests/test_guarantor_duties`
- `build/tests/test_guarantor_cert`
- `build/tests/test_guarantor_bond`
- `build/tests/test_equivocation`
- `build/tests/test_guarantor_disagreement`
- `build/tests/test_da_bundle`
- `build/tests/test_da_possession`
- `build/tests/test_da_retrieval`
- `build/tests/test_da_challenge`
- `build/tests/test_da_unavailable`
- `build/tests/test_governance_params`
- `build/tests/test_governance_activation`
- `build/tests/test_governance_emergency`
- `build/tests/test_paxeer_custody`
- `build/tests/test_paxeer_bond`
- `build/tests/test_gateway_requirement`
- `build/tests/test_receipt_offline`
- `build/tests/explorer_fixture`
- `build/tests/test_tools`
- `build/tests/test_daemon_bootstrap_artifact`
- `build/tests/test_genesis_import`
- `build/tests/test_genesis_reconcile`
- `build/tests/test_legacy_readonly`
- `build/tests/test_shadow_replay`
- `build/tests/lxp_test_codec_primitives`
- `build/tests/lxp_test_codec_composite`
- `build/tests/lxp_test_codec_strict`
- `build/tests/lxp_test_codec_vectors`
- `build/tests/lxp_test_hash`
- `build/tests/lxp_test_ed25519`
- `build/tests/lxp_test_secp256k1`
- `build/tests/lxp_test_merkle`
- `build/tests/lxp_test_merkle_proof`
- `build/tests/lxp_test_ct`
- `build/tests/lxp_test_u128`
- `build/tests/lxp_test_u256`
- `build/tests/lxp_test_rounding`
- `build/tests/lxp_test_arith_property`
- `build/tests/lxp_test_nofloat`
- `build/tests/lxp_test_log`
- `build/tests/lxp_test_log_durability`
- `build/tests/lxp_test_recovery`
- `build/tests/lxp_test_projection`
- `build/tests/lxp_test_rebuild`
- `build/tests/lxp_test_daemon_finality_authority`
- `build/tests/lxp_test_finality_json`
- `build/tests/lxp_test_activity_codec`
- `build/tests/lxp_test_envelope`
- `build/tests/lxp_test_verify_pool`
- `build/tests/lxp_test_admission`
- `build/tests/lxp_test_identity`
- `build/tests/lxp_test_grants`
- `build/tests/lxp_test_authority_resolve`
- `build/tests/lxp_test_allowance`
- `build/tests/lxp_test_revocation`
- `build/tests/lxp_test_rotation`
- `build/tests/lxp_test_sanitizer_smoke`

</details>

Repository tooling limits: `cg brief` exited 1 because this worktree has no Codify graph; `cortex_guard` exited 127 because the command is unavailable. The direct user-authorized lane scope and explicit staged-path review were used.

🤖 Generated with Codex
