### PR TITLE
Derive native binding mismatch values from the fixture

### DIFF
--- a/agent/sdk/python/tests/test_native_program_binding.py
+++ b/agent/sdk/python/tests/test_native_program_binding.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 import json
 from pathlib import Path
 import unittest
-from layerx_sdk.native_program_call import decode_native_program_call
+from layerx_sdk.native_program_call import decode_native_program_call, encode_native_program_call
 from layerx_sdk.programs import NativeProgramRequest, _wire
 from layerx_sdk.program_wire import decode_signed_program_call
 
@@ -14,8 +14,25 @@ class NativeProgramBindingTest(unittest.TestCase):
         request = NativeProgramRequest(native, 1000, bytes.fromhex(fixture["signed_activity_hex"]))
         self.assertEqual(decode_signed_program_call(request).activity_id, fixture["activity_id_hex"])
         self.assertEqual(_wire(request)["payload_encoding"], "native-v1")
-        for field, value in {"program_id": bytes([0x22]) * 32, "guest_abi": 2, "entrypoint": "other", "calldata": b"1", "capabilities": b"\0\1", "access_declaration": b"other", "response_capacity": 17, "resources": (999,) + native.resources[1:]}.items():
-            with self.subTest(field=field), self.assertRaises(ValueError):
-                decode_signed_program_call(replace(request, native_call=replace(native, **{field: value})))
+        program_id = bytearray(native.program_id)
+        index = next(i for i, value in enumerate(program_id) if value)
+        program_id[index] = 1 if program_id[index] != 1 else 2
+        mutate_bytes = lambda value: bytes([value[0] ^ 1]) + value[1:] if value else b"\1"
+        for field, value in {
+            "program_id": bytes(program_id),
+            "guest_abi": 2 if native.guest_abi == 1 else 1,
+            "entrypoint": ("a" if native.entrypoint[0] != "a" else "b") + native.entrypoint[1:],
+            "calldata": mutate_bytes(native.calldata),
+            "capabilities": mutate_bytes(native.capabilities),
+            "access_declaration": mutate_bytes(native.access_declaration),
+            "response_capacity": (native.response_capacity + 1) % 1_048_577,
+            "resources": (native.resources[0] ^ 1,) + native.resources[1:],
+        }.items():
+            with self.subTest(field=field):
+                self.assertNotEqual(value, getattr(native, field))
+                changed = replace(native, **{field: value})
+                encode_native_program_call(changed)
+                with self.assertRaises(ValueError):
+                    decode_signed_program_call(replace(request, native_call=changed))
         with self.assertRaises(ValueError):
-            decode_signed_program_call(replace(request, fee_limit=999))
+            decode_signed_program_call(replace(request, fee_limit=request.fee_limit - 1))

--- a/agent/sdk/typescript/test/receipt-fixture.test.ts
+++ b/agent/sdk/typescript/test/receipt-fixture.test.ts
@@ -210,16 +210,35 @@ const { decodeSignedProgramCall } = await import("../src/program-wire.js");
 const nativeModel = decodeNativeProgramCall(hexBytes(nativeFixture.payload_hex));
 const nativeRequest = new NativeProgramRequest(nativeModel, 1000n, hexBytes(nativeFixture.signed_activity_hex));
 assert((await decodeSignedProgramCall(nativeRequest)).activityId === nativeFixture.activity_id_hex, "native signed binding");
