### PR TITLE
Repair remaining platform workspace strict lint findings

### DIFF
--- a/platform/hosted/dashboard/src/gateway.rs
+++ b/platform/hosted/dashboard/src/gateway.rs
@@ -49,6 +49,10 @@ pub struct Store {
 }
 
 impl Store {
+    /// # Errors
+    /// Returns an error if a required environment variable is missing, the Redis
+    /// endpoint is invalid, the CA cannot be read or decoded, or a credential
+    /// file cannot be read or contains an empty or oversized value.
     pub fn from_environment() -> Result<Self, String> {
         let endpoint = parse_endpoint(
             &env::var("LAYERX_DASHBOARD_GATEWAY_REDIS_URL")
@@ -70,10 +74,14 @@ impl Store {
         })
     }
 
+    #[must_use]
     pub fn ready(&self) -> bool {
         matches!(self.command(&["PING"]), Ok(Resp::Simple(value)) if value == "PONG")
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if Redis communication fails or
+    /// the key set, principal binding, quota fields or usage values are invalid.
     pub fn keys(&self, principal: &Principal, now: u64) -> Result<Vec<KeyView>, DashboardError> {
         let digest = principal_digest(principal);
         let ids = self.key_ids(&digest)?;
@@ -129,10 +137,16 @@ impl Store {
         Ok(keys)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if the principal's keys or quota
+    /// usage cannot be read and validated.
     pub fn usage(&self, principal: &Principal, now: u64) -> Result<UsageSummary, DashboardError> {
         Ok(usage_summary(&self.keys(principal, now)?))
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if Redis communication fails or
+    /// the audit response structure, required fields or timestamp are invalid.
     pub fn requests(
         &self,
         principal: &Principal,
@@ -192,6 +206,9 @@ impl Store {
         Ok(records)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if the principal's keys, quota
+    /// usage or recent audit records cannot be read and validated.
     pub fn snapshot(
         &self,
         principal: &Principal,

--- a/platform/hosted/dashboard/src/main.rs
+++ b/platform/hosted/dashboard/src/main.rs
@@ -113,23 +113,23 @@ fn owned_route(config: &Config, request: &Request, principal: &Principal, at: u6
         ["v1", "dashboard", "overview"] => config
             .dashboard
             .overview(principal, at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "keys"] => config
             .dashboard
             .keys(principal, at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "usage"] => config
             .dashboard
             .usage(principal, at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "requests"] => config
             .dashboard
             .requests(principal, page(request))
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "webhooks"] => config
             .dashboard
             .endpoints(principal, at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "webhook-deliveries"] => {
             let endpoint = request
                 .parameter("endpoint")
@@ -139,22 +139,22 @@ fn owned_route(config: &Config, request: &Request, principal: &Principal, at: u6
                 Ok(endpoint) => config
                     .dashboard
                     .deliveries(principal, endpoint.as_ref(), page(request), at)
-                    .map(|value| serde_json::to_value(value)),
+                    .map(serde_json::to_value),
                 Err(error) => Err(DashboardError::from(error)),
             }
         }
         ["v1", "dashboard", "webhook-dead-letters"] => config
             .dashboard
             .dead_letters(principal, page(request), at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "test-payments"] => config
             .dashboard
             .payments(principal, page(request), at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         ["v1", "dashboard", "receipts", activity] => config
             .dashboard
             .receipt(principal, activity, at)
-            .map(|value| serde_json::to_value(value)),
+            .map(serde_json::to_value),
         _ => return Reply::refusal(404, "not_found", None),
     };
     result
@@ -176,7 +176,7 @@ fn route(config: &Config, request: &Request) -> Reply {
     }
 }
 
-fn serve(config: Arc<Config>) -> Result<(), String> {
+fn serve(config: &Arc<Config>) -> Result<(), String> {
     let listener = TcpListener::bind(config.listen).map_err(|error| error.to_string())?;
     for accepted in listener.incoming() {
         let Ok(tcp) = accepted else {
@@ -186,7 +186,7 @@ fn serve(config: Arc<Config>) -> Result<(), String> {
             ACTIVE_CONNECTIONS.fetch_sub(1, Ordering::AcqRel);
             continue;
         }
-        let request_config = Arc::clone(&config);
+        let request_config = Arc::clone(config);
         thread::spawn(move || {
             let _guard = ConnectionGuard;
             let _ = handle(tcp, &request_config);
@@ -219,7 +219,7 @@ fn handle(tcp: TcpStream, config: &Config) -> Result<(), String> {
 }
 
 fn main() {
-    if let Err(error) = config().and_then(|config| serve(Arc::new(config))) {
+    if let Err(error) = config().and_then(|config| serve(&Arc::new(config))) {
         eprintln!("layerx-dashboard: {error}");
         std::process::exit(2);
     }

--- a/platform/hosted/dashboard/src/model.rs
+++ b/platform/hosted/dashboard/src/model.rs
@@ -195,9 +195,8 @@ impl PaymentView {
     #[must_use]
     pub fn of(event: &ProtocolEvent) -> Self {
         let settlement = fact(event, "state");
-        let settlement_verification = settlement
-            .map(ProtocolFact::verification)
-            .unwrap_or(Verification::Unverified);
+        let settlement_verification =
+            settlement.map_or(Verification::Unverified, ProtocolFact::verification);
         let receipt_digest = settlement.and_then(ProtocolFact::receipt_digest);
         let settled = settlement.is_some_and(|fact| fact.value() == "settled")
             && settlement_verification.at_least(Verification::ReceiptVerified)

--- a/platform/hosted/dashboard/src/service.rs
+++ b/platform/hosted/dashboard/src/service.rs
@@ -18,6 +18,9 @@ pub struct Dashboard {
 }
 
 impl Dashboard {
+    /// # Errors
+    /// Returns an error if gateway or webhook Redis configuration, credentials,
+    /// CA material or webhook retry policy is missing, unreadable or invalid.
     pub fn from_environment() -> Result<Self, String> {
         Ok(Self {
             gateway: Store::from_environment()?,
@@ -25,18 +28,28 @@ impl Dashboard {
         })
     }
 
+    #[must_use]
     pub fn ready(&self) -> bool {
         self.gateway.ready() && self.webhooks.ready()
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if gateway keys or quota values
+    /// cannot be read and validated for the principal.
     pub fn keys(&self, principal: &Principal, now: u64) -> Result<Vec<KeyView>, DashboardError> {
         self.gateway.keys(principal, now)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if gateway keys or quota usage
+    /// cannot be read and validated for the principal.
     pub fn usage(&self, principal: &Principal, now: u64) -> Result<UsageSummary, DashboardError> {
         self.gateway.usage(principal, now)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if gateway audit records cannot
+    /// be read and validated.
     pub fn requests(
         &self,
         principal: &Principal,
@@ -45,6 +58,11 @@ impl Dashboard {
         self.gateway.requests(principal, limit.min(MAXIMUM_PAGE))
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::InvalidRequest`] for an invalid activity ID,
+    /// [`DashboardError::Webhooks`] if the webhook shard is unavailable or corrupt,
+    /// or [`DashboardError::UnknownReceipt`] if no settled payment has matching
+    /// receipt-backed activity and settlement facts.
     pub fn receipt(
         &self,
         principal: &Principal,
@@ -102,6 +120,9 @@ impl Dashboard {
         })
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::Webhooks`] if the principal's webhook shard
+    /// is unavailable or corrupt.
     pub fn endpoints(
         &self,
         principal: &Principal,
@@ -113,6 +134,9 @@ impl Dashboard {
             .endpoints)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::Webhooks`] if the principal's webhook shard
+    /// is unavailable or corrupt.
     pub fn deliveries(
         &self,
         principal: &Principal,
@@ -129,6 +153,9 @@ impl Dashboard {
             .collect())
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::Webhooks`] if the principal's webhook shard
+    /// is unavailable or corrupt.
     pub fn dead_letters(
         &self,
         principal: &Principal,
@@ -141,6 +168,9 @@ impl Dashboard {
             .dead_letters)
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::Webhooks`] if the principal's webhook shard
+    /// is unavailable or corrupt.
     pub fn payments(
         &self,
         principal: &Principal,
@@ -157,6 +187,10 @@ impl Dashboard {
             .collect())
     }
 
+    /// # Errors
+    /// Returns [`DashboardError::CorruptStore`] if gateway records cannot be
+    /// read and validated, or [`DashboardError::Webhooks`] if the webhook shard
+    /// is unavailable or corrupt.
     pub fn overview(&self, principal: &Principal, now: u64) -> Result<Overview, DashboardError> {
         let gateway = self.gateway.snapshot(principal, now, OVERVIEW_PAGE)?;
         let webhooks = self.webhooks.snapshot(principal, now, OVERVIEW_PAGE)?;

--- a/platform/hosted/testnet/src/lib.rs
+++ b/platform/hosted/testnet/src/lib.rs
@@ -23,6 +23,13 @@ pub struct TestnetConfig {
 }
 
 impl TestnetConfig {
+    /// Validates the release identity and testnet operations configuration.
+    ///
+    /// # Errors
+    /// Returns an error if the package or wire version differs from the pending
+    /// release, the wire version is unsupported, the network ID is incorrect,
+    /// any endpoint is not a canonical HTTPS origin, the reset schedule is empty,
+    /// or the snapshot interval is zero.
     pub fn validate(&self, pending: &PendingRelease) -> Result<(), &'static str> {
         if self.package_semver != pending.package_semver {
             return Err("testnet package release does not match pending release");

--- a/platform/ramps/reference/src/main.rs
+++ b/platform/ramps/reference/src/main.rs
@@ -198,7 +198,7 @@ fn run() -> Result<(), String> {
     let cadence = Duration::from_secs(config.reconcile_seconds);
     thread::Builder::new()
         .name("ramp-reconciler".to_owned())
-        .spawn(move || reconcile_loop(reconcile_state, cadence))
+        .spawn(move || reconcile_loop(&reconcile_state, cadence))
         .map_err(|error| format!("start reconciler: {error}"))?;
     let listener = TcpListener::bind(&config.listen)
         .map_err(|error| format!("bind {}: {error}", config.listen))?;
@@ -374,38 +374,8 @@ fn build_state(config: &Config) -> Result<State, String> {
         vault_id: config.paxeer.vault_id.clone(),
         signer_key_handle: config.paxeer.signer_key_handle.clone(),
     };
-    let rpc_trust_anchor_der = fs::read(&config.paxeer.rpc_trust_anchor_der)
-        .map_err(|_| "Paxeer RPC trust anchor is unavailable".to_owned())?;
-    if rpc_trust_anchor_der.is_empty() {
-        return Err("Paxeer RPC trust anchor is empty".to_owned());
-    }
-    let paxeer_tracker_config = TrackerConfig {
-        endpoints: config
-            .paxeer
-            .rpc_endpoints
-            .iter()
-            .map(|url| EndpointConfig {
-                url: url.clone(),
-                request_timeout: timeout,
-                transport: EndpointTransport::PinnedTls {
-                    trust_anchor_der: rpc_trust_anchor_der.clone(),
-                },
-                expected_chain_id: config.paxeer.rpc_chain_id,
-            })
-            .collect(),
-        minimum_endpoint_agreement: config.paxeer.rpc_minimum_agreement,
-        required_confirmations: config.paxeer.required_confirmations,
-        poll_cadence: Duration::from_secs(config.paxeer.poll_cadence_seconds),
-        delayed_after_polls: config.paxeer.delayed_after_polls,
-    };
-    let send = ActivityType::new(ModuleId::Asset, 5)
-        .map_err(|_| "asset send activity rejected".to_owned())?;
-    let receive = ActivityType::new(ModuleId::Asset, 6)
-        .map_err(|_| "asset receive activity rejected".to_owned())?;
-    let registration = ModuleRegistration::new(ModuleId::Asset, &[send, receive])
-        .map_err(|_| "asset registry rejected".to_owned())?;
-    let registry =
-        ModuleRegistry::new(&[registration]).map_err(|_| "module registry rejected".to_owned())?;
+    let paxeer_tracker_config = tracker_config(config, timeout)?;
+    let registry = asset_registry()?;
     let mut quotes = BTreeMap::new();
     for quote in &config.quotes {
         if quotes
@@ -439,6 +409,46 @@ fn build_state(config: &Config) -> Result<State, String> {
     })
 }
 
+fn asset_registry() -> Result<ModuleRegistry, String> {
+    let send = ActivityType::new(ModuleId::Asset, 5)
+        .map_err(|_| "asset send activity rejected".to_owned())?;
+    let receive = ActivityType::new(ModuleId::Asset, 6)
+        .map_err(|_| "asset receive activity rejected".to_owned())?;
+    let registration = ModuleRegistration::new(ModuleId::Asset, &[send, receive])
+        .map_err(|_| "asset registry rejected".to_owned())?;
+    let registry =
+        ModuleRegistry::new(&[registration]).map_err(|_| "module registry rejected".to_owned())?;
+    Ok(registry)
+}
+
+fn tracker_config(config: &Config, timeout: Duration) -> Result<TrackerConfig, String> {
+    let rpc_trust_anchor_der = fs::read(&config.paxeer.rpc_trust_anchor_der)
+        .map_err(|_| "Paxeer RPC trust anchor is unavailable".to_owned())?;
+    if rpc_trust_anchor_der.is_empty() {
+        return Err("Paxeer RPC trust anchor is empty".to_owned());
+    }
+    let paxeer_tracker_config = TrackerConfig {
+        endpoints: config
+            .paxeer
+            .rpc_endpoints
+            .iter()
+            .map(|url| EndpointConfig {
+                url: url.clone(),
+                request_timeout: timeout,
+                transport: EndpointTransport::PinnedTls {
+                    trust_anchor_der: rpc_trust_anchor_der.clone(),
+                },
+                expected_chain_id: config.paxeer.rpc_chain_id,
+            })
+            .collect(),
+        minimum_endpoint_agreement: config.paxeer.rpc_minimum_agreement,
+        required_confirmations: config.paxeer.required_confirmations,
+        poll_cadence: Duration::from_secs(config.paxeer.poll_cadence_seconds),
+        delayed_after_polls: config.paxeer.delayed_after_polls,
+    };
+    Ok(paxeer_tracker_config)
+}
+
 fn configured_key(value: &str, label: &str) -> Result<[u8; 32], String> {
     let key = parse_hex32(value).map_err(|_| format!("{label} key rejected"))?;
     if key == [0; 32] {
@@ -469,12 +479,11 @@ fn secret_text(path: &PathBuf) -> Result<String, String> {
 }
 
 fn serve(stream: TcpStream, acceptor: &TlsAcceptor, state: &State) {
-    let mut tls = match acceptor.accept(stream) {
-        Ok(tls) => tls,
-        Err(_) => return,
+    let Ok(mut tls) = acceptor.accept(stream) else {
+        return;
     };
     let response = read_request(&mut tls)
-        .and_then(|request| route(state, request))
+        .and_then(|request| route(state, &request))
         .unwrap_or_else(|response| response);
     let _ = tls.write_all(&response.encode());
     let _ = tls.flush();
@@ -588,7 +597,7 @@ fn read_request(stream: &mut TlsStream<TcpStream>) -> Result<Request, Response> 
     })
 }
 
-fn route(state: &State, request: Request) -> Result<Response, Response> {
+fn route(state: &State, request: &Request) -> Result<Response, Response> {
     if request.method == "GET" && request.path == "/livez" {
         return Ok(ok(json!({ "live": true })));
     }
@@ -608,31 +617,7 @@ fn route(state: &State, request: Request) -> Result<Response, Response> {
         });
     }
     if request.method == "POST" && request.path == "/v1/orders" {
-        let principal = authenticate(state, &request)?;
-        let create: CreateOrder =
-            serde_json::from_slice(&request.body).map_err(|_| error(400, "order_invalid"))?;
-        let mut journal = state
-            .journal
-            .lock()
-            .map_err(|_| error(503, "journal_unavailable"))?;
-        if let Some(existing) = journal.order_by_id(&create.order_id) {
-            if existing.order.customer != principal
-                || existing.order.quote.quote_id != create.quote_id
-                || existing.order.payer_grant != create.payer_grant
-            {
-                return Err(error(409, "order_id_conflict"));
-            }
-            return Ok(created(&existing.presentation()));
-        }
-        let quote = state
-            .quotes
-            .get(&create.quote_id)
-            .cloned()
-            .ok_or_else(|| error(404, "quote_not_found"))?;
-        let order = RampOrder::bind(create, quote, principal, state.operator.clone(), now())
-            .map_err(map_error)?;
-        let snapshot = journal.create_order(order, now()).map_err(map_error)?;
-        return Ok(created(&snapshot.presentation()));
+        return create_order(state, request);
     }
     if request.method == "POST" && request.path == "/v1/provider-callbacks" {
         let callback: ProviderCallback =
@@ -644,14 +629,14 @@ fn route(state: &State, request: Request) -> Result<Response, Response> {
         let mut engine = engine(state, &mut journal);
         engine
             .provider_callback(&callback, &state.provider_callback_public_key, now())
-            .map_err(map_error)?;
+            .map_err(|error| map_error(&error))?;
         return Ok(ok(json!({ "accepted": true })));
     }
     if let Some(digest) = request.path.strip_prefix("/v1/orders/") {
         if request.method != "GET" || digest.contains('/') {
             return Err(error(404, "not_found"));
         }
-        let principal = authenticate(state, &request)?;
+        let principal = authenticate(state, request)?;
         let digest = parse_hex32(digest).map_err(|_| error(400, "order_digest_invalid"))?;
         let journal = state
             .journal
@@ -670,116 +655,16 @@ fn route(state: &State, request: Request) -> Result<Response, Response> {
         })));
     }
     if request.method == "POST" && request.path == "/internal/v1/work" {
-        require_operator(state, &request)?;
-        let work: Work =
-            serde_json::from_slice(&request.body).map_err(|_| error(400, "work_invalid"))?;
-        let mut journal = state
-            .journal
-            .lock()
-            .map_err(|_| error(503, "journal_unavailable"))?;
-        let mut engine = engine(state, &mut journal);
-        match work.action {
-            WorkAction::Compliance => engine.evaluate_compliance(work.order_digest, now()),
-            WorkAction::SubmitProvider => engine.submit_provider(work.order_digest, now()),
-            WorkAction::ReconcileProvider => engine.reconcile_provider(work.order_digest, now()),
-            WorkAction::SubmitLayerx => match work.account_sequence {
-                Some(sequence) => engine.submit_layerx(work.order_digest, sequence, now()),
-                None => Err(RampError::InvalidOrder),
-            },
-            WorkAction::ResolveLayerx => engine.resolve_layerx(work.order_digest, now()),
-        }
-        .map_err(map_error)?;
-        let snapshot = journal
-            .order(&work.order_digest)
-            .ok_or_else(|| error(404, "order_not_found"))?;
-        return Ok(ok(json!({
-            "stage": snapshot.stage,
-            "presentation": snapshot.presentation()
-        })));
+        return perform_work(state, request);
     }
     if request.method == "POST" && request.path == "/internal/v1/rebalances" {
-        require_operator(state, &request)?;
-        let action: Rebalance =
-            serde_json::from_slice(&request.body).map_err(|_| error(400, "rebalance_invalid"))?;
-        let mut journal = state
-            .journal
-            .lock()
-            .map_err(|_| error(503, "journal_unavailable"))?;
-        let mut rebalancer = InventoryRebalancer {
-            journal: &mut journal,
-            custody: &state.paxeer,
-        };
-        return match action {
-            Rebalance::Submit {
-                asset,
-                amount,
-                idempotency_key,
-            } => {
-                let (operation_id, transaction) = rebalancer
-                    .submit(asset, amount, idempotency_key, now())
-                    .map_err(map_error)?;
-                Ok(accepted(json!({
-                    "operation_id": operation_id,
-                    "transaction_hash": format!("0x{}", layerx_ramp_toolkit::clients::hex(&transaction.bytes())),
-                    "status": "broadcast_unknown"
-                })))
-            }
-            Rebalance::Poll {
-                idempotency_key,
-                operation_id,
-                transaction_hash,
-            } => {
-                let transaction = TransactionHash::from_hex(&transaction_hash)
-                    .map_err(|_| error(400, "transaction_hash_invalid"))?;
-                let mut trackers = state
-                    .paxeer_trackers
-                    .lock()
-                    .map_err(|_| error(503, "paxeer_tracker_unavailable"))?;
-                if !trackers.contains_key(&idempotency_key) {
-                    let tracker =
-                        FinalityTracker::new(state.paxeer_tracker_config.clone(), transaction)
-                            .map_err(|_| error(503, "paxeer_tracker_unavailable"))?;
-                    trackers.insert(idempotency_key, tracker);
-                }
-                let tracker = trackers
-                    .get_mut(&idempotency_key)
-                    .ok_or_else(|| error(503, "paxeer_tracker_unavailable"))?;
-                if tracker.transaction() != transaction {
-                    return Err(error(409, "rebalance_transaction_conflict"));
-                }
-                let report = rebalancer
-                    .poll(idempotency_key, &operation_id, tracker, now())
-                    .map_err(map_error)?;
-                let persisted = journal
-                    .paxeer(&idempotency_key)
-                    .ok_or_else(|| error(404, "rebalance_not_found"))?;
-                Ok(ok(json!({
-                    "operation_id": operation_id,
-                    "transaction_hash": transaction_hash,
-                    "status": persisted.stage,
-                    "confirmations": report.progress().confirmed,
-                    "required_confirmations": report.progress().required,
-                    "chain": chain_signal(&report.signal()),
-                    "endpoints": endpoint_signal(&report.endpoint())
-                })))
-            }
-            Rebalance::Reconcile { idempotency_key } => {
-                let (operation_id, transaction) = rebalancer
-                    .reconcile(idempotency_key, now())
-                    .map_err(map_error)?;
-                Ok(accepted(json!({
-                    "operation_id": operation_id,
-                    "transaction_hash": format!("0x{}", layerx_ramp_toolkit::clients::hex(&transaction.bytes())),
-                    "status": "broadcast_unknown"
-                })))
-            }
-        };
+        return rebalance(state, request);
     }
     if let Some(idempotency) = request.path.strip_prefix("/internal/v1/rebalances/") {
         if request.method != "GET" || idempotency.contains('/') {
             return Err(error(404, "not_found"));
         }
-        require_operator(state, &request)?;
+        require_operator(state, request)?;
         let idempotency =
             parse_hex32(idempotency).map_err(|_| error(400, "idempotency_key_invalid"))?;
         let journal = state
@@ -801,6 +686,146 @@ fn route(state: &State, request: Request) -> Result<Response, Response> {
         })));
     }
     Err(error(404, "not_found"))
+}
+
+fn create_order(state: &State, request: &Request) -> Result<Response, Response> {
+    let principal = authenticate(state, request)?;
+    let create: CreateOrder =
+        serde_json::from_slice(&request.body).map_err(|_| error(400, "order_invalid"))?;
+    let mut journal = state
+        .journal
+        .lock()
+        .map_err(|_| error(503, "journal_unavailable"))?;
+    if let Some(existing) = journal.order_by_id(&create.order_id) {
+        if existing.order.customer != principal
+            || existing.order.quote.quote_id != create.quote_id
+            || existing.order.payer_grant != create.payer_grant
+        {
+            return Err(error(409, "order_id_conflict"));
+        }
+        return Ok(created(existing.presentation()));
+    }
+    let quote = state
+        .quotes
+        .get(&create.quote_id)
+        .cloned()
+        .ok_or_else(|| error(404, "quote_not_found"))?;
+    let order = RampOrder::bind(create, quote, principal, state.operator.clone(), now())
+        .map_err(|error| map_error(&error))?;
+    let snapshot = journal
+        .create_order(order, now())
+        .map_err(|error| map_error(&error))?;
+    Ok(created(snapshot.presentation()))
+}
+
+fn perform_work(state: &State, request: &Request) -> Result<Response, Response> {
+    require_operator(state, request)?;
+    let work: Work =
+        serde_json::from_slice(&request.body).map_err(|_| error(400, "work_invalid"))?;
+    let mut journal = state
+        .journal
+        .lock()
+        .map_err(|_| error(503, "journal_unavailable"))?;
+    let mut engine = engine(state, &mut journal);
+    match work.action {
+        WorkAction::Compliance => engine.evaluate_compliance(work.order_digest, now()),
+        WorkAction::SubmitProvider => engine.submit_provider(work.order_digest, now()),
+        WorkAction::ReconcileProvider => engine.reconcile_provider(work.order_digest, now()),
+        WorkAction::SubmitLayerx => match work.account_sequence {
+            Some(sequence) => engine.submit_layerx(work.order_digest, sequence, now()),
+            None => Err(RampError::InvalidOrder),
+        },
+        WorkAction::ResolveLayerx => engine.resolve_layerx(work.order_digest, now()),
+    }
+    .map_err(|error| map_error(&error))?;
+    let snapshot = journal
+        .order(&work.order_digest)
+        .ok_or_else(|| error(404, "order_not_found"))?;
+    Ok(ok(json!({
+        "stage": snapshot.stage,
+        "presentation": snapshot.presentation()
+    })))
+}
+
+fn rebalance(state: &State, request: &Request) -> Result<Response, Response> {
+    require_operator(state, request)?;
+    let action: Rebalance =
+        serde_json::from_slice(&request.body).map_err(|_| error(400, "rebalance_invalid"))?;
+    let mut journal = state
+        .journal
+        .lock()
+        .map_err(|_| error(503, "journal_unavailable"))?;
+    let mut rebalancer = InventoryRebalancer {
+        journal: &mut journal,
+        custody: &state.paxeer,
+    };
+    match action {
+        Rebalance::Submit {
+            asset,
+            amount,
+            idempotency_key,
+        } => {
+            let (operation_id, transaction) = rebalancer
+                .submit(asset, amount, idempotency_key, now())
+                .map_err(|error| map_error(&error))?;
+            Ok(accepted(json!({
+                "operation_id": operation_id,
+                "transaction_hash": format!("0x{}", layerx_ramp_toolkit::clients::hex(&transaction.bytes())),
+                "status": "broadcast_unknown"
+            })))
+        }
+        Rebalance::Poll {
+            idempotency_key,
+            operation_id,
+            transaction_hash,
+        } => {
+            let transaction = TransactionHash::from_hex(&transaction_hash)
+                .map_err(|_| error(400, "transaction_hash_invalid"))?;
+            let mut trackers = state
+                .paxeer_trackers
+                .lock()
+                .map_err(|_| error(503, "paxeer_tracker_unavailable"))?;
+            if let std::collections::btree_map::Entry::Vacant(entry) =
+                trackers.entry(idempotency_key)
+            {
+                let tracker =
+                    FinalityTracker::new(state.paxeer_tracker_config.clone(), transaction)
+                        .map_err(|_| error(503, "paxeer_tracker_unavailable"))?;
+                entry.insert(tracker);
+            }
+            let tracker = trackers
+                .get_mut(&idempotency_key)
+                .ok_or_else(|| error(503, "paxeer_tracker_unavailable"))?;
+            if tracker.transaction() != transaction {
+                return Err(error(409, "rebalance_transaction_conflict"));
+            }
+            let report = rebalancer
+                .poll(idempotency_key, &operation_id, tracker, now())
+                .map_err(|error| map_error(&error))?;
+            let persisted = journal
+                .paxeer(&idempotency_key)
+                .ok_or_else(|| error(404, "rebalance_not_found"))?;
+            Ok(ok(json!({
+                "operation_id": operation_id,
+                "transaction_hash": transaction_hash,
+                "status": persisted.stage,
+                "confirmations": report.progress().confirmed,
+                "required_confirmations": report.progress().required,
+                "chain": chain_signal(&report.signal()),
+                "endpoints": endpoint_signal(&report.endpoint())
+            })))
+        }
+        Rebalance::Reconcile { idempotency_key } => {
+            let (operation_id, transaction) = rebalancer
+                .reconcile(idempotency_key, now())
+                .map_err(|error| map_error(&error))?;
+            Ok(accepted(json!({
+                "operation_id": operation_id,
+                "transaction_hash": format!("0x{}", layerx_ramp_toolkit::clients::hex(&transaction.bytes())),
+                "status": "broadcast_unknown"
+            })))
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -884,12 +909,11 @@ fn engine<'a>(state: &'a State, journal: &'a mut Journal) -> RampEngine<'a> {
     }
 }
 
-fn reconcile_loop(state: Arc<State>, cadence: Duration) {
+fn reconcile_loop(state: &State, cadence: Duration) {
     loop {
         thread::sleep(cadence);
-        let mut journal = match state.journal.lock() {
-            Ok(journal) => journal,
-            Err(_) => continue,
+        let Ok(mut journal) = state.journal.lock() else {
+            continue;
         };
         let due = journal.orders();
         for snapshot in due {
@@ -910,7 +934,7 @@ fn reconcile_loop(state: Arc<State>, cadence: Duration) {
             {
                 continue;
             }
-            let mut worker = engine(&state, &mut journal);
+            let mut worker = engine(state, &mut journal);
             let result = match snapshot.stage {
                 WorkflowStage::ProviderSubmissionPlanned
                 | WorkflowStage::ProviderSubmittedUnknown
@@ -991,7 +1015,7 @@ fn json_response(status: u16, value: impl Serialize) -> Response {
     }
 }
 
-fn map_error(error_value: RampError) -> Response {
+fn map_error(error_value: &RampError) -> Response {
     match error_value {
         RampError::InvalidOrder | RampError::InvalidPrincipal | RampError::OrderBinding => {
             error(400, "request_refused")

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -2181,3 +2181,27 @@ symbol = "platform-lint"
 observed = "make platform-lint exits 2 in qual-logs/au18/platform-lint.log at cargo clippy --offline --manifest-path platform/Cargo.toml --locked --workspace --all-targets -- -D warnings. The first error is missing_errors_doc for hosted/testnet/src/lib.rs:26 validate. Concurrent jobs next report unused_mut at hosted/registry/src/builder.rs:723, missing_errors_doc at hosted/dashboard/src/gateway.rs:52 and must_use_candidate at gateway.rs:73. Later aggregate lint stages do not execute."
 assumption = "These diagnostics are outside emulator ownership and are recorded without repairs. Registry stash 32964687 remains untouched. No aggregate lint success is claimed."
 severity = "blocker"
+
+[observation.5.2.platform-cli-default-credential-test-boundary]
+task = "5.2"
+file = "platform/cli/src/credential.rs platform/cli/tests/common/mod.rs platform/cli/tests/commands.rs"
+symbol = "configure_store auth_status_reports_no_token_for_a_fresh_environment key_lifecycle_metadata_persists_in_configuration"
+observed = "Working-tree CLI strict all-target Clippy exits 0 in qual-logs/au19/cli-clippy-recheck.log. cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-cli exits 101 in qual-logs/au19/cli-test.log: 37 unit tests pass; commands.rs passes 16 tests and fails auth_status_reports_no_token_for_a_fresh_environment and key_lifecycle_metadata_persists_in_configuration because the default binary refuses the test harness credential-store override. Later integration targets do not execute. The harness requests the mock store while configure_store permits that override only behind test-credential-store. The lint repair leaves both that refusal and the existing assertions intact."
+assumption = "CLI source remains uncommitted because its required default-feature test gate does not pass. Enabling the mock credential-store feature or changing the production refusal is not a qualifying repair. Real credential-store test infrastructure requires separate scope. The exact touched source paths are listed in qual-logs/au19/cli-files.txt; all command attempts, exit codes and log paths are in qual-logs/au19/results.jsonl."
+severity = "blocker"
+
+[observation.5.2.platform-lint-registry-only-error-boundary]
+task = "5.2"
+file = "platform/hosted/registry/src/auth.rs platform/hosted/registry/src/builder.rs platform/hosted/registry/src/node_state.rs platform/hosted/registry/src/program_state.rs platform/hosted/registry/src/routes.rs platform/Makefile.inc"
+symbol = "platform-lint"
+observed = "make platform-lint exits 2 at platform/Makefile.inc:106 after workspace all-target Clippy exits 101. All 23 emitted errors are in the excluded registry library: unused_mut, dead_code, missing_errors_doc, too_many_arguments, needless_pass_by_value, suspicious_open_options and too_many_lines. Programs runtime and sandbox dependencies also emit nonfatal private-interface, unused-variable and dead-code warnings. Evidence: qual-logs/au19/platform-lint-registry-boundary.log. The workspace policy command, marketplace guest Clippy, dependency-policy script and cargo-deny stages do not execute."
+assumption = "This result includes uncommitted CLI lint repairs whose default-feature tests remain blocked as separately recorded. The pushed source does not include those CLI repairs and is not claimed to reach the same registry-only error boundary. Registry source and its retained stash are unchanged; its test import remains a separately deferred dependency. No assertion, bound, validation, authorization, encoding, tracing or lint policy is relaxed."
+severity = "blocker"
+
+[observation.5.2.platform-remaining-crate-lint-gates]
+task = "5.2"
+file = "platform/hosted/testnet/src/lib.rs platform/hosted/dashboard/src/gateway.rs platform/hosted/dashboard/src/model.rs platform/hosted/dashboard/src/service.rs platform/hosted/dashboard/src/main.rs platform/ramps/reference/src/main.rs"
+symbol = "TestnetConfig::validate Dashboard Store route build_state"
+observed = "For layerx-platform-testnet, layerx-platform-dashboard and layerx-reference-ramp, cargo clippy --locked --manifest-path platform/Cargo.toml -p PACKAGE --all-targets -- -D warnings and cargo test --locked --manifest-path platform/Cargo.toml -p PACKAGE each exit 0. Testnet passes nine tests, dashboard discovers zero tests and reference ramp passes one connection-bound test. Touched-file rustfmt checks exit 0. Exact commands, exits and log paths are in qual-logs/au19/results.jsonl, with testnet-clippy.log, testnet-test.log, dashboard-clippy-final.log, dashboard-test.log, ramp-clippy-final.log and ramp-test.log as the final crate evidence."
+assumption = "These focused gates do not establish passing aggregate platform lint or deployment qualification. Error documentation follows existing failure branches; expression, borrowing and helper extraction repairs preserve existing runtime checks. No manifest, lockfile or task status is changed."
+severity = "note"


### PR DESCRIPTION
Repairs strict lint findings in testnet, dashboard and the reference ramp while preserving existing validation, authorization, encodings, bounds and tracing. Each crate has its own commit and passing required Clippy, cargo test and touched-file rustfmt checks.

- `9bae5227`: testnet validation error documentation; nine tests passed.
- `c4bb89ad`: dashboard error documentation, must-use accessors, equivalent serialization and borrow repairs; cargo test passed with zero tests discovered.
- `819c4ed5`: reference ramp handler/configuration extraction and equivalent borrow/map-entry repairs; one connection-bound test passed. Includes appended technical blocker observations.

CLI repairs remain **uncommitted in /root/lx-lanes/authority**, outside this PR. Strict CLI Clippy and touched-file formatting pass, but the exact required default-feature cargo test exits 101: 37 unit tests and 16 command tests pass; two command tests fail because their existing mock-store override is refused by the default binary. Later integration targets did not execute. No mock feature was enabled and no assertion or refusal was changed. Paths: `qual-logs/au19/cli-files.txt`.

The final `make platform-lint` run, **including that uncommitted CLI work**, exits 2 at workspace all-target Clippy with 23 errors exclusively in the excluded registry library. Programs dependencies retain nonfatal warnings. Workspace policy, marketplace guest Clippy, dependency policy and cargo-deny stages did not execute. The pushed PR alone does not claim this registry-only error boundary. Registry and stash 32964687 remain untouched.

Rebased onto main after PR #141 landed. Only wiki files differed between the qualified pre-rebase tree and rebased commit; source equivalence passed. The normal push was rejected after history rewrite, then an explicit lease protected the branch update.

Environment: `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin`; default worktree target directory. Evidence logs are local and untracked under `qual-logs/au19/`.

Testnet commands:

- `rustfmt --edition 2021 --check platform/hosted/testnet/src/lib.rs` — exit 0; `qual-logs/au19/testnet-fmt.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-testnet --all-targets -- -D warnings` — exit 0; `qual-logs/au19/testnet-clippy.log`.
- `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-testnet` — exit 0; `qual-logs/au19/testnet-test.log`.
- `git diff --check` — exit 0; `qual-logs/au19/testnet-diff.log`.

Dashboard commands:

- `rustfmt --edition 2021 --check platform/hosted/dashboard/src/gateway.rs platform/hosted/dashboard/src/model.rs platform/hosted/dashboard/src/service.rs` — exit 1; `qual-logs/au19/dashboard-fmt.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-dashboard --all-targets -- -D warnings` — exit 101; `qual-logs/au19/dashboard-clippy.log`.
- `rustfmt --edition 2021 --check platform/hosted/dashboard/src/gateway.rs platform/hosted/dashboard/src/model.rs platform/hosted/dashboard/src/service.rs platform/hosted/dashboard/src/main.rs` — exit 0; `qual-logs/au19/dashboard-fmt-final.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-dashboard --all-targets -- -D warnings` — exit 0; `qual-logs/au19/dashboard-clippy-final.log`.
- `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-dashboard` — exit 0; `qual-logs/au19/dashboard-test.log`.
- `git diff --check` — exit 0; `qual-logs/au19/dashboard-diff.log`.

Reference ramp commands:

- `rustfmt --edition 2021 --check platform/ramps/reference/src/main.rs` — exit 0; `qual-logs/au19/ramp-fmt.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-reference-ramp --all-targets -- -D warnings` — exit 101; `qual-logs/au19/ramp-clippy.log`.
- `rustfmt --edition 2021 --check platform/ramps/reference/src/main.rs` — exit 0; `qual-logs/au19/ramp-fmt-final.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-reference-ramp --all-targets -- -D warnings` — exit 0; `qual-logs/au19/ramp-clippy-final.log`.
- `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-reference-ramp` — exit 0; `qual-logs/au19/ramp-test.log`.
- `git commit -m 'Refactor reference ramp handlers and pass strict Clippy and tests' -m 'Co-Authored-By: Codex <noreply@openai.com>'` — exit 0; `qual-logs/au19/ramp-commit.log`.

Uncommitted CLI commands:

- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-cli --all-targets -- -D warnings` — exit 101; `qual-logs/au19/cli-clippy.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-cli --all-targets -- -D warnings` — exit 101; `qual-logs/au19/cli-clippy-final.log`.
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-cli --all-targets -- -D warnings` — exit 0; `qual-logs/au19/cli-clippy-recheck.log`.
- `rustfmt --edition 2021 --config skip_children=true --check platform/cli/src/a2a.rs platform/cli/src/credential.rs platform/cli/src/emulator.rs platform/cli/src/http.rs platform/cli/src/install/a2a.rs platform/cli/src/install/mcp.rs platform/cli/src/install/mod.rs platform/cli/src/main.rs platform/cli/src/programs.rs platform/cli/src/workspace.rs platform/cli/tests/commands.rs platform/cli/tests/credential.rs platform/cli/tests/emulator.rs platform/cli/tests/workspace.rs` — exit 0; `qual-logs/au19/cli-fmt-final.log`.
- `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-cli` — exit 101; `qual-logs/au19/cli-test.log`.

Aggregate and publication commands:

- `cg spec lint` — exit 0; `qual-logs/au19/spec-lint.log`.
- `cortex_guard` — exit 127; `qual-logs/au19/cortex-guard.log`.
- `make platform-lint` — exit 2; `qual-logs/au19/platform-lint.log`.
- `git diff --check` — exit 0; `qual-logs/au19/diff-final.log`.
- `cg spec lint` — exit 0; `qual-logs/au19/spec-lint-final.log`.
- `make platform-lint` — exit 2; `qual-logs/au19/platform-lint-final.log`.
- `make platform-lint` — exit 2; `qual-logs/au19/platform-lint-registry-boundary.log`.
- `git diff --check` — exit 0; `qual-logs/au19/publication-diff.log`.
- `cg spec lint` — exit 0; `qual-logs/au19/publication-spec-lint.log`.
- `git fetch origin` — exit 0; `qual-logs/au19/final-fetch.log`.
- `git rebase --autostash origin/main` — exit 0; `qual-logs/au19/final-rebase.log`.
- `git push -u origin lane/platform-lint-rest` — exit 1; `qual-logs/au19/final-push.log`.
- `git diff --exit-code ec28d3bf HEAD -- platform agent human programs interop` — exit 0; `qual-logs/au19/rebase-source-equivalence.log`.
- `git push --force-with-lease=refs/heads/lane/platform-lint-rest:56b5fc1ada7858464bfe60afef1738d9a5d37c25 -u origin lane/platform-lint-rest` — exit 0; `qual-logs/au19/final-push-lease.log`.

`cg spec lint` reports zero errors and nine pre-existing missing-path warnings. `cortex_guard` is unavailable (exit 127); no guard success is claimed.

🤖 Generated with Codex
