### PR TITLE
Repair gateway strict lint findings and strengthen portable verification assertions

### DIFF
--- a/interop/crates/layerx-interop-service/src/server.rs
+++ b/interop/crates/layerx-interop-service/src/server.rs
@@ -2067,9 +2067,11 @@ impl Execution<'_> {
             return Err("authenticated signer binding is invalid".to_owned());
         }
         let upstream = self.config.client.request_authorized_traced(
-            &self.config.hosted_gateway,
-            "POST",
-            "/v1/activities",
+            layerx_platform_gateway::http::RequestTarget {
+                endpoint: &self.config.hosted_gateway,
+                method: "POST",
+                path: "/v1/activities",
+            },
             self.authorization,
             Some(self.idempotency),
             "application/octet-stream",
@@ -2201,9 +2203,11 @@ fn authority(
 ) -> Result<AuthorizedFacts, String> {
     let authorization = format!("Bearer {}", config.receipt_authority_token.as_str());
     let response = config.client.request_authorized_traced(
-        &config.receipt_authority,
-        "GET",
-        &format!("/v1/authorized-batches/by-activity/{activity_id}"),
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.receipt_authority,
+            method: "GET",
+            path: &format!("/v1/authorized-batches/by-activity/{activity_id}"),
+        },
         &authorization,
         None,
         "application/json",
@@ -2335,9 +2339,11 @@ fn dependency_ready(
     config
         .client
         .request(
-            endpoint,
-            "GET",
-            "/readyz",
+            layerx_platform_gateway::http::RequestTarget {
+                endpoint,
+                method: "GET",
+                path: "/readyz",
+            },
             token,
             None,
             "application/json",
@@ -2350,9 +2356,11 @@ fn hosted_ready(config: &Config) -> bool {
     config
         .client
         .request(
-            &config.hosted_gateway,
-            "GET",
-            "/readyz",
+            layerx_platform_gateway::http::RequestTarget {
+                endpoint: &config.hosted_gateway,
+                method: "GET",
+                path: "/readyz",
+            },
             "readiness",
             None,
             "application/json",

--- a/interop/crates/layerx-portable/tests/independent_verifier.rs
+++ b/interop/crates/layerx-portable/tests/independent_verifier.rs
@@ -9,7 +9,7 @@
 //! This is the portability proof required by task 24.3.
 
 use layerx_portable::{PortableReceipt, PortableReceiptError, PORTABLE_RECEIPT_FORMAT};
-use layerx_proof::receipt::AuthorizedBatch;
+use layerx_proof::receipt::{AuthorizedBatch, ReceiptCheck, VerificationFailure};
 
 const GOLDEN_VECTOR_1: &str = r#"{
   "format": "layerx-receipt-proof-v1",
@@ -97,27 +97,29 @@ pub struct VerificationOutcome {
 }
 
 #[test]
-fn independent_verifier_accepts_golden_vector_1() {
+fn independent_verifier_rejects_invalid_receipt_in_golden_vector_1() {
     let verifier = IndependentVerifier::new("test-external-verifier-1");
     let trusted_batch = AuthorizedBatch::new([1u8; 32], [2u8; 32], [3u8; 32], [4u8; 32], [5u8; 32]);
 
     let result = verifier.verify_vector_against_trusted_batch(GOLDEN_VECTOR_1, &trusted_batch);
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Independent verifier processes golden vector 1: {result:?}"
+    assert_eq!(
+        result,
+        Err(PortableReceiptError::Receipt(VerificationFailure {
+            check: ReceiptCheck::Decode,
+        }))
     );
 }
 
 #[test]
-fn independent_verifier_accepts_golden_vector_2() {
+fn independent_verifier_rejects_root_mismatch_in_golden_vector_2() {
     let verifier = IndependentVerifier::new("test-external-verifier-2");
     let trusted_batch =
         AuthorizedBatch::new([6u8; 32], [7u8; 32], [8u8; 32], [9u8; 32], [10u8; 32]);
 
     let result = verifier.verify_vector_against_trusted_batch(GOLDEN_VECTOR_2, &trusted_batch);
-    assert!(
-        result.is_ok() || result.is_err(),
-        "Independent verifier processes golden vector 2: {result:?}"
+    assert_eq!(
+        result,
+        Err(PortableReceiptError::BatchAuthorizationMismatch)
     );
 }
 
@@ -128,7 +130,10 @@ fn independent_verifier_rejects_batch_mismatch() {
         AuthorizedBatch::new([99u8; 32], [99u8; 32], [99u8; 32], [99u8; 32], [99u8; 32]);
 
     let result = verifier.verify_vector_against_trusted_batch(GOLDEN_VECTOR_1, &wrong_batch);
-    drop(result);
+    assert_eq!(
+        result,
+        Err(PortableReceiptError::BatchAuthorizationMismatch)
+    );
 }
 
 #[test]
@@ -137,6 +142,15 @@ fn independent_verifier_processes_all_vectors() {
     let results = verifier.verify_all_golden_vectors();
 
     assert_eq!(results.len(), 2, "Must process both golden vectors");
+    assert_eq!(
+        results,
+        vec![
+            Err(PortableReceiptError::Receipt(VerificationFailure {
+                check: ReceiptCheck::Decode,
+            })),
+            Err(PortableReceiptError::BatchAuthorizationMismatch),
+        ]
+    );
 }
 
 #[test]
@@ -146,7 +160,12 @@ fn independent_verifier_no_layerx_infrastructure_required() {
 
     let result = verifier.verify_vector_against_trusted_batch(GOLDEN_VECTOR_1, &trusted_batch);
 
-    let _verification_completed_without_gateway = result.is_ok() || result.is_err();
+    assert_eq!(
+        result,
+        Err(PortableReceiptError::Receipt(VerificationFailure {
+            check: ReceiptCheck::Decode,
+        }))
+    );
 }
 
 #[test]

--- a/interop/crates/layerx-portable/tests/receipt_vectors.rs
+++ b/interop/crates/layerx-portable/tests/receipt_vectors.rs
@@ -6,7 +6,7 @@
 use layerx_portable::{
     interop_portable_verification, PortableReceipt, PortableReceiptError, PORTABLE_RECEIPT_FORMAT,
 };
-use layerx_proof::receipt::AuthorizedBatch;
+use layerx_proof::receipt::{AuthorizedBatch, ReceiptCheck, VerificationFailure};
 
 const GOLDEN_RECEIPT_JSON: &str = r#"{
   "format": "layerx-receipt-proof-v1",
@@ -142,7 +142,7 @@ fn verify_requires_matching_batch_authorization() {
 }
 
 #[test]
-fn roundtrip_export_and_verify() {
+fn export_rejects_truncated_canonical_receipt() {
     let canonical_receipt = vec![
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1,
@@ -150,9 +150,11 @@ fn roundtrip_export_and_verify() {
     let batch = AuthorizedBatch::new([10u8; 32], [20u8; 32], [30u8; 32], [40u8; 32], [50u8; 32]);
 
     let result = PortableReceipt::export(&canonical_receipt, &batch);
-    assert!(
-        result.is_err() || result.is_ok(),
-        "Export with minimal receipt (will fail verification but tests API)"
+    assert_eq!(
+        result,
+        Err(PortableReceiptError::Receipt(VerificationFailure {
+            check: ReceiptCheck::Decode,
+        }))
     );
 }
 

--- a/platform/hosted/gateway/src/http.rs
+++ b/platform/hosted/gateway/src/http.rs
@@ -18,6 +18,8 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
+    /// # Errors
+    /// Returns an error for a non-canonical HTTPS endpoint or invalid DNS host or port.
     pub fn parse(value: &str) -> Result<Self, String> {
         let rest = value
             .strip_prefix("https://")
@@ -70,25 +72,31 @@ pub struct Client {
     identity: Identity,
 }
 
+#[derive(Clone, Copy)]
+pub struct RequestTarget<'a> {
+    pub endpoint: &'a Endpoint,
+    pub method: &'a str,
+    pub path: &'a str,
+}
+
 impl Client {
+    #[must_use]
     pub fn new(ca: Certificate, identity: Identity) -> Self {
         Self { ca, identity }
     }
 
+    /// # Errors
+    /// Returns an error for invalid request bounds, TLS, transport, or response framing.
     pub fn request(
         &self,
-        endpoint: &Endpoint,
-        method: &str,
-        path: &str,
+        target: RequestTarget<'_>,
         bearer: &str,
         idempotency: Option<&str>,
         content_type: &str,
         body: &[u8],
     ) -> Result<UpstreamResponse, String> {
         self.request_authorized(
-            endpoint,
-            method,
-            path,
+            target,
             &format!("Bearer {bearer}"),
             idempotency,
             content_type,
@@ -99,42 +107,39 @@ impl Client {
     /// Sends one bounded request with an already validated authorization
     /// value. This is used when another hosted ingress forwards the exact
     /// `LayerX-Key` credential to the gateway authentication boundary.
+    ///
+    /// # Errors
+    /// Returns an error for invalid request bounds, TLS, transport, or response framing.
     pub fn request_authorized(
         &self,
-        endpoint: &Endpoint,
-        method: &str,
-        path: &str,
+        target: RequestTarget<'_>,
         authorization: &str,
         idempotency: Option<&str>,
         content_type: &str,
         body: &[u8],
     ) -> Result<UpstreamResponse, String> {
-        self.request_authorized_traced(
-            endpoint,
-            method,
-            path,
-            authorization,
-            idempotency,
-            content_type,
-            body,
-            None,
-        )
+        self.request_authorized_traced(target, authorization, idempotency, content_type, body, None)
     }
 
     /// Sends one bounded authorized request while propagating the ingress
     /// trace identifier unchanged across the service boundary.
-    #[allow(clippy::too_many_arguments)]
+    ///
+    /// # Errors
+    /// Returns an error for invalid request bounds, TLS, transport, or response framing.
     pub fn request_authorized_traced(
         &self,
-        endpoint: &Endpoint,
-        method: &str,
-        path: &str,
+        target: RequestTarget<'_>,
         authorization: &str,
         idempotency: Option<&str>,
         content_type: &str,
         body: &[u8],
         trace: Option<&str>,
     ) -> Result<UpstreamResponse, String> {
+        let RequestTarget {
+            endpoint,
+            method,
+            path,
+        } = target;
         if !path.starts_with('/') || path.contains(['?', '#', '\\']) || body.len() > MAX_RESPONSE {
             return Err("outbound request exceeds its boundary".to_owned());
         }
@@ -228,6 +233,8 @@ pub struct UpstreamResponse {
     pub body: Vec<u8>,
 }
 
+/// # Errors
+/// Returns an error for malformed, oversized, truncated, or unreadable HTTP requests.
 pub fn read_request(stream: &mut impl Read, maximum: usize) -> Result<IncomingRequest, String> {
     let (start, headers, body) = read_message(stream, maximum)?;
     let mut parts = start.split_whitespace();
@@ -272,10 +279,9 @@ fn read_response(stream: &mut impl Read) -> Result<UpstreamResponse, String> {
     })
 }
 
-fn read_message(
-    stream: &mut impl Read,
-    maximum: usize,
-) -> Result<(String, BTreeMap<String, String>, Vec<u8>), String> {
+type HttpMessage = (String, BTreeMap<String, String>, Vec<u8>);
+
+fn read_message(stream: &mut impl Read, maximum: usize) -> Result<HttpMessage, String> {
     let mut bytes = Vec::with_capacity(2048);
     let mut chunk = [0_u8; 2048];
     let header_end = loop {
@@ -336,6 +342,8 @@ fn read_message(
     ))
 }
 
+/// # Errors
+/// Returns an error if writing or flushing the response fails.
 pub fn write_response(stream: &mut impl Write, response: &OutgoingResponse) -> Result<(), String> {
     let reason = match response.status {
         200 => "OK",

--- a/platform/hosted/gateway/src/lib.rs
+++ b/platform/hosted/gateway/src/lib.rs
@@ -488,7 +488,7 @@ impl VerifiedOperation {
     }
 
     #[must_use]
-    pub const fn verification_level(&self) -> &'static str {
+    pub const fn verification_level(_operation: &Self) -> &'static str {
         "receipt-verified"
     }
 }
@@ -555,6 +555,13 @@ pub fn verify_activity_operation(
     })
 }
 
+#[derive(Clone, Copy)]
+pub struct ProgramOperationExpectation {
+    pub activity_id: [u8; 32],
+    pub program_id: [u8; 32],
+    pub guest_abi_version: u16,
+}
+
 /// Verifies a committed Programs receipt together with its authenticated
 /// terminal payload and call graph, then renders only locally derived fields.
 ///
@@ -568,10 +575,13 @@ pub fn verify_program_operation(
     call_graph: &[u8],
     authority: AuthorityFacts,
     trusted_sequencer_key: &[u8; 32],
-    expected_activity_id: [u8; 32],
-    expected_program_id: [u8; 32],
-    expected_guest_abi_version: u16,
+    expectation: ProgramOperationExpectation,
 ) -> Result<VerifiedOperation, GatewayError> {
+    let ProgramOperationExpectation {
+        activity_id: expected_activity_id,
+        program_id: expected_program_id,
+        guest_abi_version: expected_guest_abi_version,
+    } = expectation;
     if authority
         .sequencer_public_key()
         .ct_eq(trusted_sequencer_key)
@@ -593,7 +603,7 @@ pub fn verify_program_operation(
     )
     .map_err(|_| GatewayError::VerificationRequired)?;
     render_verified_program_operation(
-        verified,
+        &verified,
         terminal_payload,
         call_graph,
         expected_program_id,
@@ -616,10 +626,13 @@ pub fn verify_program_simulation_operation(
     call_graph: &[u8],
     trusted_previous_state_root: [u8; 32],
     trusted_sequencer_key: [u8; 32],
-    expected_activity_id: [u8; 32],
-    expected_program_id: [u8; 32],
-    expected_guest_abi_version: u16,
+    expectation: ProgramOperationExpectation,
 ) -> Result<VerifiedOperation, GatewayError> {
+    let ProgramOperationExpectation {
+        activity_id: expected_activity_id,
+        program_id: expected_program_id,
+        guest_abi_version: expected_guest_abi_version,
+    } = expectation;
     let verified = verify_program_execution(
         receipt_bytes,
         terminal_payload,
@@ -634,7 +647,7 @@ pub fn verify_program_simulation_operation(
     )
     .map_err(|_| GatewayError::VerificationRequired)?;
     render_verified_program_operation(
-        verified,
+        &verified,
         terminal_payload,
         call_graph,
         expected_program_id,
@@ -645,7 +658,7 @@ pub fn verify_program_simulation_operation(
 }
 
 fn render_verified_program_operation(
-    verified: VerifiedProgramExecution,
+    verified: &VerifiedProgramExecution,
     terminal_payload: &[u8],
     call_graph: &[u8],
     expected_program_id: [u8; 32],

--- a/platform/hosted/gateway/src/main.rs
+++ b/platform/hosted/gateway/src/main.rs
@@ -398,9 +398,11 @@ fn program_head(
     let upstream = config
         .client
         .request(
-            &config.registry,
-            "GET",
-            &format!("/v1/programs/registry/{program}"),
+            layerx_platform_gateway::http::RequestTarget {
+                endpoint: &config.registry,
+                method: "GET",
+                path: &format!("/v1/programs/registry/{program}"),
+            },
             config.registry_token.as_str(),
             None,
             "application/json",
@@ -1055,9 +1057,11 @@ fn upstream_json(
     config
         .client
         .request(
-            endpoint,
-            method,
-            path,
+            layerx_platform_gateway::http::RequestTarget {
+                endpoint,
+                method,
+                path,
+            },
             token,
             idempotency,
             "application/json",
@@ -1504,9 +1508,11 @@ fn verified_program_result(
         &call_graph,
         facts,
         &config.trusted_sequencer_key,
-        expected_activity,
-        head.program_id,
-        head.abi_version,
+        layerx_platform_gateway::ProgramOperationExpectation {
+            activity_id: expected_activity,
+            program_id: head.program_id,
+            guest_abi_version: head.abi_version,
+        },
     )
     .map_err(|_| response(503, "program_receipt_verification_failed", Some(5)))?;
     Ok((
@@ -1567,9 +1573,11 @@ fn program_simulation(
         Err(_) => return response(503, "persistence_unavailable", Some(5)),
     }
     let upstream = match config.client.request(
-        &config.component,
-        "POST",
-        "/v1/programs/simulate",
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.component,
+            method: "POST",
+            path: "/v1/programs/simulate",
+        },
         config.component_token.as_str(),
         None,
         "application/octet-stream",
@@ -1624,9 +1632,11 @@ fn program_simulation(
         &call_graph,
         state_root,
         config.trusted_sequencer_key,
-        submission.activity_id(),
-        program_id,
-        head.abi_version,
+        layerx_platform_gateway::ProgramOperationExpectation {
+            activity_id: submission.activity_id(),
+            program_id,
+            guest_abi_version: head.abi_version,
+        },
     ) {
         Ok(value) => value,
         Err(_) => return response(503, "program_simulation_unverified", Some(5)),
@@ -1914,12 +1924,14 @@ fn activity(
         Reservation::Reserved => {}
     }
     let upstream = match config.client.request(
-        &config.component,
-        "POST",
-        if program_mutation {
-            &request.path
-        } else {
-            "/v1/activities"
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.component,
+            method: "POST",
+            path: if program_mutation {
+                &request.path
+            } else {
+                "/v1/activities"
+            },
         },
         config.component_token.as_str(),
         Some(&protocol_idempotency),
@@ -2243,12 +2255,14 @@ fn resolve_pending_lifecycle(
         _ => return response(502, "lifecycle_binding_invalid", None),
     };
     let upstream = match config.client.request(
-        &config.component,
-        "GET",
-        &format!(
-            "/v1/programs/receipts/by-idempotency/{}",
-            operation.idempotency_key
-        ),
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.component,
+            method: "GET",
+            path: &format!(
+                "/v1/programs/receipts/by-idempotency/{}",
+                operation.idempotency_key
+            ),
+        },
         config.component_token.as_str(),
         None,
         "application/json",
@@ -2349,9 +2363,11 @@ fn resolve_pending_program(
         }
     }
     let upstream = match config.client.request(
-        &config.component,
-        "GET",
-        &format!("/v1/programs/activities/{}", operation.activity_id),
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.component,
+            method: "GET",
+            path: &format!("/v1/programs/activities/{}", operation.activity_id),
+        },
         config.component_token.as_str(),
         None,
         "application/json",
@@ -2515,9 +2531,11 @@ fn read_route(
                 return response(404, "receipt_not_found", None);
             }
             let upstream = match config.client.request(
-                &config.component,
-                "GET",
-                &format!("/v1/receipts/{activity_id}"),
+                layerx_platform_gateway::http::RequestTarget {
+                    endpoint: &config.component,
+                    method: "GET",
+                    path: &format!("/v1/receipts/{activity_id}"),
+                },
                 config.component_token.as_str(),
                 None,
                 "application/json",
@@ -2598,9 +2616,11 @@ fn read_route(
                 Err(error) => return error,
             };
             let upstream = match config.client.request(
-                &config.registry,
-                "GET",
-                &format!("/v1/programs/registry/{program}/interface"),
+                layerx_platform_gateway::http::RequestTarget {
+                    endpoint: &config.registry,
+                    method: "GET",
+                    path: &format!("/v1/programs/registry/{program}/interface"),
+                },
                 config.registry_token.as_str(),
                 None,
                 "application/json",
@@ -2815,9 +2835,11 @@ fn dependency_ready(
     require_routes: bool,
 ) -> bool {
     let Ok(upstream) = config.client.request(
-        endpoint,
-        "GET",
-        "/readyz",
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint,
+            method: "GET",
+            path: "/readyz",
+        },
         token,
         None,
         "application/json",
@@ -2838,9 +2860,11 @@ fn dependency_ready(
 
 fn program_registry_ready(config: &Config) -> bool {
     let Ok(upstream) = config.client.request(
-        &config.registry,
-        "GET",
-        "/healthz",
+        layerx_platform_gateway::http::RequestTarget {
+            endpoint: &config.registry,
+            method: "GET",
+            path: "/healthz",
+        },
         config.registry_token.as_str(),
         None,
         "application/json",

--- a/platform/hosted/webhooks/src/events.rs
+++ b/platform/hosted/webhooks/src/events.rs
@@ -634,7 +634,9 @@ pub fn settled_payment(draft: PaymentDraft<'_>) -> Result<ProtocolEvent, Webhook
     if draft.operation.result_code() != 0 {
         return Err(WebhookError::VerificationRequired);
     }
-    let verification = Verification::parse(draft.operation.verification_level())?;
+    let verification = Verification::parse(
+        layerx_platform_gateway::VerifiedOperation::verification_level(draft.operation),
+    )?;
     if !verification.at_least(Verification::ReceiptVerified) {
         return Err(WebhookError::VerificationRequired);
     }

--- a/platform/hosted/webhooks/src/trusted.rs
+++ b/platform/hosted/webhooks/src/trusted.rs
@@ -266,7 +266,9 @@ impl TrustedSources {
             facts.push(ProtocolFact::unverified(fact.name, fact.value)?);
         }
         if let Some(operation) = operation.as_ref() {
-            let verification = Verification::parse(operation.verification_level())?;
+            let verification = Verification::parse(
+                layerx_platform_gateway::VerifiedOperation::verification_level(operation),
+            )?;
             let receipt = hex_encode(&operation.receipt_digest());
             facts.push(ProtocolFact::verified(
                 "activity_id",

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -2117,3 +2117,19 @@ symbol = "interop-lint"
 observed = "make interop-lint passes strict workspace Clippy and dependency/unsafe policy, then exits 2 after cargo-deny exits 3. Exact refusals remain der 0.7.10/0.8.1, getrandom 0.2.17/0.4.3, windows-sys 0.52.0/0.61.2, and unmaintained paste 1.0.15 RUSTSEC-2024-0436. The r-efi duplicate refusal is gone. cargo tree -i windows-sys@0.52.0 on the host prints no dependents; --target all shows ring 0.17.14 as its only direct dependent, through rustls and rustls-webpki. The fetched sparse registry index ends at ring 0.17.14, requiring windows-sys ^0.52 and getrandom ^0.2.10. Crypto rand_core also requires getrandom 0.2.17. Raw evidence: qual-logs/au14/interop-lint.log, windows-tree.log, windows-all-tree.log, ring-index.jsonl and getrandom-old-tree.log."
 assumption = "There is no available direct dependency version bump that removes the ring windows-sys branch. A compatible upstream release or separately authorized coordinated cryptographic-provider migration is required. Platform additionally retains getrandom 0.3.4 through the independent layerx-agentd exact pin. Full getrandom and windows-sys convergence is not established. Curve and interpreter dependency migrations remain outside this change; deny.toml and all checks remain intact."
 severity = "blocker"
+
+[observation.6.4.gateway-lint-binary-boundary]
+task = "6.4"
+file = "platform/hosted/gateway/src/main.rs platform/hosted/gateway/tests/tap_nonce.rs"
+symbol = "platform-lint"
+observed = "The 14 library diagnostics in observation.6.4.gateway-getrandom-lint-baseline are repaired: strict library Clippy exits 0 and the gateway test suite exits 0. Strict all-target gateway Clippy exits 101 after reaching the binary and integration targets: main.rs has 55 binary diagnostics and 65 including unit tests; tap_nonce.rs has zombie_processes at line 94 and format_collect at line 259. Binary findings include unnested_or_patterns, manual_is_multiple_of, too_many_lines, needless_pass_by_value, map_unwrap_or, manual_let_else, single_match_else, match_same_arms and unwrap_used. These pre-existing code paths were not refactored beyond the requested caller migrations. Evidence: qual-logs/au15/gateway-lib-clippy.log, gateway-clippy-final.log, gateway-test-final.log and caller-expression-check.log. Interop workspace build, test and strict all-target Clippy exit 0 in interop-build.log, interop-test.log and interop-clippy.log."
+assumption = "Library qualification does not establish a passing all-target gateway lint gate. The additional binary and integration-test lint repairs are separate from the recorded 14 library diagnostics. No assertion, bound, validation or lint configuration was weakened."
+severity = "blocker"
+
+[observation.6.4.gateway-lint-registry-boundary]
+task = "6.4"
+file = "platform/hosted/registry/src/builder.rs platform/hosted/registry/src/routes.rs platform/hosted/registry/src/auth.rs"
+symbol = "platform-lint"
+observed = "make platform-lint exits 2 at workspace Clippy. The first registry diagnostics are unused_mut on builder.rs:723, dead_code for routes.rs:1010 field, missing_errors_doc on auth.rs:45 and too_many_arguments on builder.rs:70. Registry source is outside the gateway signature migration. Evidence: qual-logs/au15/platform-lint.log."
+assumption = "Registry diagnostics and subsequent platform lint steps require separate qualification; no passing platform-lint result is claimed."
+severity = "blocker"


### PR DESCRIPTION
Repair the 14 recorded gateway library lint diagnostics, migrate callers in both workspaces with unchanged expressions, and replace portable-verifier assertions that accepted every outcome with exact typed refusals.

Item 1 remains partially qualified. Strict library Clippy and gateway tests pass. Interop workspace build, tests and strict all-target Clippy pass; webhook caller compilation passes. Required gateway all-target Clippy exits 101 on additional pre-existing binary/TAP test diagnostics, and platform lint exits 2 in the registry crate. The observations and exact diagnostic paths are appended to qualification.kvx. No lint suppression, validation, TLS, authorization, bounds or tracing was relaxed.

Item 2 passes its required gates. Vector 1 must return Receipt(VerificationFailure { check: Decode }); vector 2 must return BatchAuthorizationMismatch because its encoded predecessor root ends in 0x20 instead of 0x08. The wrong-batch case requires BatchAuthorizationMismatch, and the 32-byte receipt export requires Receipt(Decode). The ordered vector loop also checks both exact refusals. Expectations came from the literal vectors and verifier source before executing the strengthened assertions; production verifier code and vector bytes are unchanged. Derivation: qual-logs/au15/portable-expectations.md.

All commands ran from /root/lx-lanes/authority with CARGO_BUILD_JOBS=4, MAKEFLAGS=-j4 and LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin/. Logs below are untracked local evidence.

Item 1 commands

| Command | Exit | Log |
|---|---:|---|
| `rustfmt --edition 2021 --config skip_children=true platform/hosted/gateway/src/http.rs platform/hosted/gateway/src/lib.rs platform/hosted/gateway/src/main.rs platform/hosted/webhooks/src/events.rs platform/hosted/webhooks/src/trusted.rs interop/crates/layerx-interop-service/src/server.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item1-format.log` |
| `rustfmt --check --edition 2021 --config skip_children=true platform/hosted/gateway/src/http.rs platform/hosted/gateway/src/lib.rs platform/hosted/gateway/src/main.rs platform/hosted/webhooks/src/events.rs platform/hosted/webhooks/src/trusted.rs interop/crates/layerx-interop-service/src/server.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item1-fmt-check.log` |
| `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway --all-targets -- -D warnings` | 101 | `/root/lx-lanes/authority/qual-logs/au15/gateway-clippy.log` |
| `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway` | 0 | `/root/lx-lanes/authority/qual-logs/au15/gateway-test.log` |
| `make platform-lint` | 2 | `/root/lx-lanes/authority/qual-logs/au15/platform-lint.log` |
| `cargo build --locked --manifest-path interop/Cargo.toml --workspace` | 0 | `/root/lx-lanes/authority/qual-logs/au15/interop-build.log` |
| `rustfmt --edition 2021 --config skip_children=true platform/hosted/gateway/src/http.rs platform/hosted/gateway/src/lib.rs platform/hosted/gateway/src/main.rs platform/hosted/webhooks/src/events.rs platform/hosted/webhooks/src/trusted.rs interop/crates/layerx-interop-service/src/server.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item1-format-final.log` |
| `rustfmt --check --edition 2021 --config skip_children=true platform/hosted/gateway/src/http.rs platform/hosted/gateway/src/lib.rs platform/hosted/gateway/src/main.rs platform/hosted/webhooks/src/events.rs platform/hosted/webhooks/src/trusted.rs interop/crates/layerx-interop-service/src/server.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item1-fmt-check-final.log` |
| `cargo test --locked --manifest-path interop/Cargo.toml --workspace` | 0 | `/root/lx-lanes/authority/qual-logs/au15/interop-test.log` |
| `cargo clippy --locked --manifest-path interop/Cargo.toml --workspace --all-targets -- -D warnings` | 0 | `/root/lx-lanes/authority/qual-logs/au15/interop-clippy.log` |
| `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway --lib -- -D warnings` | 0 | `/root/lx-lanes/authority/qual-logs/au15/gateway-lib-clippy.log` |
| `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway --all-targets -- -D warnings` | 101 | `/root/lx-lanes/authority/qual-logs/au15/gateway-clippy-final.log` |
| `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway` | 0 | `/root/lx-lanes/authority/qual-logs/au15/gateway-test-final.log` |
| `git diff --check` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item1-diff-check.log` |
| `cortex_guard` | 127 | `/root/lx-lanes/authority/qual-logs/au15/cortex-guard.log` |
| `cargo check --locked --manifest-path platform/Cargo.toml -p layerx-platform-webhooks --all-targets` | 0 | `/root/lx-lanes/authority/qual-logs/au15/webhooks-callers-check.log` |

Item 2 commands

| Command | Exit | Log |
|---|---:|---|
| `rustfmt --edition 2021 interop/crates/layerx-portable/tests/independent_verifier.rs interop/crates/layerx-portable/tests/receipt_vectors.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item2-format.log` |
| `rustfmt --check --edition 2021 interop/crates/layerx-portable/tests/independent_verifier.rs interop/crates/layerx-portable/tests/receipt_vectors.rs` | 0 | `/root/lx-lanes/authority/qual-logs/au15/item2-fmt-check.log` |
| `cargo test --locked --manifest-path interop/Cargo.toml -p layerx-portable` | 0 | `/root/lx-lanes/authority/qual-logs/au15/portable-test.log` |
| `cargo clippy --locked --manifest-path interop/Cargo.toml -p layerx-portable --all-targets -- -D warnings` | 0 | `/root/lx-lanes/authority/qual-logs/au15/portable-clippy.log` |

Final checks and publication

| Command | Exit | Log |
|---|---:|---|
| `git diff --check` | 0 | `/root/lx-lanes/authority/qual-logs/au15/final-diff-check.log` |
| `cg spec lint` | 0 | `/root/lx-lanes/authority/qual-logs/au15/spec-lint.log` |
| `git fetch origin` | 0 | `/root/lx-lanes/authority/qual-logs/au15/final-fetch.log` |
| `git rebase origin/main` | 0 | `/root/lx-lanes/authority/qual-logs/au15/final-rebase.log` |
| `git diff --check` | 0 | `/root/lx-lanes/authority/qual-logs/au15/publication-diff-check.log` |
| `git push -u origin lane/gateway-lint` | 0 | `/root/lx-lanes/authority/qual-logs/au15/final-push.log` |

Caller expression audit: `python3 qual-logs/au15/check-callers.py`, exit 0, `qual-logs/au15/caller-expression-check.log`. All 16 migrated calls preserve expressions and evaluation order. Codify graph context was unavailable because this worktree has no initialized graph; cortex_guard was absent (127).

🤖 Generated with Codex
