### PR TITLE
Converge getrandom and windows-sys across the platform and interop workspaces

### DIFF
--- a/interop/Cargo.lock
+++ b/interop/Cargo.lock
@@ -435,25 +435,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
 ]
 
 [[package]]
@@ -803,7 +791,7 @@ dependencies = [
 name = "layerx-platform-gateway"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-crypto",
  "layerx-proof",
  "layerx-types",
@@ -1167,12 +1155,6 @@ checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1590,15 +1572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-instrument"
 version = "0.4.0"
 dependencies = [
@@ -1730,12 +1703,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -1327,7 +1327,7 @@ name = "layerx-platform-agent-boundary"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-client",
  "layerx-programs-runtime",
  "layerx-proof",
@@ -1347,7 +1347,7 @@ name = "layerx-platform-authority"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-client",
  "layerx-proof",
  "layerx-types",
@@ -1367,7 +1367,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "keyring",
  "keyring-core",
  "layerx-crypto",
@@ -1458,7 +1458,7 @@ name = "layerx-platform-gateway"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-crypto",
  "layerx-proof",
  "layerx-types",
@@ -1476,7 +1476,7 @@ dependencies = [
 name = "layerx-platform-identity"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "native-tls",
  "rustls",
  "serde",
@@ -1491,7 +1491,7 @@ name = "layerx-platform-internal"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-wire",
  "native-tls",
  "ring",
@@ -1577,7 +1577,7 @@ name = "layerx-platform-webhooks"
 version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "layerx-platform-gateway",
  "layerx-wire",
  "native-tls",

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -32,7 +32,7 @@ license = "LicenseRef-Centra-ai-Protocol"
 [workspace.dependencies]
 clap = { version = "=4.6.6", features = ["derive"] }
 ed25519-dalek = "=2.2.0"
-getrandom = "=0.3.4"
+getrandom = "=0.4.3"
 keyring = "=4.1.6"
 keyring-core = "=1.0.0"
 native-tls = "=0.2.15"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -2093,3 +2093,27 @@ symbol = "interop-build interop-test interop-lint"
 observed = "cargo build --locked --manifest-path interop/Cargo.toml --workspace, cargo test --locked --manifest-path interop/Cargo.toml --workspace, cargo clippy --locked --manifest-path interop/Cargo.toml --workspace --all-targets -- -D warnings, make interop-build and make interop-test each exit 0. Each workspace test run passes 231 tests with six pre-existing protected-testnet tests ignored. make interop-lint exits 2 at cargo-deny with the same four duplicate groups and paste advisory; Clippy and dependency/unsafe policy pass. git diff --check exits 0. Exact commands, exits and individual log paths are recorded in qual-logs/au13/gates.jsonl."
 assumption = "CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 and LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin are exported. These gates describe unchanged dependency/source inputs at f1c60a5d; they do not establish dependency convergence or external testnet qualification. Only blocker observations are appended. No task status is changed."
 severity = "blocker"
+
+[observation.6.4.gateway-getrandom-convergence]
+task = "6.4"
+file = "platform/Cargo.toml platform/Cargo.lock platform/hosted/gateway/src/lib.rs interop/Cargo.lock"
+symbol = "IssuedKey::generate"
+observed = "The platform workspace getrandom pin is 0.4.3. Its seven inheriting consumers resolve to the existing 0.4.3 package in platform/Cargo.lock. The gateway retains getrandom::fill on the identical buffer and the same GatewayError::Entropy mapping because the 0.4.3 API supports that call unchanged. Interop removes getrandom 0.3.4, r-efi 5.3.0 and their now-unused wasip2 and wit-bindgen dependencies. Locked gateway build and all 18 gateway tests exit 0. Locked interop workspace build, 231 tests and strict all-target Clippy exit 0; six existing protected-testnet tests remain ignored. Exact commands and exits are in qual-logs/au14/results.jsonl; outputs are gateway-build.log, gateway-test.log, interop-build.log, interop-test.log and interop-clippy.log in that directory. git diff --check exits 0."
+assumption = "The initial targeted platform getrandom update refused the independent layerx-agentd exact 0.3.4 pin; updating the gateway package resolution offline changed only inherited workspace dependency edges. Agent source and pins remain unchanged. No Rust source, entropy behavior, assertion, dependency policy or task status changes. CARGO_BUILD_JOBS=4 and MAKEFLAGS=-j4 are exported; LAYERX_TEST_NATIVE_BIN_DIR points to /root/lx-lanes/native-bin. Full lint qualification remains blocked by the separately recorded source and dependency refusals."
+severity = "note"
+
+[observation.6.4.gateway-getrandom-lint-baseline]
+task = "6.4"
+file = "platform/hosted/gateway/src/http.rs platform/hosted/gateway/src/lib.rs"
+symbol = "platform-lint"
+observed = "Strict gateway all-target Clippy exits 101 with 14 diagnostics in unchanged source: http.rs missing_errors_doc at lines 21, 78, 102, 127, 231 and 339; must_use_candidate at 74; too_many_arguments at 78 and 102; type_complexity at 278; lib.rs unused_self at 491, too_many_arguments at 565 and 613 and needless_pass_by_value at 648. The same command with the unchanged base platform manifest and lockfile also exits 101 with the same 14 diagnostic messages. make platform-lint exits 2 at its workspace Clippy step; later platform lint steps do not execute. Evidence: qual-logs/au14/gateway-clippy.log, baseline-gateway-clippy.log, baseline-comparison.log and platform-lint.log."
+assumption = "These source locations are outside the authorized entropy-call edit. No diagnostics were suppressed or source signatures changed. No passing platform lint gate is claimed."
+severity = "blocker"
+
+[observation.6.4.interop-ring-convergence-boundary]
+task = "6.4"
+file = "interop/Cargo.toml interop/Cargo.lock platform/Cargo.toml agent/crates/layerx-client/Cargo.toml agent/crates/layerx-agentd/Cargo.toml"
+symbol = "interop-lint"
+observed = "make interop-lint passes strict workspace Clippy and dependency/unsafe policy, then exits 2 after cargo-deny exits 3. Exact refusals remain der 0.7.10/0.8.1, getrandom 0.2.17/0.4.3, windows-sys 0.52.0/0.61.2, and unmaintained paste 1.0.15 RUSTSEC-2024-0436. The r-efi duplicate refusal is gone. cargo tree -i windows-sys@0.52.0 on the host prints no dependents; --target all shows ring 0.17.14 as its only direct dependent, through rustls and rustls-webpki. The fetched sparse registry index ends at ring 0.17.14, requiring windows-sys ^0.52 and getrandom ^0.2.10. Crypto rand_core also requires getrandom 0.2.17. Raw evidence: qual-logs/au14/interop-lint.log, windows-tree.log, windows-all-tree.log, ring-index.jsonl and getrandom-old-tree.log."
+assumption = "There is no available direct dependency version bump that removes the ring windows-sys branch. A compatible upstream release or separately authorized coordinated cryptographic-provider migration is required. Platform additionally retains getrandom 0.3.4 through the independent layerx-agentd exact pin. Full getrandom and windows-sys convergence is not established. Curve and interpreter dependency migrations remain outside this change; deny.toml and all checks remain intact."
+severity = "blocker"


### PR DESCRIPTION
The platform getrandom pin moves to 0.4.3 with the existing fill call and GatewayError::Entropy mapping unchanged. Both workspace lockfiles reflect the inherited dependency update; interop drops getrandom 0.3.4, r-efi 5.3.0, wasip2 and wit-bindgen.

This is a partial checkpoint. No windows-sys bump is available: its only old-version dependent is ring 0.17.14, the newest published ring release, which requires windows-sys ^0.52. Full getrandom convergence also remains blocked by ring and crypto using 0.2.17. No cryptographic-provider, curve, interpreter or deny-policy change is included.

Gateway build and 18 tests pass. Interop build, 231 tests and strict Clippy pass; six existing protected-testnet cases remain ignored. Gateway Clippy fails with the same 14 diagnostics on both base and updated dependencies. make platform-lint stops at those diagnostics. make interop-lint passes Clippy and dependency/unsafe policy, then cargo-deny exits 3 for der 0.7.10/0.8.1, getrandom 0.2.17/0.4.3, windows-sys 0.52.0/0.61.2 and paste 1.0.15 (RUSTSEC-2024-0436); Make exits 2. The r-efi duplicate refusal is removed.

Commands ran from /root/lx-lanes/authority with CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin. Logs are untracked files in this worktree.

| Item | Exact command | Exit | Log |
|---|---|---:|---|
| getrandom / shared qualification | `cargo build --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway` | 0 | `/root/lx-lanes/authority/qual-logs/au14/gateway-build.log` |
| getrandom / shared qualification | `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway` | 0 | `/root/lx-lanes/authority/qual-logs/au14/gateway-test.log` |
| getrandom / shared qualification | `cargo clippy --offline --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway --all-targets -- -D warnings` | 101 | `/root/lx-lanes/authority/qual-logs/au14/gateway-clippy.log` |
| getrandom / shared qualification | `make platform-lint` | 2 | `/root/lx-lanes/authority/qual-logs/au14/platform-lint.log` |
| getrandom / shared qualification | `cargo build --locked --manifest-path interop/Cargo.toml --workspace` | 0 | `/root/lx-lanes/authority/qual-logs/au14/interop-build.log` |
| getrandom / shared qualification | `cargo test --locked --manifest-path interop/Cargo.toml --workspace` | 0 | `/root/lx-lanes/authority/qual-logs/au14/interop-test.log` |
| getrandom / shared qualification | `cargo clippy --locked --manifest-path interop/Cargo.toml --workspace --all-targets -- -D warnings` | 0 | `/root/lx-lanes/authority/qual-logs/au14/interop-clippy.log` |
| getrandom / shared qualification | `make interop-lint` | 2 | `/root/lx-lanes/authority/qual-logs/au14/interop-lint.log` |
| getrandom / shared qualification | `git diff --check` | 0 | `/root/lx-lanes/authority/qual-logs/au14/diff-check.log` |
| getrandom / shared qualification | `cargo clippy --offline --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway --all-targets -- -D warnings (base manifests from HEAD)` | 101 | `/root/lx-lanes/authority/qual-logs/au14/baseline-gateway-clippy.log` |
| publication | `git diff --check` | 0 | `/root/lx-lanes/authority/qual-logs/au14/post-rebase-diff-check.log` |

Windows-sys investigation: `cargo tree -i windows-sys@0.52.0 --manifest-path interop/Cargo.toml` exits 0 and reports nothing for the host (`qual-logs/au14/windows-tree.log`). `cargo tree --locked --target all -i windows-sys@0.52.0 --manifest-path interop/Cargo.toml` exits 0 and identifies ring (`qual-logs/au14/windows-all-tree.log`). Published registry evidence is `qual-logs/au14/ring-index.jsonl`; remaining getrandom and r-efi trees are in `getrandom-old-tree.log`, `getrandom-new-tree.log` and `r-efi-tree.log` in the same directory.

Rebased on origin/main; incoming changes were documentation and appended qualification observations only. Build/test inputs are unchanged across rebase. Both sets of observations are preserved. No task status is changed and no merge is requested.

🤖 Generated with Codex