-for (const changed of [
-  { ...nativeModel, programId: new Uint8Array(32).fill(0x22) }, { ...nativeModel, guestAbi: 2 as const },
-  { ...nativeModel, entrypoint: "other" }, { ...nativeModel, calldata: new Uint8Array([1]) },
-  { ...nativeModel, capabilities: new Uint8Array([0, 1]) }, { ...nativeModel, accessDeclaration: new Uint8Array([1]) },
-  { ...nativeModel, responseCapacity: 17 }, { ...nativeModel, resources: [999n, ...nativeModel.resources.slice(1)] as unknown as typeof nativeModel.resources },
-]) {
+const changedProgramId = nativeModel.programId.slice();
+const nonzeroIndex = changedProgramId.findIndex(value => value !== 0);
+changedProgramId[nonzeroIndex] = changedProgramId[nonzeroIndex] === 1 ? 2 : 1;
+const mutateBytes = (value: Uint8Array): Uint8Array => {
+  const changed = value.length ? value.slice() : new Uint8Array(1);
+  changed[0] = (changed[0] ?? 0) ^ 1;
+  return changed;
+};
+const mismatches: { [K in keyof typeof nativeModel]: [K, (typeof nativeModel)[K]] }[keyof typeof nativeModel][] = [
+  ["programId", changedProgramId], ["guestAbi", nativeModel.guestAbi === 1 ? 2 : 1],
+  ["entrypoint", (nativeModel.entrypoint[0] === "a" ? "b" : "a") + nativeModel.entrypoint.slice(1)],
+  ["calldata", mutateBytes(nativeModel.calldata)], ["capabilities", mutateBytes(nativeModel.capabilities)],
+  ["accessDeclaration", mutateBytes(nativeModel.accessDeclaration)],
+  ["responseCapacity", (nativeModel.responseCapacity + 1) % 1_048_577],
+  ["resources", [nativeModel.resources[0] ^ 1n, nativeModel.resources[1], nativeModel.resources[2], nativeModel.resources[3], nativeModel.resources[4], nativeModel.resources[5], nativeModel.resources[6]]],
+];
+for (const [field, value] of mismatches) {
+  const original = nativeModel[field];
+  assert(value instanceof Uint8Array && original instanceof Uint8Array
+    ? value.length !== original.length || value.some((byte, index) => byte !== original[index])
+    : Array.isArray(value) && Array.isArray(original)
+      ? value.some((item, index) => item !== original[index]) : value !== original,
+  `native ${field} mutation is unchanged`);
+  const changed = { ...nativeModel, [field]: value };
+  encodeNativeProgramCall(changed);
   let rejected = false;
   try { await decodeSignedProgramCall(new NativeProgramRequest(changed, 1000n, nativeRequest.signedActivity)); } catch { rejected = true; }
   assert(rejected, "mismatched native field accepted");
 }
 let rejectedNativeFee = false;
-try { await decodeSignedProgramCall(new NativeProgramRequest(nativeModel, 999n, nativeRequest.signedActivity)); } catch { rejectedNativeFee = true; }
+try { await decodeSignedProgramCall(new NativeProgramRequest(nativeModel, nativeRequest.budget.feeLimit - 1n, nativeRequest.signedActivity)); } catch { rejectedNativeFee = true; }
 assert(rejectedNativeFee, "native envelope fee mismatch accepted");

--- a/platform/sdk/dotnet/tests/LayerX.Sdk.Tests/ReceiptFixtureTests.cs
+++ b/platform/sdk/dotnet/tests/LayerX.Sdk.Tests/ReceiptFixtureTests.cs
@@ -112,7 +112,10 @@ public sealed class ReceiptFixtureTests
         var method = typeof(ProgramsClient).GetMethod("DecodeSignedCall", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
         method.Invoke(null, new object[] { new ProgramCall(nativeCall, new ProtocolAmount("1000"), signed) });
         Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(null, new object[] { new ProgramCall(nativeCall, new ProtocolAmount("999"), signed) }));
-        Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(null, new object[] { new ProgramCall(nativeCall with { ResponseCapacity = 17 }, new ProtocolAmount("1000"), signed) }));
+        var changed = nativeCall with { ResponseCapacity = (nativeCall.ResponseCapacity + 1) % 1_048_577 };
+        Assert.NotEqual(nativeCall.ResponseCapacity, changed.ResponseCapacity);
+        changed.Encode();
+        Assert.Throws<System.Reflection.TargetInvocationException>(() => method.Invoke(null, new object[] { new ProgramCall(changed, new ProtocolAmount("1000"), signed) }));
         for (var length = 0; length < payload.Length; length++) Assert.Throws<ArgumentException>(() => NativeProgramCall.Decode(payload[..length]));
     }
 

--- a/platform/sdk/jvm/src/test/java/com/sidiora/layerx/sdk/ReceiptFixtureTest.java
+++ b/platform/sdk/jvm/src/test/java/com/sidiora/layerx/sdk/ReceiptFixtureTest.java
@@ -59,7 +59,9 @@ public final class ReceiptFixtureTest {
         method.setAccessible(true);
         method.invoke(null, new ProgramsClient.Call(nativeCall, BigInteger.valueOf(1000), signed));
         assertThrows(java.lang.reflect.InvocationTargetException.class, () -> method.invoke(null, new ProgramsClient.Call(nativeCall, BigInteger.valueOf(999), signed)));
-        NativeProgramCall changed = new NativeProgramCall(nativeCall.programId(), nativeCall.guestAbi(), nativeCall.entrypoint(), nativeCall.calldata(), nativeCall.capabilities(), nativeCall.accessDeclaration(), 17, nativeCall.resources());
+        NativeProgramCall changed = new NativeProgramCall(nativeCall.programId(), nativeCall.guestAbi(), nativeCall.entrypoint(), nativeCall.calldata(), nativeCall.capabilities(), nativeCall.accessDeclaration(), (nativeCall.responseCapacity() + 1) % 1_048_577, nativeCall.resources());
+        assertNotEquals(nativeCall.responseCapacity(), changed.responseCapacity());
+        changed.encode();
         assertThrows(java.lang.reflect.InvocationTargetException.class, () -> method.invoke(null, new ProgramsClient.Call(changed, BigInteger.valueOf(1000), signed)));
         for (int length = 0; length < payload.length; length++) {
             byte[] truncated = java.util.Arrays.copyOf(payload, length);

--- a/platform/sdk/swift/Tests/LayerXSDKTests/ReceiptFixtureTests.swift
+++ b/platform/sdk/swift/Tests/LayerXSDKTests/ReceiptFixtureTests.swift
@@ -137,7 +137,9 @@ final class ReceiptFixtureTests: XCTestCase {
         XCTAssertEqual(try decodeSignedCall(call).activityID, try hexField(fixture, "activity_id_hex"))
         let wrongFee = try ProgramCall(nativeCall: native, feeLimit: ProtocolAmount("999"), signedActivity: signed)
         XCTAssertThrowsError(try decodeSignedCall(wrongFee))
-        let changed = NativeProgramCall(programID: native.programID, guestABI: native.guestABI, entrypoint: native.entrypoint, calldata: native.calldata, capabilities: native.capabilities, accessDeclaration: native.accessDeclaration, responseCapacity: 17, resources: native.resources)
+        let changed = NativeProgramCall(programID: native.programID, guestABI: native.guestABI, entrypoint: native.entrypoint, calldata: native.calldata, capabilities: native.capabilities, accessDeclaration: native.accessDeclaration, responseCapacity: (native.responseCapacity + 1) % 1_048_577, resources: native.resources)
+        XCTAssertNotEqual(native.responseCapacity, changed.responseCapacity)
+        _ = try changed.encode()
         XCTAssertThrowsError(try decodeSignedCall(ProgramCall(nativeCall: changed, feeLimit: ProtocolAmount("1000"), signedActivity: signed)))
         for length in 0..<payload.count { XCTAssertThrowsError(try NativeProgramCall.decode(payload.prefix(length))) }
     }

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -2022,3 +2022,27 @@ symbol = "programs-check-executed-fixture programs-abi-drift"
 observed = "Passing fixture and ABI gates emit private-interface, unused-import, unused-variable and dead-code warnings from existing Programs runtime, sandbox and porting sources. Exact diagnostics are retained in qual-logs/pass6-final-executed-fixture.log and qual-logs/pass6-final-abi-drift.log."
 assumption = "These sources are outside SDK ownership and were not modified. No warning or assertion was disabled."
 severity = "note"
+
+[observation.6.11.native-binding-fixture-derived-mismatches]
+task = "6.11"
+file = "agent/sdk/python/tests/test_native_program_binding.py agent/sdk/typescript/test/receipt-fixture.test.ts platform/sdk/jvm/src/test/java/com/sidiora/layerx/sdk/ReceiptFixtureTest.java platform/sdk/swift/Tests/LayerXSDKTests/ReceiptFixtureTests.swift platform/sdk/dotnet/tests/LayerX.Sdk.Tests/ReceiptFixtureTests.cs"
+symbol = "test_real_signed_native_binding_and_mismatches nativeSignedBinding testNativeSignedBinding"
+observed = "Every native-field mutation in Python and TypeScript derives from the decoded fixture; ABI swaps between supported values 1 and 2. Each mutation is asserted different and encoded successfully before signed-binding refusal. JVM, Swift and dotnet capacity mutations derive from decoded capacity within its bound and assert inequality. With branch ABI-1 fixtures, make agent-test-sdk-py, make agent-test-sdk-ts, sh platform/sdk/conformance/run-jvm.sh /root/lx-lanes/terminal, swift test --disable-automatic-resolution --package-path platform/sdk/swift -j 4, and dotnet test platform/sdk/dotnet/tests/LayerX.Sdk.Tests/LayerX.Sdk.Tests.csproj --no-restore --nologo exit 0 in qual-logs/binding-branch-py.log, qual-logs/binding-branch-ts.log, qual-logs/binding-branch-jvm.log, qual-logs/binding-branch-swift.log and qual-logs/binding-branch-dotnet.log. Python has 34 tests, JVM 33, Swift 16 and dotnet 17. git diff --check exits 0 in qual-logs/binding-diff-check.log."
+assumption = "CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 are exported. Go already derives its negative capacity by incrementing the fixture value and is unchanged. No SDK sources or tracked fixtures change. The local Codify graph is absent; cg brief, cg survey and cg context report not inside a Codify project. No graph gate or task completion is claimed."
+severity = "note"
+
+[observation.6.11.native-binding-abi2-scratch]
+task = "6.11"
+file = "platform/sdk/conformance/fixtures/native-program-call-v3.json platform/sdk/conformance/fixtures/receipt-programs-executed-v3.json"
+symbol = "decode_signed_program_call decodeSignedProgramCall nativeSignedBinding testNativeSignedBinding"
+observed = "Untracked qual-logs/binding-abi2-scratch contains copied SDK code and captured ABI-2 native-call and executed-receipt fixtures from /root/lx-lanes/native/platform/sdk/conformance/fixtures. Python native-binding unittest and TypeScript receipt-fixture suite exit 0 in qual-logs/binding-abi2-scratch-py-focused.log and qual-logs/binding-abi2-scratch-ts-focused.log. Full JVM, Swift and dotnet suites exit 0 in qual-logs/binding-abi2-scratch-jvm-final.log, qual-logs/binding-abi2-swift.log and qual-logs/binding-abi2-dotnet.log. Full Python and TypeScript suites with only the native-call fixture replaced by the captured ABI-2 fixture also exit 0 in qual-logs/binding-abi2-binding-only-py.log and qual-logs/binding-abi2-binding-only-ts.log. All eight Python and TypeScript native-field refusal cases are retained and execute with both ABIs."
+assumption = "The scratch copies are untracked. Initial scratch Python and JVM failures came from omitted FastAPI signature-verifier and schema/codec input files; the complete existing tracked dependencies were copied and suites rerun. Exact commands and scratch working directories are listed in the PR command table."
+severity = "note"
+
+[observation.6.11.executed-fixture-missing-execution-document]
+task = "6.11"
+file = "platform/sdk/conformance/fixtures/receipt-programs-executed-v3.json agent/sdk/python/tests/test_program_executed_v3.py agent/sdk/typescript/test/program-executed-v3.test.ts"
+symbol = "test_actual_kernel_runtime_receipt_and_module_binding parseProgramExecutionDocument"
+observed = "The captured external ABI-2 executed-receipt fixture lacks execution_document. Full Python tests exit 1 with KeyError execution_document in qual-logs/binding-abi2-py-complete-scratch.log. Full TypeScript tests exit 1 reading document.usage in qual-logs/binding-abi2-ts.log. The native-binding refusal tests pass on that same scratch tree. The exact captured producer fixture remains at qual-logs/binding-abi2-scratch/platform/sdk/conformance/fixtures/receipt-programs-executed-v3.json."
+assumption = "The fixture producer must emit the complete execution_document required by the existing SDK execution tests. Producer and execution tests are outside native-binding test ownership. Assertions and fixtures were not weakened or edited to hide this independent failure. Full qualification against the captured executed-receipt fixture remains blocked."
+severity = "blocker"


### PR DESCRIPTION
Native-binding negative tests could become no-ops when the signed fixture changed from guest ABI 1 to ABI 2. Python and TypeScript now derive all eight native-field mutations from the fixture, assert that each differs, and confirm it encodes before requiring binding refusal. JVM, Swift and .NET capacity mutations also derive from the fixture within its allowed range. Go already derives its capacity mutation and is unchanged.

The scoped binding fix passes with both ABIs. Full Python and TypeScript suites pass with branch fixtures and with only the captured ABI-2 native-call fixture substituted. JVM (33), Swift (16), and .NET (17) tests pass with branch fixtures and both captured ABI-2 fixtures. Python runs all 34 tests on the passing full-suite runs. All original assertions remain.

**Independent blocker:** the captured `receipt-programs-executed-v3.json` from `/root/lx-lanes/native/platform/sdk/conformance/fixtures/` lacks `execution_document`. Full Python and TypeScript suites with this executed fixture fail in the existing execution-document tests. Native-binding tests pass in that same tree. Producer repair is requested in untracked `NEEDS.md`; the observation and exact failing logs are recorded in qualification.kvx. No fixture bytes or SDK source were changed in this item.

The first scratch Python/JVM attempts also exposed missing scratch FastAPI/schema/codec dependencies. Existing tracked dependencies were copied, then the full suites rerun; the remaining Python failure is the missing execution_document. Scratch inputs and outputs remain untracked.

The branch is based on `origin/lane/terminal` at `dc275fbf` and was rebased on `origin/main` (`84499b80`, no change). PR #99 was still open at that check, so this branch currently includes its predecessor commits; this item is commit `041b8b7a`. Base is main. No PR was merged.

Every test command exports `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`. Existing locked TypeScript dependencies were already installed (`node_modules/.bin/tsc` was present), so npm ci was not needed. Branch Make targets include the SDK generator tests and drift check; scratch runs invoke the full SDK suites directly. No aggregate platform-verify-sdks or runtime deployment gate is claimed. The local Codify graph is absent; its read-only queries reported that condition. `cortex_guard` was unavailable on PATH; no guard run is claimed.

| Working directory | Exact command | Exit | Log (untracked) |
| --- | --- | --- | --- |
| `/root/lx-lanes/terminal` | `make agent-test-sdk-py` | 0 | `qual-logs/binding-branch-py.log` |
| `/root/lx-lanes/terminal` | `make agent-test-sdk-ts` | 0 | `qual-logs/binding-branch-ts.log` |
| `/root/lx-lanes/terminal` | `sh platform/sdk/conformance/run-jvm.sh /root/lx-lanes/terminal` | 0 | `qual-logs/binding-branch-jvm.log` |
| `/root/lx-lanes/terminal` | `swift test --disable-automatic-resolution --package-path platform/sdk/swift -j 4` | 0 | `qual-logs/binding-branch-swift.log` |
| `/root/lx-lanes/terminal` | `dotnet test platform/sdk/dotnet/tests/LayerX.Sdk.Tests/LayerX.Sdk.Tests.csproj --no-restore --nologo` | 0 | `qual-logs/binding-branch-dotnet.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `PYTHONPATH=agent/sdk/python python3 -m unittest discover -s agent/sdk/python/tests -p 'test_*.py'` | 1 | `qual-logs/binding-abi2-py.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `PYTHONPATH=agent/sdk/python python3 -m unittest discover -s agent/sdk/python/tests -p 'test_*.py'` | 1 | `qual-logs/binding-abi2-py-complete-scratch.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `npm --prefix agent/sdk/typescript test` | 1 | `qual-logs/binding-abi2-ts.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `mvn -o -q -f platform/sdk/jvm/pom.xml -Dlayerx.repo.root=/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch test` | 1 | `qual-logs/binding-abi2-jvm.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `mvn -o -q -f platform/sdk/jvm/pom.xml -Dlayerx.repo.root=/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch test` | 0 | `qual-logs/binding-abi2-scratch-jvm-final.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `swift test --disable-automatic-resolution --package-path platform/sdk/swift -j 4` | 0 | `qual-logs/binding-abi2-swift.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `dotnet test platform/sdk/dotnet/tests/LayerX.Sdk.Tests/LayerX.Sdk.Tests.csproj --nologo` | 0 | `qual-logs/binding-abi2-dotnet.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `PYTHONPATH=agent/sdk/python python3 -m unittest discover -s agent/sdk/python/tests -p test_native_program_binding.py` | 0 | `qual-logs/binding-abi2-scratch-py-focused.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-scratch` | `node agent/sdk/typescript/dist/test/receipt-fixture.test.js` | 0 | `qual-logs/binding-abi2-scratch-ts-focused.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-binding-only` | `PYTHONPATH=agent/sdk/python python3 -m unittest discover -s agent/sdk/python/tests -p 'test_*.py'` | 0 | `qual-logs/binding-abi2-binding-only-py.log` |
| `/root/lx-lanes/terminal/qual-logs/binding-abi2-binding-only` | `npm --prefix agent/sdk/typescript test` | 0 | `qual-logs/binding-abi2-binding-only-ts.log` |
| `/root/lx-lanes/terminal` | `git diff --check` | 0 | `qual-logs/binding-diff-check.log` |
| `/root/lx-lanes/terminal` | `git diff --check` | 0 | `qual-logs/binding-final-diff-check.log` |

🤖 Generated with Codex
