### PR TITLE
Document the hosted faucet, testnet control, node and agent boundary services

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -71,6 +71,8 @@ See `docs/MONOREPO.md` for build boundaries, workflow naming, and tag convention
 - [Hosted identity](HostedIdentity.md)
 - [Hosted faucet](HostedFaucet.md)
 - [Hosted testnet control](HostedTestnetControl.md)
+- [Hosted node](HostedNode.md)
+- [Hosted agent boundary](HostedAgentBoundary.md)
 - [Paxeer boundary](PaxeerBoundary.md)
 
 ---

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -69,6 +69,8 @@ See `docs/MONOREPO.md` for build boundaries, workflow naming, and tag convention
 - [Hosted registry](HostedRegistry.md)
 - [Hosted internal](HostedInternal.md)
 - [Hosted identity](HostedIdentity.md)
+- [Hosted faucet](HostedFaucet.md)
+- [Hosted testnet control](HostedTestnetControl.md)
 - [Paxeer boundary](PaxeerBoundary.md)
 
 ---

--- a/docs/wiki/HostedAgentBoundary.md
+++ b/docs/wiki/HostedAgentBoundary.md
@@ -1,0 +1,455 @@
+# Hosted agent boundary
+
+`layerx-agent-boundary` is the TLS HTTP surface that submits
+signed activities onto the node LNI and serves receipts to the
+gateway, program registry, and webhooks
+(`platform/hosted/agent-boundary/Cargo.toml:2`;
+`platform/hosted/agent-boundary/Cargo.toml:8-10`;
+`platform/hosted/agent-boundary/src/main.rs:39`). The crate is
+`layerx-platform-agent-boundary`; the binary path is
+`src/main.rs`. Service string `agent-boundary`
+(`platform/hosted/agent-boundary/src/main.rs:39`).
+
+The image is `ghcr.io/sidiora-labs/layerx-agent-boundary:0.1.0`,
+user `4020:4020`, entrypoint
+`/usr/local/bin/layerx-agent-boundary`
+(`platform/hosted/agent-boundary/Dockerfile:5-11`). The node
+StatefulSet runs that image as container `agent-boundary` with
+`runAsUser: 4021` and `runAsGroup: 4020`
+(`platform/hosted/node/deployment.yaml:193-196`). Those two
+identities differ. Uid `4021` is the LNI allowed uid; see
+[Hosted node](HostedNode.md).
+
+It listens on `0.0.0.0:9446`. Service
+`layerx-agent-boundary` is ClusterIP port `9443` targeting
+container port `agent-tls` (`9446`)
+(`platform/hosted/node/deployment.yaml:198`;
+`platform/hosted/node/deployment.yaml:211`;
+`platform/hosted/node/deployment.yaml:261-264`). There is no
+Ingress object for this Service. The gateway component URL is
+this Service, not the core Service
+(`platform/hosted/gateway/deployment.yaml:78`;
+[Hosted gateway](HostedGateway.md)). Qualification binds
+`LAYERX_QUALIFICATION_AGENT_URL` as that Service
+(`platform/hosted/tests/beta-cluster.sh:1136-1137`).
+
+This page covers that binary, its journal, the tests in
+`platform/hosted/agent-boundary/`, and the node-pod wiring.
+It does not document [Agentd](Agentd.md) itself.
+
+---
+
+## TLS
+
+Inbound TLS is rustls. The certificate is
+`LAYERX_AGENT_BOUNDARY_TLS_CERT_DER`; the PKCS#8 key is
+`LAYERX_AGENT_BOUNDARY_TLS_KEY_DER`
+(`platform/hosted/agent-boundary/src/main.rs:334-341`). When
+`LAYERX_AGENT_BOUNDARY_CLIENT_CA_DER` is set, a presented
+client certificate must chain to it; the verifier is built
+with `allow_unauthenticated`
+(`platform/hosted/agent-boundary/src/main.rs:343-357`). When
+unset, the listener uses no client authentication
+(`platform/hosted/agent-boundary/src/main.rs:359-361`). The
+node manifest always sets the CA to
+`/run/layerx/trust/ca.crt.der`
+(`platform/hosted/node/deployment.yaml:203`). A certificate
+outside that CA does not complete `/livez`
+(`platform/hosted/agent-boundary/tests/real_node.rs:2021-2032`).
+
+At most 128 connections are live; further accepts are dropped
+with no HTTP response
+(`platform/hosted/agent-boundary/src/main.rs:46`;
+`platform/hosted/agent-boundary/src/main.rs:1942-1967`).
+Request bodies are bounded at `1_048_576 + 16 KiB`; activity
+bodies at `1_048_576`
+(`platform/hosted/agent-boundary/src/main.rs:40-41`;
+`platform/hosted/agent-boundary/src/main.rs:1871`). Connect
+timeout to the node is 3s; I/O timeout is 15s
+(`platform/hosted/agent-boundary/src/main.rs:44-45`). Incoming
+headers and bodies are zeroized on drop
+(`platform/hosted/agent-boundary/src/main.rs:191-198`).
+Responses are `Content-Type: application/json`,
+`Cache-Control: no-store`, `Connection: close`
+(`platform/hosted/agent-boundary/src/main.rs:1915-1921`).
+
+---
+
+## Tokens
+
+Three inbound Bearer planes and one outbound node Bearer. The
+three inbound secrets must be pairwise distinct
+(`platform/hosted/agent-boundary/src/main.rs:430-446`).
+Comparison is length-checked and constant-time
+(`platform/hosted/agent-boundary/src/main.rs:1676-1699`).
+`GET /livez` and `GET /readyz` run before authentication
+(`platform/hosted/agent-boundary/src/main.rs:1710-1718`).
+
+| Credential | File | Plane | Never |
+| --- | --- | --- | --- |
+| Gateway token | `LAYERX_AGENT_BOUNDARY_GATEWAY_TOKEN_FILE` | `POST /v1/activities`, program call/deploy/upgrade/wind-down/simulate, `GET /v1/receipts/{id}`, `GET /v1/programs/activities/{id}`, `GET /v1/programs/receipts/by-idempotency/{key}` (`platform/hosted/agent-boundary/src/main.rs:1741-1768`) | Relay paths or `/internal/v1/receipts/` |
+| Registry token | `LAYERX_AGENT_BOUNDARY_REGISTRY_TOKEN_FILE` | `GET` relay paths and `GET /internal/v1/receipts/{id}` (`platform/hosted/agent-boundary/src/main.rs:1720-1736`) | Gateway `/v1` writes |
+| Webhook token | `LAYERX_AGENT_BOUNDARY_WEBHOOK_TOKEN_FILE` | `GET /internal/v1/receipts/{id}` only (`platform/hosted/agent-boundary/src/main.rs:1729-1736`) | Gateway `/v1` writes and relay paths |
+| Node token | `LAYERX_AGENT_BOUNDARY_NODE_BEARER_TOKEN_FILE` | `Authorization: Bearer` to loopback program HTTP (`platform/hosted/agent-boundary/src/main.rs:1612-1616`) | Presented on the TLS listener |
+
+Missing, empty, oversized, or non-matching Bearer is `401`
+`identity_required`
+(`platform/hosted/agent-boundary/src/main.rs:1665-1700`).
+Wrong plane is `403` `entitlement_denied`
+(`platform/hosted/agent-boundary/src/main.rs:1721-1722`;
+`platform/hosted/agent-boundary/src/main.rs:1730-1731`;
+`platform/hosted/agent-boundary/src/main.rs:1760-1761`). Secret
+files are stripped of trailing CR/LF and refused when empty or
+longer than 4096 bytes
+(`platform/hosted/agent-boundary/src/main.rs:309-319`).
+Startup with a shared or missing webhook token exits `2`
+(`platform/hosted/agent-boundary/tests/real_node.rs:2443-2478`;
+`platform/hosted/agent-boundary/src/main.rs:1983-1987`).
+
+The node manifest mounts Secret
+`layerx-gateway-component-client` as the gateway token,
+`layerx-webhooks-component-client` as the webhook token, and
+`layerx-program-registry-node-client` as the registry token
+(`platform/hosted/node/deployment.yaml:204-206`;
+`platform/hosted/node/deployment.yaml:221-223`;
+`platform/hosted/node/deployment.yaml:239-241`). The node
+program token is `/run/layerx/tokens/program-token`
+(`platform/hosted/node/deployment.yaml:209`).
+
+---
+
+## Routes
+
+HTTP/1.1 only. `Transfer-Encoding` is refused. Duplicate
+headers are refused. Host is required
+(`platform/hosted/agent-boundary/src/main.rs:1839-1894`).
+Query strings are refused on `/v1` and `/internal` except the
+relay allow-list
+(`platform/hosted/agent-boundary/src/main.rs:1733-1739`).
+Malformed framing is `400` `invalid_request`
+(`platform/hosted/agent-boundary/src/main.rs:1932-1934`).
+
+| Method and path | Plane | Input | Success |
+| --- | --- | --- | --- |
+| `GET /livez` | none | none | `200` `{"status":"live","service":"agent-boundary"}` (`platform/hosted/agent-boundary/src/main.rs:1710-1711`) |
+| `GET /readyz` | none | none | readiness document below (`platform/hosted/agent-boundary/src/main.rs:1713-1714`; `platform/hosted/agent-boundary/src/main.rs:1648-1662`) |
+| `POST /v1/activities` | Gateway | `Content-Type: application/octet-stream`; `Idempotency-Key`; signed activity bytes | LNI submit then receipt (`platform/hosted/agent-boundary/src/main.rs:1764`; `platform/hosted/agent-boundary/src/main.rs:1303-1379`) |
+| `POST /v1/programs/call` | Gateway | same; Programs ordinal `3` | same; success `state` `executed` (`platform/hosted/agent-boundary/src/main.rs:133-139`; `platform/hosted/agent-boundary/src/main.rs:1765`) |
+| `POST /v1/programs/deploy` | Gateway | ordinal `1` | same (`platform/hosted/agent-boundary/src/main.rs:1766`) |
+| `POST /v1/programs/upgrade` | Gateway | ordinal `2` | same |
+| `POST /v1/programs/wind-down` | Gateway | ordinal `7` | same |
+| `POST /v1/programs/simulate` | Gateway | octet-stream Programs ordinal `3`; no idempotency key | simulation document; `committed` is `false` (`platform/hosted/agent-boundary/src/main.rs:1189-1267`; `platform/hosted/agent-boundary/src/main.rs:1769`) |
+| `GET /v1/receipts/{id}` | Gateway | 64 hex activity id | `{"result":{"activity_id","receipt"}}` (`platform/hosted/agent-boundary/src/main.rs:1382-1393`; `platform/hosted/agent-boundary/src/main.rs:1773-1774`) |
+| `GET /internal/v1/receipts/{id}` | Registry or Webhook | 64 hex | `{"activity_id","receipt"}` without the `result` wrapper (`platform/hosted/agent-boundary/src/main.rs:1389-1392`; `platform/hosted/agent-boundary/src/main.rs:1729-1736`) |
+| `GET /v1/programs/activities/{id}` | Gateway | 64 hex | completed program call plus `program_id` (`platform/hosted/agent-boundary/src/main.rs:1490-1565`; `platform/hosted/agent-boundary/src/main.rs:1775-1776`) |
+| `GET /v1/programs/receipts/by-idempotency/{key}` | Gateway | identifier ≤ 128 | node lookup then sequencer-signature check (`platform/hosted/agent-boundary/src/main.rs:1460-1487`; `platform/hosted/agent-boundary/src/main.rs:1771-1772`) |
+
+Gateway submit success is
+`{"result":{"state","activity_id","receipt","terminal_payload","call_graph"}}`
+(`platform/hosted/agent-boundary/src/main.rs:870-873`).
+`state` is `completed` for `/v1/activities` with
+`result_code == 0`, `executed` for program routes with
+`result_code == 0`, otherwise `refused`
+(`platform/hosted/agent-boundary/src/main.rs:123-131`;
+`platform/hosted/agent-boundary/src/main.rs:865-868`).
+Ordinary activities leave `terminal_payload` and `call_graph`
+empty (`platform/hosted/agent-boundary/tests/real_node.rs:1607-1615`).
+
+Indeterminate submit is `202`
+`{"state":"unknown","activity_id":…,"retry":"after","retry_after_seconds":2}`
+(`platform/hosted/agent-boundary/src/main.rs:880-887`;
+`platform/hosted/agent-boundary/src/main.rs:1173-1184`). That
+is not a verified success.
+
+Simulation success
+(`platform/hosted/agent-boundary/src/main.rs:1275-1300`):
+
+```
+{"result":{"committed":false,"execution":{state,activity_id,program_id,result_code,receipt,terminal_payload,call_graph},"simulation_evidence":{boundary_id,activity_id,previous_state_root,hypothetical_state_root,observed_sequence,observed_at,committed:false,public_key,signature}}}
+```
+
+`execution.state` is `simulated` when `result_code == 0`, else
+`refused` (`platform/hosted/agent-boundary/src/main.rs:1261-1264`).
+
+---
+
+## Relay paths
+
+Registry `GET` only. The path and query must match exactly
+(`platform/hosted/agent-boundary/src/main.rs:1568-1596`;
+`platform/hosted/agent-boundary/src/main.rs:1720-1727`). The
+response status and body are the node document unchanged
+(`platform/hosted/agent-boundary/src/main.rs:1602-1645`;
+`platform/hosted/agent-boundary/tests/real_node.rs:1983-2003`).
+
+| Path | Query |
+| --- | --- |
+| `/v1/protocol/account-state/head` | none |
+| `/v1/receipts/{64 hex}/account-state` | none |
+| `/v1/programs/account-state/changes` | `after_sequence=` decimal |
+| `/v1/programs/{64 hex}/account-state` | `at=` decimal |
+| `/v1/batches/{64 hex}/receipt-authority` | `receipt_digest=` 64 hex |
+
+Any other query or identifier is `404` `not_found`
+(`platform/hosted/agent-boundary/tests/real_node.rs:2007-2015`).
+Gateway Bearer on a relay path is `403` `entitlement_denied`
+(`platform/hosted/agent-boundary/src/main.rs:1721-1722`). Node
+connect/I/O failure is `503` `node_unavailable`; a non-HTTP/1.1
+or non-UTF-8 node reply is `503` `node_invalid`
+(`platform/hosted/agent-boundary/src/main.rs:1604-1639`). Relay
+body bound is 4 MiB
+(`platform/hosted/agent-boundary/src/main.rs:42`).
+
+These relay targets are the program listener on
+[Hosted node](HostedNode.md), not [Hosted core](HostedCore.md)
+and not [Hosted authority](HostedAuthority.md). The
+receipt-authority TLS Service is a separate container in the
+same pod. The node does not expose this listener through
+[Paxeer boundary](PaxeerBoundary.md).
+`LAYERX_AGENT_BOUNDARY_NODE_URL` must be
+`http://127.0.0.1:<port>`
+(`platform/hosted/agent-boundary/src/main.rs:410-422`). The
+manifest sets `http://127.0.0.1:9401`
+(`platform/hosted/node/deployment.yaml:208`).
+
+---
+
+## Submit, journal, and receipts
+
+`decode_activity` requires a canonical signed envelope for the
+configured module registry, protocol
+`STATE_COMMITMENT_PROTOCOL_VERSION`, and
+`LAYERX_AGENT_BOUNDARY_PROTOCOL_NETWORK_ID`
+(`platform/hosted/agent-boundary/src/main.rs:765-776`).
+Authority must be 32 bytes
+(`platform/hosted/agent-boundary/src/main.rs:777-780`). A
+program route that does not match module Programs and the
+route ordinal is `400` `not_program_call` or
+`wrong_program_operation`
+(`platform/hosted/agent-boundary/src/main.rs:785-797`).
+Deploy/upgrade require Wasm magic `\0asm\x01\0\0\0` and
+SHA-256 of the Wasm equal to `new_hash`
+(`platform/hosted/agent-boundary/src/main.rs:817-842`).
+
+LNI connect uses interface `Version::V1_4`, the built protocol
+version, and the configured network id, and requires
+capabilities `NodeInfo`, `Submit`, and `ReceiptLookup`
+(`platform/hosted/agent-boundary/src/main.rs:511-531`). Frame
+limit is `1_212_416` bytes
+(`platform/hosted/agent-boundary/src/main.rs:47`;
+`platform/hosted/agent-boundary/src/main.rs:501-508`). Submit
+maps `SubmitError` (`platform/hosted/agent-boundary/src/main.rs:669-701`):
+
+| `SubmitError` | HTTP |
+| --- | --- |
+| `CoreRefusal` | `409` if retriable, `422` if terminal, code from `ResultCode` (`platform/hosted/agent-boundary/src/main.rs:626-642`; `platform/hosted/agent-boundary/src/main.rs:681-682`) |
+| `Wire` / `Envelope` | `400` `malformed_activity` |
+| `SignatureLength` / `Signature` | `422` `bad_signature` |
+| `ProtocolVersion` | `422` `version_unsupported` |
+| `Network` | `422` `wrong_network` |
+| `UnavailableCapability` | `503` `node_unavailable` |
+| `Disconnected` | `503` `node_transport_lost` on lookup; `202` unknown on submit (`platform/hosted/agent-boundary/src/main.rs:699-700`; `platform/hosted/agent-boundary/src/main.rs:1184`) |
+
+Receipt lookup is LNI tag `5` / `6`; empty payload is Absent
+(`platform/hosted/agent-boundary/src/main.rs:50-52`;
+`platform/hosted/agent-boundary/src/main.rs:563-603`). Present
+receipts are sequencer-signed protocol receipts whose activity
+id matches (`platform/hosted/agent-boundary/src/main.rs:605-623`).
+Poll interval is 50 ms until `LAYERX_AGENT_BOUNDARY_RECEIPT_WAIT_MS`
+(`platform/hosted/agent-boundary/src/main.rs:49`;
+`platform/hosted/agent-boundary/src/main.rs:1096-1108`).
+
+Idempotency key is required, identifier ≤ 128
+(`[A-Za-z0-9_-.:]`)
+(`platform/hosted/agent-boundary/src/main.rs:286-292`;
+`platform/hosted/agent-boundary/src/main.rs:1310-1314`). The
+journal file is `STATE_DIR/journal/{sha256(key)}.json`; the
+activity index is `STATE_DIR/activities/{activity_id}`
+(`platform/hosted/agent-boundary/src/main.rs:705-714`;
+`platform/hosted/agent-boundary/src/main.rs:475-476`). Same
+digest and route replay the stored outcome; a different
+digest or route is `409` `idempotency_conflict`
+(`platform/hosted/agent-boundary/src/main.rs:1328-1337`).
+Writes are temp file, `sync_all`, `rename`, directory
+`sync_all` (`platform/hosted/agent-boundary/src/main.rs:716-734`).
+
+Program CALL additionally fetches replica evidence and node
+artifacts, then `artifacts::verify`
+(`platform/hosted/agent-boundary/src/main.rs:890-955`;
+`platform/hosted/agent-boundary/src/artifacts.rs:105-166`).
+Lifecycle deploy/upgrade/wind-down bind protocol 3, module 9
+version 4, operation 0, and absent program outcome
+(`platform/hosted/agent-boundary/src/main.rs:958-993`).
+
+---
+
+## Config keys
+
+| Key | Role |
+| --- | --- |
+| `LAYERX_AGENT_BOUNDARY_LISTEN` | Bind address; default `0.0.0.0:9446` (`platform/hosted/agent-boundary/src/main.rs:426-428`; `platform/hosted/node/deployment.yaml:198`) |
+| `LAYERX_AGENT_BOUNDARY_TLS_CERT_DER` | Inbound server certificate DER; manifest `/run/layerx/agent-tls/server.crt.der` |
+| `LAYERX_AGENT_BOUNDARY_TLS_KEY_DER` | Inbound PKCS#8 key DER; manifest `/run/layerx/agent-tls/server.key.der` |
+| `LAYERX_AGENT_BOUNDARY_CLIENT_CA_DER` | Optional client CA DER; manifest `/run/layerx/trust/ca.crt.der` |
+| `LAYERX_AGENT_BOUNDARY_GATEWAY_TOKEN_FILE` | Gateway Bearer |
+| `LAYERX_AGENT_BOUNDARY_REGISTRY_TOKEN_FILE` | Registry Bearer |
+| `LAYERX_AGENT_BOUNDARY_WEBHOOK_TOKEN_FILE` | Webhook Bearer |
+| `LAYERX_AGENT_BOUNDARY_LNI_SOCKET` | Unix socket to `layerxd` LNI; manifest `/run/layerx/node/layerxd.lni.sock` (`platform/hosted/node/deployment.yaml:207`) |
+| `LAYERX_AGENT_BOUNDARY_LNI_DEADLINE_MS` | LNI deadline `1..=60000`; default `10000` (`platform/hosted/agent-boundary/src/main.rs:451-454`) |
+| `LAYERX_AGENT_BOUNDARY_RECEIPT_WAIT_MS` | Receipt poll `1..=60000`; default `5000` (`platform/hosted/agent-boundary/src/main.rs:455-458`) |
+| `LAYERX_AGENT_BOUNDARY_PROTOCOL_NETWORK_ID` | Non-zero `u32` protocol network id (`platform/hosted/agent-boundary/src/main.rs:459-465`) |
+| `LAYERX_AGENT_BOUNDARY_NETWORK_ID` | Canonical network name ≤ 64 (`platform/hosted/agent-boundary/src/main.rs:466-470`) |
+| `LAYERX_AGENT_BOUNDARY_NODE_URL` | Loopback `http://127.0.0.1:<port>` |
+| `LAYERX_AGENT_BOUNDARY_NODE_BEARER_TOKEN_FILE` | Bearer for node HTTP |
+| `LAYERX_AGENT_BOUNDARY_STATE_DIR` | Creates `journal/` and `activities/`; manifest `/var/lib/layerx/agent-boundary` (`platform/hosted/agent-boundary/src/main.rs:471-476`; `platform/hosted/node/deployment.yaml:210`) |
+| `LAYERX_AGENT_BOUNDARY_MODULE_REGISTRY_FILE` | Optional JSON `{modules:[{module,ordinals}]}`; default modules `1..=9` with ordinals `1..=16` (`platform/hosted/agent-boundary/src/main.rs:367-407`) |
+
+The testnet pod pins
+`LAYERX_AGENT_BOUNDARY_NETWORK_ID` from ConfigMap
+`network-name` (`layerx-testnet`) and
+`LAYERX_AGENT_BOUNDARY_PROTOCOL_NETWORK_ID` from `network-id`
+(`402`) (`platform/hosted/node/deployment.yaml:199-200`).
+
+---
+
+## Callers the NetworkPolicy admits
+
+Node ingress admits TCP `9446` from `app=layerx-gateway`,
+`app=layerx-program-registry`, namespace `layerx-developer`
+`app=layerx-webhooks`, and namespace `layerx-developer`
+`app=layerx-dashboard-api`
+(`platform/hosted/node/deployment.yaml:275-284`).
+`app=layerx-testnet-control` is admitted on `9443`/`9444`/`9445`
+and not on `9446`
+(`platform/hosted/node/deployment.yaml:273-274`). Those two
+port sets differ.
+
+---
+
+## Typed refusals
+
+HTTP envelope `{ "error": { "code": …, "retry": "never"|"after", … } }`
+(`platform/hosted/agent-boundary/src/main.rs:1793-1807`).
+
+| HTTP | Code | Condition |
+| --- | --- | --- |
+| 400 | `invalid_request` | Framing, Host, or request line failed (`platform/hosted/agent-boundary/src/main.rs:1932-1934`) |
+| 400 | `content_type_required` | Submit/simulate without `application/octet-stream` (`platform/hosted/agent-boundary/src/main.rs:1190-1191`; `platform/hosted/agent-boundary/src/main.rs:1304-1305`) |
+| 400 | `invalid_activity_length` | Empty or > 1 MiB body (`platform/hosted/agent-boundary/src/main.rs:1193-1194`; `platform/hosted/agent-boundary/src/main.rs:1307-1308`) |
+| 400 | `idempotency_key_required` | Missing `Idempotency-Key` on submit (`platform/hosted/agent-boundary/src/main.rs:1310-1311`) |
+| 400 | `invalid_idempotency_key` | Key fails `valid_identifier` (`platform/hosted/agent-boundary/src/main.rs:1313-1314`; `platform/hosted/agent-boundary/src/main.rs:1461-1462`) |
+| 400 | `malformed_activity` | Signed decode failed (`platform/hosted/agent-boundary/src/main.rs:766-767`) |
+| 400 | `non_canonical_activity` | Re-encode ≠ body (`platform/hosted/agent-boundary/src/main.rs:768-769`) |
+| 400 | `not_program_call` | Call route is not Programs ordinal 3 (`platform/hosted/agent-boundary/src/main.rs:789-796`) |
+| 400 | `wrong_program_operation` | Lifecycle route ordinal mismatch (`platform/hosted/agent-boundary/src/main.rs:794`) |
+| 400 | `malformed_program_call` | `NativeProgramCall::decode` failed (`platform/hosted/agent-boundary/src/main.rs:804-805`) |
+| 400 | `malformed_program_deploy` / `malformed_program_upgrade` / `malformed_program_wind_down` | Lifecycle payload decode failed (`platform/hosted/agent-boundary/src/main.rs:820-832`) |
+| 400 | `malformed_program_wasm` | Wasm magic mismatch (`platform/hosted/agent-boundary/src/main.rs:836-837`) |
+| 400 | `program_payload_hash_mismatch` | SHA-256(Wasm) ≠ `new_hash` (`platform/hosted/agent-boundary/src/main.rs:839-841`) |
+| 400 | `invalid_activity_id` | Path id is not 64 hex (`platform/hosted/agent-boundary/src/main.rs:1383-1384`; `platform/hosted/agent-boundary/src/main.rs:1491-1492`) |
+| 401 | `identity_required` | Missing/wrong Bearer (`platform/hosted/agent-boundary/src/main.rs:1671`; `platform/hosted/agent-boundary/src/main.rs:1700`) |
+| 403 | `entitlement_denied` | Token plane does not own the path (`platform/hosted/agent-boundary/src/main.rs:1721-1722`; `platform/hosted/agent-boundary/src/main.rs:1760-1761`) |
+| 404 | `not_found` | Unknown path, query on a non-relay route, or non-GET on a GET route (`platform/hosted/agent-boundary/src/main.rs:1724-1725`; `platform/hosted/agent-boundary/src/main.rs:1738-1739`; `platform/hosted/agent-boundary/src/main.rs:1781`) |
+| 404 | `receipt_not_found` | LNI Absent, node 404, or unknown non-hex32 idempotency key (`platform/hosted/agent-boundary/src/main.rs:1395`; `platform/hosted/agent-boundary/src/main.rs:1424-1425`; `platform/hosted/agent-boundary/src/main.rs:1473-1474`) |
+| 404 | `activity_not_journaled` | No activity index (`platform/hosted/agent-boundary/src/main.rs:1497-1498`) |
+| 409 | `idempotency_conflict` | Same key, different digest or route (`platform/hosted/agent-boundary/src/main.rs:1336-1337`) |
+| 409 / 422 | `ResultCode` snake_case | LNI `CoreRefusal`; 409 with retry 5 if retriable, 422 if terminal (`platform/hosted/agent-boundary/src/main.rs:626-642`) |
+| 422 | `version_unsupported` | Protocol version mismatch (`platform/hosted/agent-boundary/src/main.rs:771-772`; `platform/hosted/agent-boundary/src/main.rs:690-691`) |
+| 422 | `wrong_network` | Network id mismatch (`platform/hosted/agent-boundary/src/main.rs:774-775`; `platform/hosted/agent-boundary/src/main.rs:693-694`) |
+| 422 | `unsupported_authority` | Authority not 32 bytes (`platform/hosted/agent-boundary/src/main.rs:777-780`) |
+| 422 | `bad_signature` | Submit signature error (`platform/hosted/agent-boundary/src/main.rs:687-688`) |
+| 502 | `receipt_invalid` | Idempotency receipt failed sequencer/protocol bind (`platform/hosted/agent-boundary/src/main.rs:1484-1486`) |
+| 503 | `node_unavailable` | LNI or node HTTP connect/I/O (`platform/hosted/agent-boundary/src/main.rs:214-216`; `platform/hosted/agent-boundary/src/main.rs:1605`) |
+| 503 | `node_transport_lost` | LNI send/receive/correlation (`platform/hosted/agent-boundary/src/main.rs:218-220`) |
+| 503 | `node_invalid` | Node HTTP status/body invalid (`platform/hosted/agent-boundary/src/main.rs:1622-1639`) |
+| 503 | `capability_unavailable` | Simulate without `Capability::Simulate` or class 3 (`platform/hosted/agent-boundary/src/main.rs:1208-1209`; `platform/hosted/agent-boundary/src/main.rs:1227-1236`) |
+| 503 | `persistence_unavailable` | Journal I/O (`platform/hosted/agent-boundary/src/main.rs:1147-1148`) |
+| 503 | `persistence_invalid` | Journal binding mismatch (`platform/hosted/agent-boundary/src/main.rs:1342`; `platform/hosted/agent-boundary/src/main.rs:1401-1402`) |
+| 503 | `program_artifacts_unavailable` | Replica or artifact HTTP not 200 (`platform/hosted/agent-boundary/src/main.rs:907-908`; `platform/hosted/agent-boundary/src/main.rs:930-931`) |
+| 503 | `program_artifacts_invalid` | Artifact verify failed (`platform/hosted/agent-boundary/src/main.rs:897`; `platform/hosted/agent-boundary/src/main.rs:1044-1046`) |
+| 503 | `lifecycle_receipt_invalid` | Lifecycle receipt bind failed (`platform/hosted/agent-boundary/src/main.rs:1000-1002`; `platform/hosted/agent-boundary/src/main.rs:1086-1087`) |
+| 503 | `receipt_unavailable` | Idempotency node status not 200/404 (`platform/hosted/agent-boundary/src/main.rs:1476-1482`) |
+
+---
+
+## Readiness
+
+`GET /livez` does not contact the node
+(`platform/hosted/agent-boundary/src/main.rs:1710-1711`).
+`GET /readyz` is ready only when LNI handshake succeeds and
+TCP to `127.0.0.1:{node.port}` connects. Success is `200`
+
+`{"ready":true,"network_id":"<LAYERX_AGENT_BOUNDARY_NETWORK_ID>","wire_version":"<handshake protocol>","synchronous_receipts":true,"state_snapshot":true}`
+
+(`platform/hosted/agent-boundary/src/main.rs:1648-1662`).
+Handshake or TCP failure is `503` `node_unavailable` retry 5.
+HTTPS probes are `/readyz` period 5s and `/livez` period 15s
+on `agent-tls` (`platform/hosted/node/deployment.yaml:212-213`).
+After sequencer loss, `/readyz` is `503` and `/livez` is `200`
+(`platform/hosted/agent-boundary/tests/real_node.rs:2151-2193`).
+
+The gateway `/readyz` component probe labels this surface
+`core_agent_boundary` and requires this JSON plus matching
+`network_id` and `wire_version`
+([Hosted gateway](HostedGateway.md);
+`platform/hosted/gateway/src/main.rs:2805`).
+
+---
+
+## Tests
+
+`make platform-test-agent-boundary` runs
+`cargo test --offline --manifest-path platform/Cargo.toml --locked -p layerx-platform-agent-boundary`
+(`platform/Makefile.inc:150-151`).
+`platform-test-trusted-boundary` depends on that target
+(`platform/Makefile.inc:159`).
+
+Portable crate tests:
+
+| Test | Proves |
+| --- | --- |
+| `native_c_lifecycle_vectors_are_admitted` | Deploy/upgrade/wind-down fixtures decode; a trailing byte is refused (`platform/hosted/agent-boundary/src/lifecycle_tests.rs:18-39`) |
+| `lifecycle_code_hash_substitution_refuses_before_submit` | Flipped hash is `400` `program_payload_hash_mismatch`; reserved-field flip is `malformed_program_*` (`platform/hosted/agent-boundary/src/lifecycle_tests.rs:42-59`) |
+| `idempotency_receipts_require_signed_activity_and_sequencer_bindings` | Idempotency receipt JSON binds activity id and sequencer key (`platform/hosted/agent-boundary/src/lifecycle_tests.rs:62-80`) |
+| `historical_native_evidence_retains_identity_and_root_checks` | Historical batch evidence binds batch id and state roots; wrong key or network is refused (`platform/hosted/agent-boundary/src/artifacts.rs:267-335`) |
+| `maintained_signed_evidence_authenticates_activity_identity_and_refuses_substitution` | Occupancy-maintenance evidence; historical kind, swapped proof, or flipped receipt is refused (`platform/hosted/agent-boundary/src/artifacts.rs:338-410`) |
+| `artifact_documents_reject_identity_substitution_partial_pairs_and_noncanonical_hex` | Artifact JSON identity, partial payload/graph, and uppercase hex (`platform/hosted/agent-boundary/src/artifacts.rs:413-426`) |
+
+`tests/real_node.rs` drives the real `layerx-agent-boundary`
+binary over TLS against a real `layerxd` sequencer and
+`layerxd --authority-replica` from `build/bin`
+(`platform/hosted/agent-boundary/tests/real_node.rs:1-3`):
+
+- `real_node_boundary_serves_the_component_contract`: `/livez`
+  and `/readyz`; entitlements; SEND submit/replay/conflict;
+  receipt routes; program-route mismatch; typed refusals
+  (`unknown_did`, `bad_signature`, `malformed_activity`,
+  `content_type_required`, `idempotency_key_required`,
+  `invalid_idempotency_key`); registry relays equal the
+  daemon document; client-certificate CA pin; journal replay
+  after process restart; daemon loss keeps `/livez` 200
+  (`platform/hosted/agent-boundary/tests/real_node.rs:2035-2101`)
+- `persisted_submission_attempt_is_not_repeated_after_connectivity_returns`:
+  LNI denied is `503` `node_unavailable` with `attempts=1`;
+  restore yields `202` `unknown` without a second attempt
+  (`platform/hosted/agent-boundary/tests/real_node.rs:2104-2148`)
+- `real_program_simulation_executes_without_committing`:
+  `committed: false`; simulated activity is not journaled;
+  later commit then simulate is `422` `idempotent_replay`
+  (`platform/hosted/agent-boundary/tests/real_node.rs:1813-1910`)
+- `malformed_program_call_is_refused_before_a_following_send`:
+  `400` `malformed_program_call` then a SEND still completes
+  (`platform/hosted/agent-boundary/tests/real_node.rs:2276-2293`)
+- `real_program_call_refusal_artifacts_are_bound_and_replay_after_restart`:
+  refused CALL artifacts verify and replay after restart
+  (`platform/hosted/agent-boundary/tests/real_node.rs:2296-2301`)
+- `webhook_credential_configuration_refuses_shared_or_invalid_material`:
+  shared or empty/oversize webhook token refuses boot
+  (`platform/hosted/agent-boundary/tests/real_node.rs:2442-2503`)
+- `real_escrow_deploy_call_upgrade_deprecate_exit_receipts_and_durable_dedup`:
+  real deploy/call/upgrade/wind-down against a funded node,
+  idempotent replay, registry denied on gateway paths
+  (`platform/hosted/agent-boundary/tests/real_node/lifecycle.rs:593-628`)
+- `maintained_program_journal_rejects_missing_corrupt_and_substituted_attachments`:
+  journal artifact tamper is `503` `program_artifacts_invalid`
+  (`platform/hosted/agent-boundary/tests/real_node/custody.rs:872-896`)

--- a/docs/wiki/HostedFaucet.md
+++ b/docs/wiki/HostedFaucet.md
@@ -1,0 +1,402 @@
+# Hosted faucet
+
+`layerx-faucet` is the public claim surface for hosted testnet funds
+(`platform/hosted/faucet/Cargo.toml:8-10`;
+`platform/hosted/faucet/src/main.rs:914`). The crate is
+`layerx-platform-faucet`; the binary path is `src/main.rs`. A
+developer or agent with a hosted session Bearer posts
+`POST /v1/faucet/claims` and receives either a funded body or a typed
+refusal. There is no `layerx faucet` command
+(`platform/cli/src/main.rs:43-81`; `docs/wiki/Quickstart.md`).
+
+The image is `ghcr.io/sidiora-labs/layerx-faucet:0.1.0`, user
+`4020:4020`, entrypoint `/usr/local/bin/layerx-faucet`
+(`platform/hosted/faucet/Dockerfile:5-11`;
+`platform/hosted/testnet/deployment.yaml:138`;
+`platform/hosted/tests/beta-cluster.sh:116`). There is no
+`platform/hosted/faucet/deployment.yaml`. The Deployment, Redis,
+Service, and NetworkPolicy live in
+`platform/hosted/testnet/deployment.yaml`.
+
+The Deployment has three replicas, listens on `0.0.0.0:9443`, and
+exposes Service `layerx-faucet-public` port `443` to container `9443`
+(`platform/hosted/testnet/deployment.yaml:128-141`;
+`platform/hosted/testnet/deployment.yaml:158`;
+`platform/hosted/testnet/deployment.yaml:174-181`). That Service is
+`type: LoadBalancer` with `externalTrafficPolicy: Local`. Beta-cluster
+render appends Ingress `layerx-faucet-public` host
+`faucet.testnet.layerx.network` (override `LAYERX_BETA_FAUCET_HOST`)
+path `/` backend that Service
+(`platform/hosted/tests/beta-cluster.sh:74`;
+`platform/hosted/tests/beta-cluster.sh:837-854`). Bring-up
+port-forwards `19445:443` and exports `LAYERX_FAUCET_URL`
+(`platform/hosted/tests/beta-cluster.sh:83`;
+`platform/hosted/tests/beta-cluster.sh:1116`;
+`platform/hosted/tests/beta-cluster.sh:1260`;
+`platform/hosted/tests/beta-cluster.sh:1280`). Library
+`platform_testnet` names the same faucet origin
+`https://faucet.testnet.layerx.network`
+(`platform/hosted/testnet/src/lib.rs:77`). The source Deployment has
+no Ingress object; the cluster apply path adds one. Those two
+manifests differ.
+
+This page covers that binary, its Redis, and the claim path through
+testnet-control. It does not document treasury SEND construction.
+That path is on [Hosted core](HostedCore.md). Journey admission is on
+[Hosted testnet control](HostedTestnetControl.md). Session minting is
+on [Hosted identity](HostedIdentity.md).
+
+---
+
+## TLS
+
+Inbound TLS is rustls with no client authentication. The certificate
+is `LAYERX_FAUCET_TLS_CERT_DER`; the PKCS#8 key is
+`LAYERX_FAUCET_TLS_KEY_DER`
+(`platform/hosted/faucet/src/main.rs:217-233`). Each accepted TCP
+connection becomes a rustls `ServerConnection`
+(`platform/hosted/faucet/src/main.rs:1067-1068`). At most 128
+connections are live; further accepts are dropped without a response
+(`platform/hosted/faucet/src/main.rs:23`;
+`platform/hosted/faucet/src/main.rs:1102-1104`). Request bodies are
+bounded at 16 KiB (`platform/hosted/faucet/src/main.rs:18`;
+`platform/hosted/faucet/src/main.rs:429-430`). Query strings,
+`Transfer-Encoding`, duplicate headers, and a missing `Host` are
+refused (`platform/hosted/faucet/src/main.rs:400-403`;
+`platform/hosted/faucet/src/main.rs:444-449`).
+
+Outbound HTTPS uses `native_tls` `TlsConnector` with
+`LAYERX_OUTBOUND_CA_DER` and a minimum protocol of TLS 1.2
+(`platform/hosted/faucet/src/main.rs:327-330`). Endpoints must be
+`https://` or `rediss://` with a DNS host, not a literal IP
+(`platform/hosted/faucet/src/main.rs:34-65`). The client writes
+`Authorization: Bearer`, `Content-Type: application/json`, and
+optional `Idempotency-Key`
+(`platform/hosted/faucet/src/main.rs:336-344`). Connect timeout is 3s;
+I/O timeout is 8s (`platform/hosted/faucet/src/main.rs:20-21`).
+
+Redis is `rediss://` only, TLS 1.2, the same outbound CA, then `AUTH`
+username and password (`platform/hosted/faucet/src/main.rs:273-279`;
+`platform/hosted/faucet/src/main.rs:497-517`). The Redis server
+manifest sets `tls-auth-clients no`
+(`platform/hosted/testnet/deployment.yaml:24`). HTTPS upstreams do not
+present a client certificate.
+
+---
+
+## Tokens
+
+The faucet accepts one inbound scheme and three outbound credentials.
+It never forwards a caller session Bearer as the upstream
+`Authorization` value.
+
+| Credential | Accepted from | Used as | Never |
+| --- | --- | --- | --- |
+| `Bearer` session | `POST /v1/faucet/claims` (`platform/hosted/faucet/src/main.rs:453-487`) | JSON body `{"token": …}` to identity `POST` at `LAYERX_IDENTITY_INTROSPECTION_URL` (`platform/hosted/faucet/src/main.rs:464-476`) | Upstream `Authorization`. That header carries `LAYERX_IDENTITY_SERVICE_TOKEN_FILE` |
+| Identity service token | File `LAYERX_IDENTITY_SERVICE_TOKEN_FILE` (`platform/hosted/faucet/src/main.rs:266`; `platform/hosted/testnet/deployment.yaml:146`) | `Authorization: Bearer` to identity introspect | Presented by humans |
+| Testnet-control admin token | File `LAYERX_TESTNET_ADMIN_TOKEN_FILE` (`platform/hosted/faucet/src/main.rs:272`; `platform/hosted/testnet/deployment.yaml:148`) | `Authorization: Bearer` to `LAYERX_TESTNET_FUNDING_URL` | Presented by humans |
+| Redis username and password | `LAYERX_FAUCET_REDIS_USERNAME_FILE`, `LAYERX_FAUCET_REDIS_PASSWORD_FILE` (`platform/hosted/faucet/src/main.rs:278-279`) | Redis `AUTH` (`platform/hosted/faucet/src/main.rs:507-513`) | HTTP |
+
+`authenticate` requires prefix `Bearer `, a non-empty token of at most
+4096 bytes, identity HTTP 200, JSON `active: true`, and `sub` a
+1..=512 identifier of alnum/`-`/`_`/`.`/`:`
+(`platform/hosted/faucet/src/main.rs:180-186`;
+`platform/hosted/faucet/src/main.rs:453-487`). Identity non-200 or an
+inactive/`sub` miss is `401 identity_required`. Transport or JSON
+failure is `503 identity_unavailable`
+(`platform/hosted/faucet/src/main.rs:466-483`). Incoming headers and
+bodies are zeroized on drop
+(`platform/hosted/faucet/src/main.rs:135-141`).
+
+The hosted identity path for this caller is `/v1/introspect`, not
+`/v1/sessions/introspect`
+(`platform/hosted/testnet/deployment.yaml:145`;
+`platform/hosted/identity/src/main.rs:863`;
+`docs/wiki/HostedIdentity.md`). The faucet response shape is
+`SubjectShape` `active` plus `sub`
+(`platform/hosted/identity/src/main.rs:131-134`;
+`platform/hosted/identity/src/main.rs:637-650`;
+`platform/hosted/faucet/src/main.rs:106-110`). Bring-up copies
+`identity-client.token` to `identity-tokens/faucet`
+(`platform/hosted/tests/beta-cluster.sh:528`).
+
+---
+
+## Public routes
+
+Unauthenticated probes are dispatched before the claim route
+(`platform/hosted/faucet/src/main.rs:902-915`). HTTP/1.1 only.
+
+| Method and path | Inputs | Result |
+| --- | --- | --- |
+| `GET /livez` | none | `200` `{"status":"live","service":"faucet"}` (`platform/hosted/faucet/src/main.rs:903-904`) |
+| `GET /readyz` | none | Redis `PING` `PONG` → `200` `{"status":"ready","service":"faucet"}`; else `503 dependency_unavailable` (`platform/hosted/faucet/src/main.rs:906-912`) |
+| `POST /v1/faucet/claims` | `Authorization: Bearer`, `Idempotency-Key`, `Content-Type: application/json`, JSON `did` and `public_key` only (`platform/hosted/faucet/src/main.rs:99-104`; `platform/hosted/faucet/src/main.rs:914-954`) | `200` funded body, `202` `still_checking`, or a typed refusal |
+
+Unknown method or path is `404 not_found`
+(`platform/hosted/faucet/src/main.rs:914-915`). Probe JSON does not
+wrap `ok`. Claim success is not an `{"ok": true, …}` envelope.
+
+`ClaimRequest` denies unknown fields
+(`platform/hosted/faucet/src/main.rs:99-104`). `did` must start with
+`did:` and pass `valid_identifier` at max 512
+(`platform/hosted/faucet/src/main.rs:188-190`). `public_key` is 64
+ASCII hex digits (`platform/hosted/faucet/src/main.rs:192-194`;
+`platform/hosted/faucet/src/main.rs:953-954`). `Idempotency-Key` is
+1–128 alnum/`-`/`_`/`.`/`:` (`platform/hosted/faucet/src/main.rs:180-186`;
+`platform/hosted/faucet/src/main.rs:939-943`). Those claim fields
+match [Testnet quickstart](Quickstart.md).
+
+Headers `forwarded`, `x-forwarded-for`, `x-real-ip`,
+`x-layerx-client-ip`, and `x-layerx-principal` are refused as
+`400 untrusted_identity_header` before admission
+(`platform/hosted/faucet/src/main.rs:920-926`). Network admission
+uses the TCP peer address, not a forwarded header
+(`platform/hosted/faucet/src/main.rs:625-646`;
+`platform/hosted/faucet/src/main.rs:1071`).
+
+Hosted smoke:
+
+```sh
+jq -n --arg did "$LAYERX_TEST_SOURCE_DID" --arg public_key "$LAYERX_TEST_SOURCE_PUBLIC_KEY" \
+  '{did:$did, public_key:$public_key}' > faucet-request.json
+curl --fail --silent --show-error --max-time 30 --cacert "$LAYERX_TEST_CA_FILE" \
+  --header "Authorization: Bearer $(tr -d '\r\n' < "$LAYERX_TEST_AUTH_TOKEN_FILE")" \
+  --request POST "$LAYERX_FAUCET_URL/v1/faucet/claims" \
+  --header "Idempotency-Key: faucet-quickstart-01" \
+  --header 'Content-Type: application/json' --data-binary @faucet-request.json
+```
+
+(`platform/hosted/testnet/tests/hosted-smoke.sh:101-109`;
+`docs/wiki/Quickstart.md`). Smoke asserts
+`.funded == true and .funding_id != null`
+(`platform/hosted/testnet/tests/hosted-smoke.sh:110`).
+
+---
+
+## Claim reservation and funding
+
+Quota and idempotency are one Redis `EVAL` (`RESERVE_SCRIPT`)
+(`platform/hosted/faucet/src/main.rs:649-676`;
+`platform/hosted/faucet/src/main.rs:678-768`). The request digest is
+SHA-256 over `identity`, `did`, `public_key`, and the configured
+amount, each part followed by a 0 byte
+(`platform/hosted/faucet/src/main.rs:171-178`;
+`platform/hosted/faucet/src/main.rs:956-961`). `funding_id` is
+SHA-256 over the idempotency key and that digest
+(`platform/hosted/faucet/src/main.rs:693`).
+
+| Reservation | HTTP |
+| --- | --- |
+| `Reserved` (fresh) or `Pending` (same digest, not yet `funded`) | `fund` then complete or pending (`platform/hosted/faucet/src/main.rs:974-991`) |
+| `Funded` same digest | `200` with the stored response body (`platform/hosted/faucet/src/main.rs:756-758`; `platform/hosted/faucet/src/main.rs:973`) |
+| Different digest under the same idempotency key | `409 idempotency_conflict` (`platform/hosted/faucet/src/main.rs:747-753`; `platform/hosted/faucet/src/main.rs:993`) |
+| Identity, address, or network window exceeded | `429` with code `identity_quota`, `address_quota`, or `network_quota` (`platform/hosted/faucet/src/main.rs:736-743`; `platform/hosted/faucet/src/main.rs:994-1000`) |
+
+`fund` POSTs JSON `funding_id`, `did`, `public_key`, `amount` to
+`LAYERX_TESTNET_FUNDING_URL` with the control-admin token and
+`Idempotency-Key` equal to `funding_id`
+(`platform/hosted/faucet/src/main.rs:112-118`;
+`platform/hosted/faucet/src/main.rs:861-876`;
+`platform/hosted/testnet/deployment.yaml:147`). Upstream HTTP 400–499
+is `FundingResult::Rejected`: Redis rollback, then
+`503 funding_rejected` (`platform/hosted/faucet/src/main.rs:880-881`;
+`platform/hosted/faucet/src/main.rs:983-988`). HTTP 200 with matching
+`funding_id` and `state == "funded"` becomes the public body
+(`platform/hosted/faucet/src/main.rs:889-898`). Any other status,
+transport failure, or JSON miss is `FundingResult::Unknown` → `202`
+(`platform/hosted/faucet/src/main.rs:877-884`;
+`platform/hosted/faucet/src/main.rs:990`). Complete-script failure
+after a funded upstream is also `202`
+(`platform/hosted/faucet/src/main.rs:976-980`).
+
+A 200 claim body is `funded` `true`, `funding_id`, optional
+`transaction_id`, `amount` as a decimal string of
+`LAYERX_FAUCET_CLAIM_AMOUNT` (default `1000000`), and `network`
+`layerx-testnet` (`platform/hosted/faucet/src/main.rs:239`;
+`platform/hosted/faucet/src/main.rs:892-898`). A 202 body is `state`
+`still_checking`, `retry` `after`, `retry_after_seconds` `10`
+(`platform/hosted/faucet/src/main.rs:1012-1018`). Retrying an
+indeterminate result repeats the same `funding_id`. A definite
+upstream 4xx releases the quota reservation
+(`platform/hosted/faucet/src/main.rs:778-790`;
+`platform/hosted/faucet/src/main.rs:983-985`).
+
+Faucet `did` is any `did:` identifier. Testnet-control admin requires
+the same prefix and a 64-hex `public_key`
+(`platform/hosted/testnet/src/main.rs:1235-1248`). Core fund
+additionally requires `did == did:layerx:` plus the lowercase public
+key, and refuses the treasury DID
+(`platform/hosted/core/src/main.rs:1475-1484`;
+`docs/wiki/HostedCore.md`). Those three DID checks differ. A core
+`400`/`422` returns to the faucet as rejected and is published as
+`503 funding_rejected`.
+
+The in-cluster funding URL is
+
+`https://layerx-testnet-admin.layerx-testnet.svc.cluster.local/admin/v1/testnet/fund`
+
+(`platform/hosted/testnet/deployment.yaml:147`). Identity is
+
+`https://layerx-identity.layerx-testnet.svc.cluster.local:9443/v1/introspect`
+
+(`platform/hosted/testnet/deployment.yaml:145`). Redis is
+
+`rediss://layerx-faucet-redis.layerx-testnet.svc.cluster.local:6379`
+
+(`platform/hosted/testnet/deployment.yaml:149`).
+
+---
+
+## Config keys
+
+| Key | Role |
+| --- | --- |
+| `LAYERX_FAUCET_LISTEN` | Bind address; default `0.0.0.0:9443` (`platform/hosted/faucet/src/main.rs:246-248`; `platform/hosted/testnet/deployment.yaml:141`) |
+| `LAYERX_FAUCET_TLS_CERT_DER` | Inbound server certificate DER; mounted `/run/layerx/tls/server.crt.der` |
+| `LAYERX_FAUCET_TLS_KEY_DER` | Inbound PKCS#8 key DER; mounted `/run/layerx/tls/server.key.der` |
+| `LAYERX_OUTBOUND_CA_DER` | Trust bundle for HTTPS and Redis; mounted `/run/layerx/tls/ca.crt.der` |
+| `LAYERX_IDENTITY_INTROSPECTION_URL` | Identity HTTPS origin including introspect path |
+| `LAYERX_IDENTITY_SERVICE_TOKEN_FILE` | Bearer to identity; mounted `/run/layerx/identity/token` |
+| `LAYERX_TESTNET_FUNDING_URL` | Testnet-control admin fund origin including path |
+| `LAYERX_TESTNET_ADMIN_TOKEN_FILE` | Bearer to testnet-control; mounted `/run/layerx/control-admin/token` |
+| `LAYERX_FAUCET_REDIS_URL` | `rediss://` origin |
+| `LAYERX_FAUCET_REDIS_USERNAME_FILE` | Redis ACL user; mounted `/run/layerx/redis-auth/username` |
+| `LAYERX_FAUCET_REDIS_PASSWORD_FILE` | Redis ACL password; mounted `/run/layerx/redis-auth/password` |
+| `LAYERX_FAUCET_IDENTITY_LIMIT` | Identity window cap; default `10000000` (`platform/hosted/faucet/src/main.rs:280`; `platform/hosted/testnet/deployment.yaml:152`) |
+| `LAYERX_FAUCET_ADDRESS_LIMIT` | Address window cap; default `10000000` |
+| `LAYERX_FAUCET_NETWORK_LIMIT` | Peer window cap; default `50000000` |
+| `LAYERX_FAUCET_NETWORK_REQUEST_LIMIT` | Admission count; default `60` |
+| `LAYERX_FAUCET_NETWORK_REQUEST_WINDOW_SECONDS` | Admission window; default `60` |
+| `LAYERX_FAUCET_WINDOW_SECONDS` | Quota window; default `86400` (`platform/hosted/faucet/src/main.rs:237`). The Deployment does not set this key |
+| `LAYERX_FAUCET_IDEMPOTENCY_SECONDS` | Idempotency TTL; default `604800`; must be ≥ the quota window (`platform/hosted/faucet/src/main.rs:238-244`; `platform/hosted/testnet/deployment.yaml:157`) |
+| `LAYERX_FAUCET_CLAIM_AMOUNT` | Funded amount; default `1000000`; must be positive (`platform/hosted/faucet/src/main.rs:239-244`). The Deployment does not set this key |
+
+Secret files are read, trailing CR/LF stripped, and refused when empty
+or longer than 4096 bytes (`platform/hosted/faucet/src/main.rs:196-206`).
+Volume mounts are TLS Secret `layerx-faucet-tls` at `/run/layerx/tls`,
+`layerx-testnet-identity-client` at `/run/layerx/identity`,
+`layerx-testnet-control-admin` at `/run/layerx/control-admin`, and
+`layerx-faucet-redis-client` at `/run/layerx/redis-auth`
+(`platform/hosted/testnet/deployment.yaml:163-172`).
+
+---
+
+## Redis state and ACL
+
+The faucet owns StatefulSet `layerx-faucet-redis`: Redis 8.2.1, TLS
+port 6379, `appendonly yes`, `appendfsync always`,
+`maxmemory-policy noeviction`, `protected-mode yes`, ACL file
+`/run/layerx/auth/users.acl`
+(`platform/hosted/testnet/deployment.yaml:17-29`;
+`platform/hosted/testnet/deployment.yaml:31-61`). Service
+`layerx-faucet-redis` is headless port 6379
+(`platform/hosted/testnet/deployment.yaml:63-66`). NetworkPolicy
+admits TCP 6379 only from pods `app=layerx-faucet` and
+`app=layerx-testnet-control`
+(`platform/hosted/testnet/deployment.yaml:286-294`).
+
+Cluster bring-up writes ACL `user default off` and one enabled user
+`layerx-faucet` with `~* &* +@all`
+(`platform/hosted/tests/beta-cluster.sh:481-483`;
+`platform/hosted/tests/beta-cluster.sh:501-503`).
+
+| Key | Contents |
+| --- | --- |
+| `faucet:admission:{window}:{digest}` | INCR count with EXPIRE window seconds; digest is SHA-256 of the peer (`platform/hosted/faucet/src/main.rs:618-641`) |
+| `faucet:quota:{window}:identity:{digest}` | INCRBY claim amount, EXPIRE remaining window (`platform/hosted/faucet/src/main.rs:689`; `platform/hosted/faucet/src/main.rs:668`) |
+| `faucet:quota:{window}:address:{digest}` | Same for destination public key (`platform/hosted/faucet/src/main.rs:690`) |
+| `faucet:quota:{window}:network:{digest}` | Same for TCP peer (`platform/hosted/faucet/src/main.rs:691`) |
+| `faucet:idem:{digest}` | Hash: `digest`, `state`, `funding_id`, `identity_key`, `address_key`, `network_key`, `amount`, later `response` (`platform/hosted/faucet/src/main.rs:671`; `platform/hosted/faucet/src/main.rs:773`) |
+| `faucet:audit` / `faucet:audit:head` | Hash-chained `XADD` stream (`platform/hosted/faucet/src/main.rs:664-674`; `platform/hosted/faucet/src/main.rs:696-703`) |
+
+Audit fields are `event`, `result`, optional `funding_id`, and
+`chain`. Authentication values do not enter the stream
+(`platform/hosted/faucet/src/main.rs:664-673`).
+
+---
+
+## Callers the NetworkPolicy admits
+
+`topology-check.sh` default manifests include
+`platform/hosted/testnet/deployment.yaml`
+(`platform/hosted/tests/topology-check.sh:21`;
+`platform/hosted/tests/topology-check.sh:87`). Faucet ingress admits
+TCP 9443 from `0.0.0.0/0` and `::/0`, and from pods
+`app=layerx-testnet-control`
+(`platform/hosted/testnet/deployment.yaml:296-306`). Egress is
+`layerx-plane: trusted-boundary` on 9443, `layerx-testnet-control` on
+9444, Redis 6379, and DNS 53
+(`platform/hosted/testnet/deployment.yaml:308-321`). Node ingress
+admits `app=layerx-faucet` on TCP 9443
+(`platform/hosted/node/deployment.yaml:279-280`). The faucet binary
+does not call the core URL. Those two edges differ.
+
+Identity ingress admits `app=layerx-faucet`
+(`platform/hosted/identity/deployment.yaml:57`). Testnet-control
+admin ingress admits `app=layerx-faucet` on TCP 9444
+(`platform/hosted/testnet/deployment.yaml:254-262`).
+
+Probes: Deployment `readinessProbe` HTTPS `/readyz` every 5s,
+`livenessProbe` HTTPS `/livez` every 15s
+(`platform/hosted/testnet/deployment.yaml:159-160`). Readiness is
+Redis `PING` only. Identity and testnet-control are not `/readyz`
+components (`platform/hosted/faucet/src/main.rs:906-912`).
+
+---
+
+## Typed refusals
+
+HTTP refusals use `{"error":{"code":…,"retry":…}}` and optional
+`retry_after_seconds`. `Retry-After` is set when a retry delay is
+present (`platform/hosted/faucet/src/main.rs:1021-1035`;
+`platform/hosted/faucet/src/main.rs:1049-1050`). Success and `202`
+bodies are not that envelope.
+
+| HTTP | Code | Condition |
+| --- | --- | --- |
+| 400 | `invalid_request` | Request framing failed (`platform/hosted/faucet/src/main.rs:1069-1070`) |
+| 400 | `content_type_required` | Claim `Content-Type` is not `application/json` (`platform/hosted/faucet/src/main.rs:917-918`) |
+| 400 | `untrusted_identity_header` | Forwarded IP or `x-layerx-principal` present (`platform/hosted/faucet/src/main.rs:920-926`) |
+| 400 | `idempotency_key_required` | Missing `Idempotency-Key` (`platform/hosted/faucet/src/main.rs:939-940`) |
+| 400 | `invalid_idempotency_key` | Key fails `valid_identifier` max 128 (`platform/hosted/faucet/src/main.rs:942-943`) |
+| 400 | `invalid_argument` | JSON/`did`/`public_key` rejected (`platform/hosted/faucet/src/main.rs:949-954`) |
+| 401 | `identity_required` | Missing/empty Bearer, identity non-200, inactive session, or invalid `sub` (`platform/hosted/faucet/src/main.rs:458-485`) |
+| 404 | `not_found` | Method/path is not a listed route (`platform/hosted/faucet/src/main.rs:914-915`) |
+| 409 | `idempotency_conflict` | Same key, different request digest (`platform/hosted/faucet/src/main.rs:993`) |
+| 429 | `network_request_rate` | Admission INCR exceeded (`platform/hosted/faucet/src/main.rs:930-935`) |
+| 429 | `identity_quota` | Identity window cap (`platform/hosted/faucet/src/main.rs:736-739`) |
+| 429 | `address_quota` | Address window cap |
+| 429 | `network_quota` | Peer window cap |
+| 503 | `dependency_unavailable` | `/readyz` Redis miss (`platform/hosted/faucet/src/main.rs:911`) |
+| 503 | `persistence_unavailable` | Admission or reserve Redis error (`platform/hosted/faucet/src/main.rs:937`; `platform/hosted/faucet/src/main.rs:969-970`) |
+| 503 | `identity_unavailable` | Introspect encode/transport/JSON failed (`platform/hosted/faucet/src/main.rs:466-483`) |
+| 503 | `funding_rejected` | Upstream 4xx and rollback succeeded (`platform/hosted/faucet/src/main.rs:983-985`) |
+
+`202` is not a refusal. It is `still_checking` with `Retry-After: 10`
+(`platform/hosted/faucet/src/main.rs:1012-1018`). Reason phrase for
+any unlisted status is `Service Unavailable`
+(`platform/hosted/faucet/src/main.rs:1039-1047`).
+
+---
+
+## Tests
+
+The faucet crate has no `#[cfg(test)]` module
+(`platform/hosted/faucet/src/main.rs`). `platform-test-tooling` still
+runs `cargo test -p layerx-platform-faucet`
+(`platform/Makefile.inc:118`).
+
+Hosted smoke, against a real faucet URL
+(`platform/hosted/testnet/tests/hosted-smoke.sh`):
+
+- `GET /readyz` is 200 with `status=ready` and `service=faucet`
+  (`platform/hosted/testnet/tests/hosted-smoke.sh:80-86`)
+- Funding journey is admitted, then `POST /v1/faucet/claims` with the
+  session Bearer returns `funded` true and a `funding_id`
+  (`platform/hosted/testnet/tests/hosted-smoke.sh:101-111`)
+
+`make platform-hosted-smoke` requires `LAYERX_FAUCET_URL` among its
+inputs (`platform/Makefile.inc:161-173`). `platform-test` is workspace
+`cargo test`, including `layerx-platform-faucet`
+(`platform/Makefile.inc:112-113`; `platform/Cargo.toml:7`).

--- a/docs/wiki/HostedNode.md
+++ b/docs/wiki/HostedNode.md
@@ -1,0 +1,542 @@
+# Hosted node
+
+The hosted node is the in-cluster sequencer pod. Image
+`ghcr.io/sidiora-labs/layerx-node:0.1.0` builds `layerxd`,
+`layerx-genesis-build`, and `layerxctl`, copies
+`bootstrap.sh` and `supervisor.sh`, and sets `USER 4020:4020`
+with `ENTRYPOINT` `/opt/layerx/supervisor.sh`
+(`platform/hosted/node/Dockerfile:10-11`;
+`platform/hosted/node/Dockerfile:20-27`). The binary
+`layerxd` is `cmd/layerxd/`; its CLI is `--check-config`,
+`--serve`, or `--authority-replica` plus a configuration path
+(`cmd/layerxd/lxp_daemon_cli.c:8-16`). Any other argv is
+`LXP_ERR_NON_CANONICAL`.
+
+StatefulSet `layerx-node` in `layerx-testnet` has one replica
+and headless Service `layerx-node` on port `9443`
+(`platform/hosted/node/deployment.yaml:12-21`). Pod labels are
+`app: layerx-node` and `layerx-plane: trusted-boundary`
+(`platform/hosted/node/deployment.yaml:24`). There is no Ingress
+object in that manifest.
+
+This page covers bootstrap, the supervisor, `layerxd`
+listeners, and the node StatefulSet. The colocated TLS
+boundaries are [Hosted core](HostedCore.md),
+[Hosted authority](HostedAuthority.md), and
+[Hosted agent boundary](HostedAgentBoundary.md). The loopback
+Paxeer relay is documented with [Paxeer boundary](PaxeerBoundary.md).
+
+---
+
+## Cluster shape
+
+Containers in the pod (`platform/hosted/node/deployment.yaml:28-223`):
+
+| Container | Image | Role |
+| --- | --- | --- |
+| `layerxd` | `layerx-node:0.1.0` | Sequencer supervisor: bootstrap, `layerxd --serve`, supervisor Unix socket |
+| `layerxd-authority` | `layerx-node:0.1.0` | Replica supervisor: `layerxd --authority-replica` |
+| `paxeer-relay` | `layerx-node:0.1.0` | `socat` TCP `127.0.0.1:18545` to `OPENSSL:paxeer-boundary.layerx-testnet.svc.cluster.local:9443` (`platform/hosted/node/deployment.yaml:78-90`) |
+| `core-boundary` | `layerx-core-boundary:0.1.0` | TLS core/admin planes; see [Hosted core](HostedCore.md) |
+| `receipt-authority` | `layerx-receipt-authority:0.1.0` | TLS receipt authority; see [Hosted authority](HostedAuthority.md) |
+| `agent-boundary` | `layerx-agent-boundary:0.1.0` | TLS agent boundary; see [Hosted agent boundary](HostedAgentBoundary.md) |
+
+Services (`platform/hosted/node/deployment.yaml:12-14`;
+`platform/hosted/node/deployment.yaml:246-264`):
+
+| Service | Type | Port | Target |
+| --- | --- | --- | --- |
+| `layerx-node` | headless | `9443` | `core-tls` |
+| `layerx-pending-core` | ClusterIP | `9443` | `core-tls` (`9443`) |
+| `layerx-pending-core-admin` | ClusterIP | `9444` | `core-admin-tls` (`9444`) |
+| `layerx-receipt-authority` | ClusterIP | `9443` | `authority-tls` (`9445`) |
+| `layerx-agent-boundary` | ClusterIP | `9443` | `agent-tls` (`9446`) |
+
+Loopback listeners inside the pod are not Services:
+program HTTP `127.0.0.1:9401`, replica HTTP `127.0.0.1:9402`,
+LNI Unix socket `/run/layerx/node/layerxd.lni.sock`, supervisor
+Unix socket `/run/layerx/node/supervisor.sock`
+(`platform/hosted/node/deployment.yaml:55-58`;
+`platform/hosted/node/deployment.yaml:130-131`;
+`platform/hosted/node/bootstrap.sh:358-359`).
+
+`platform-hosted-topology-check` loads
+`platform/hosted/node/deployment.yaml` among its default
+manifests (`platform/hosted/tests/topology-check.sh:18`;
+`platform/hosted/tests/topology-check.sh:84`). Beta-cluster
+apply of `node.yaml` must create the trusted-boundary Services
+including `layerx-pending-core`,
+`layerx-pending-core-admin`, `layerx-receipt-authority`, and
+`layerx-agent-boundary`
+(`platform/hosted/tests/beta-cluster.sh:91`;
+`platform/hosted/tests/beta-cluster.sh:862-864`). Qualification
+binds `LAYERX_QUALIFICATION_NODE_URL` to Service
+`layerx-pending-core` and `LAYERX_QUALIFICATION_AGENT_URL` to
+Service `layerx-agent-boundary`
+(`platform/hosted/tests/beta-cluster.sh:1134-1137`).
+
+---
+
+## Bootstrap artefacts
+
+`bootstrap.sh` writes a signed genesis and the files the
+supervisor sources (`platform/hosted/node/bootstrap.sh:4-8`;
+`platform/hosted/node/bootstrap.sh:73-78`). Required flags:
+`--data-dir`, `--run-dir`, `--network-id`, `--sequencer-key`,
+`--treasury-key` (`platform/hosted/node/bootstrap.sh:14-26`;
+`platform/hosted/node/bootstrap.sh:191-195`). `--data-dir` and
+`--run-dir` must differ, and the run directory must not sit
+inside the data directory
+(`platform/hosted/node/bootstrap.sh:347-348`). The data
+directory is created mode `0700` and must be empty unless
+`--force` (`platform/hosted/node/bootstrap.sh:343`;
+`platform/hosted/node/bootstrap.sh:352-354`). The run directory
+is mode `0750` with group `--lni-gid`
+(`platform/hosted/node/bootstrap.sh:355-357`).
+
+Outputs under the data directory
+(`platform/hosted/node/bootstrap.sh:73-78`):
+
+| Path | Contents |
+| --- | --- |
+| `genesis/genesis.manifest` | Signed genesis manifest from `layerx-genesis-build` |
+| `genesis/00000000000000000000.lxs` | Genesis snapshot |
+| `genesis/paxeer-registration-request.lxrr` | LXRR v1, length `73` (`platform/hosted/node/bootstrap.sh:416`) |
+| `genesis/paxeer-deployment-descriptor.lxgd` | LXGD descriptor |
+| `genesis/genesis.registration` | LXGR v1 self-registration, length `82`, written only when `--custody-profile` is absent (`platform/hosted/node/bootstrap.sh:420-434`) |
+| `identities.txt` | One line `{treasury-did-hex}:{treasury-public-key}:0` (`platform/hosted/node/bootstrap.sh:438`) |
+| `checkpoints/` | Empty checkpoint directory |
+| `logs/` | `program-feed.log`, `canonical.log`, `receipt-authority.log`, `batch.log`, `evidence.log` |
+| `replica/receipt-authority.log` | Replica log |
+| `secrets/program-token` | Program-listener bearer |
+| `secrets/replica-token` | Replica-listener bearer |
+| `secrets/treasury-key.hex` | Treasury seed hex |
+| `secrets/guarantor-key.pem` | secp256k1 guarantor private key |
+| `sequencer.conf` / `replica.conf` | Eight-line `layerxd` configurations; both pass `layerxd --check-config` (`platform/hosted/node/bootstrap.sh:449-455`) |
+| `sequencer.env` / `replica.env` | Daemon environments |
+| `node.env` | Published node facts, mode `0644` |
+| `treasury.json` | Treasury DID, public key, account, asset, genesis balance, network id (`platform/hosted/node/bootstrap.sh:543-546`) |
+
+The run directory receives `core.env` with
+`LAYERX_CORE_SEQUENCER_ID` and `LAYERX_CORE_TREASURY_ASSET`
+(`platform/hosted/node/bootstrap.sh:538-541`). Cluster bring-up
+waits until `node.env`, the LXGD descriptor, and the LXRR
+request are present, then fetches those three files
+(`platform/hosted/tests/beta-cluster.sh:885-902`).
+
+A non-zero `--treasury-balance` is refused:
+`treasury_balance_unsupported`. The genesis manifest admits
+only the three system accounts at balance zero
+(`platform/hosted/node/bootstrap.sh:217-219`). Default balance
+is `0`. `--asset` must be 64 lowercase hex and not zero;
+default is
+`b5a32b12029f8ddfb905f90f280f664b46390de0fc62770fc197dd87b18cd898`,
+`sha256("layerx-beta-asset:LXT")`
+(`platform/hosted/node/bootstrap.sh:29-30`;
+`platform/hosted/node/bootstrap.sh:146`;
+`platform/hosted/node/bootstrap.sh:214-216`). ConfigMap
+`layerx-node-config` pins that same asset id, network id
+`402`, network name `layerx-testnet`, replica id
+`6c61796572782d626574612d726563656970742d617574686f726974792d3031`,
+and Paxeer relay port `18545`
+(`platform/hosted/node/deployment.yaml:2-9`).
+
+`--custody-profile` must name a readable regular file that is
+not a symlink and is exactly 207 bytes
+(`platform/hosted/node/bootstrap.sh:196-201`). When set,
+`layerx-genesis-build` receives `--custody-profile` and
+bootstrap does not write `genesis.registration`
+(`platform/hosted/node/bootstrap.sh:405-407`;
+`platform/hosted/node/bootstrap.sh:423-434`).
+
+---
+
+## Genesis request and guarantor keys
+
+Bootstrap generates a secp256k1 key at
+`secrets/guarantor-key.pem`, derives the compressed public key
+(33 bytes, prefix `02` or `03`), and sets
+`GUARANTOR_ID = sha256("layerx-beta-guarantor:" || public-key-hex)`
+(`platform/hosted/node/bootstrap.sh:364-368`). Cluster bring-up
+requires `LAYERX_NODE_GENESIS_GUARANTOR_ID` as 64 hex and
+`LAYERX_NODE_GENESIS_GUARANTOR_PUBLIC_KEY` as that compressed
+form (`platform/hosted/tests/beta-cluster.sh:903-908`). The
+same public key is the Paxeer guarantor signer input
+(`platform/hosted/tests/beta-cluster.sh:917-923`).
+
+The genesis request is LXGB v1, length `395`
+(`platform/hosted/node/bootstrap.sh:370-398`):
+
+- magic `LXGB`, version `1`, protocol `3`
+- network id, genesis timestamp milliseconds
+- one parameter `parameter-version` = `1`
+- one guarantor (id, compressed public key, bond `0`)
+- the genesis asset, fee coefficients, and demand coefficients
+
+`layerx-genesis-build` signs that request with the sequencer
+seed (`platform/hosted/node/bootstrap.sh:400-408`). LXRR bytes
+`[9,41)` are `LAYERX_NODE_GENESIS_STATE_ROOT`; the last 32
+bytes are `LAYERX_NODE_GENESIS_RECEIPT_STATE_ROOT`
+(`platform/hosted/node/bootstrap.sh:417-418`). Without a
+custody profile, LXGR anchors both registration roots to the
+receipt state root (`platform/hosted/node/bootstrap.sh:420-432`).
+
+Sequencer and treasury seeds are 32 raw bytes or 64 hex
+characters and must yield distinct public keys
+(`platform/hosted/node/bootstrap.sh:283-315`). Sequencer id is
+`sha256("layerx-sequencer:" || public-key-hex)`
+(`platform/hosted/node/bootstrap.sh:316`). Replica id defaults
+to `sha256("layerx-authority-replica:" || public-key-hex)`
+(`platform/hosted/node/bootstrap.sh:317-321`). The hosted
+manifest overrides replica id from ConfigMap
+(`platform/hosted/node/deployment.yaml:45-46`;
+`platform/hosted/node/deployment.yaml:68`).
+
+---
+
+## Settlement environment
+
+Five keys bind Paxeer settlement. They are either in the
+bootstrap process environment or deferred to
+`--settlement-env FILE`
+(`platform/hosted/node/bootstrap.sh:55-64`;
+`platform/hosted/node/bootstrap.sh:221-232`). The file form
+excludes those five from the environment
+(`platform/hosted/node/bootstrap.sh:228-229`). Path must be
+absolute (`platform/hosted/node/bootstrap.sh:227`).
+
+`bootstrap.sh --check-settlement FILE` is the validator
+(`platform/hosted/node/bootstrap.sh:67-72`;
+`platform/hosted/node/bootstrap.sh:135-138`). The file must be
+a readable regular file of at most 4096 bytes, holding exactly
+these `KEY=VALUE` lines with no repeats and no other keys
+(`platform/hosted/node/bootstrap.sh:110-132`):
+
+| Key | Rule |
+| --- | --- |
+| `LAYERX_NODE_PAXEER_CHAIN_ID` | Positive decimal `uint64` (`platform/hosted/node/bootstrap.sh:94-97`) |
+| `LAYERX_NODE_SETTLEMENT_CONTRACT` | `0x` plus 40 hex, not zero (`platform/hosted/node/bootstrap.sh:98-105`) |
+| `LAYERX_NODE_CHECKPOINT_REGISTRY` | same address rule |
+| `LAYERX_NODE_PAXEER_RPC_ADDRESS` | exactly `127.0.0.1` (`platform/hosted/node/bootstrap.sh:106`) |
+| `LAYERX_NODE_PAXEER_RPC_PORT` | `1..=65535` (`platform/hosted/node/bootstrap.sh:107`) |
+
+The hosted sequencer args pass `--settlement-env`
+`/run/layerx/settlement/settlement.env`
+(`platform/hosted/node/deployment.yaml:63-64`). That path is
+ConfigMap `layerx-node-settlement`, optional at apply
+(`platform/hosted/node/deployment.yaml:229`). Cluster bring-up
+writes the five lines after contract deploy, runs
+`--check-settlement`, then applies that ConfigMap
+(`platform/hosted/tests/beta-cluster.sh:953-957`).
+
+When `sequencer.env` names `LAYERX_NODE_SETTLEMENT_ENV`, the
+sequencer supervisor waits for the file (log every 30 seconds,
+cap `LAYERX_NODE_SETTLEMENT_WAIT_SECONDS`, default `3600`),
+validates it with `--check-settlement`, and exports the five
+values before `layerxd --serve`
+(`platform/hosted/node/supervisor.sh:30-34`;
+`platform/hosted/node/supervisor.sh:161-181`;
+`platform/hosted/node/supervisor.sh:188-198`).
+
+---
+
+## `node.env` keys
+
+`node.env` is mode `0644`
+(`platform/hosted/node/bootstrap.sh:509-537`):
+
+| Key | Role |
+| --- | --- |
+| `LAYERX_NODE_NETWORK_ID` | Decimal network id |
+| `LAYERX_NODE_ASSET_ID` | Genesis asset hex |
+| `LAYERX_NODE_LNI_SOCKET` | Absolute LNI Unix path |
+| `LAYERX_NODE_SUPERVISOR_SOCKET` | Absolute supervisor Unix path |
+| `LAYERX_NODE_PROGRAM_URL` | `http://127.0.0.1:{program-port}` |
+| `LAYERX_NODE_REPLICA_URL` | `http://127.0.0.1:{replica-port}` |
+| `LAYERX_NODE_PROGRAM_BEARER_TOKEN_FILE` | `{data}/secrets/program-token` |
+| `LAYERX_NODE_REPLICA_BEARER_TOKEN_FILE` | `{data}/secrets/replica-token` |
+| `LAYERX_NODE_SEQUENCER_ID` | Sequencer id hex |
+| `LAYERX_NODE_SEQUENCER_PUBLIC_KEY` | Sequencer public key hex |
+| `LAYERX_NODE_REPLICA_ID` | Replica id hex |
+| `LAYERX_NODE_GENESIS_STATE_ROOT` | From LXRR |
+| `LAYERX_NODE_GENESIS_RECEIPT_STATE_ROOT` | From LXRR |
+| `LAYERX_NODE_GENESIS_GUARANTOR_ID` | Guarantor id hex |
+| `LAYERX_NODE_GENESIS_GUARANTOR_PUBLIC_KEY` | Compressed guarantor public key hex |
+| `LAYERX_NODE_GENESIS_GUARANTOR_KEY_FILE` | `{data}/secrets/guarantor-key.pem` |
+| `LAYERX_PAXEER_GENESIS_DIR` | `{data}/genesis` |
+| `LAYERX_NODE_TREASURY_DID` | `did:layerx:{treasury-public-key}` |
+| `LAYERX_NODE_TREASURY_PUBLIC_KEY` | Treasury public key hex |
+| `LAYERX_NODE_TREASURY_ACCOUNT` | `agent:{did}:main` |
+| `LAYERX_NODE_TREASURY_BALANCE` | Genesis treasury balance (`0`) |
+| `LAYERX_NODE_TREASURY_KEY_FILE` | `{data}/secrets/treasury-key.hex` |
+| `LAYERX_NODE_SEQUENCER_CONFIG` | `{data}/sequencer.conf` |
+| `LAYERX_NODE_REPLICA_CONFIG` | `{data}/replica.conf` |
+| `LAYERX_NODE_SEQUENCER_ENV` | `{data}/sequencer.env` |
+| `LAYERX_NODE_REPLICA_ENV` | `{data}/replica.env` |
+
+`sequencer.env` additionally carries snapshot, manifest,
+registration, identities, logs, history database, sequencer
+keys, batch range `1`..`18446744073709551615`, replica
+address/port/id/token, program address/port/token, LNI socket,
+allowed uid/gid, `LAYERX_NODE_LNI_FRAME_BYTES=1212416`, and
+`LAYERX_NODE_LNI_DEADLINE_MS=2000`, or
+`LAYERX_NODE_SETTLEMENT_ENV` in place of the five settlement
+keys (`platform/hosted/node/bootstrap.sh:457-494`).
+`replica.env` carries replica log, replica id, sequencer id
+and public key, batch range, bearer token, and
+`LAYERX_AUTHORITY_ADDRESS=127.0.0.1` plus port
+(`platform/hosted/node/bootstrap.sh:496-506`).
+
+`layerxd --serve` requires
+`LAYERX_NODE_LNI_FRAME_BYTES` equal to
+`LXP_DAEMON_LNI_MAX_FRAME_BYTES`
+(`cmd/layerxd/lxp_daemon_process.c:3804-3810`). Bootstrap
+writes `1212416` (`platform/hosted/node/bootstrap.sh:492`).
+`cmd/layerxd/lni.env.example:23` writes `1146902`. Those two
+values differ.
+
+---
+
+## LNI socket
+
+The production LNI is the sole activity-ingress boundary
+(`cmd/layerxd/lni.env.example:1-5`). Path is
+`RUN_DIR/layerxd.lni.sock`, length less than 108
+(`platform/hosted/node/bootstrap.sh:358-360`;
+`include/layerx/lxp_daemon.h:36`). The parent is mode `0750`,
+owned by the daemon uid with the configured client gid. The
+socket is mode `0660`, owned by `layerxd` and that gid
+(`cmd/layerxd/lxp_daemon_process.c:3790`;
+`cmd/layerxd/lxp_daemon_lni.c:3321-3324`;
+`cmd/layerxd/lni.env.example:2-5`). `SO_PEERCRED` requires the
+exact configured uid and gid; a mismatch is `LXP_ERR_AUTH_SCOPE`
+(`cmd/layerxd/lxp_daemon_lni.c:2975-2991`). The client uid must
+differ from the daemon uid
+(`platform/hosted/node/bootstrap.sh:238`;
+`cmd/layerxd/lni.env.example:6`). Hosted values: daemon
+`4020:4020`, `--lni-uid 4021`, `--lni-gid 4020`
+(`platform/hosted/node/deployment.yaml:26`;
+`platform/hosted/node/deployment.yaml:59-62`). Colocated
+`core-boundary`, `receipt-authority`, and `agent-boundary`
+run as `4021:4020` so the LNI admits them
+(`platform/hosted/node/deployment.yaml:119`;
+`platform/hosted/node/deployment.yaml:155`;
+`platform/hosted/node/deployment.yaml:196`).
+
+Interface is LNI 1.4 (`cmd/layerxd/lxp_daemon_lni.c:38-39`).
+The first frame must be NodeInfo request tag `1` with
+correlation `0` and empty payload; otherwise refusal class `2`
+`LXP_ERR_AUTH_SCOPE` (`cmd/layerxd/lxp_daemon_lni.c:40-41`;
+`cmd/layerxd/lxp_daemon_lni.c:3126-3132`). Later tags
+(`cmd/layerxd/lxp_daemon_lni.c:40-60`;
+`cmd/layerxd/lxp_daemon_lni.c:3138-3167`):
+
+| Tag | Name |
+| --- | --- |
+| `1` / `2` | NodeInfo |
+| `3` / `4` | Submit |
+| `5` / `6` | ReceiptLookup |
+| `7` / `8` | AccountRead |
+| `12` / `13` | BatchHeader |
+| `14` / `15` | Checkpoint |
+| `16` / `17` | ProofBundle |
+| `25` | Error |
+| `26` / `27` | PreparationState |
+| `28` / `29` | FinalityEvidenceRegister |
+| `30` / `31` | Simulate |
+
+An unknown tag is refusal class `3` `LXP_ERR_MODULE_DISABLED`.
+A second NodeInfo is class `1` `LXP_ERR_NON_CANONICAL`.
+Sequencer NodeInfo advertises at least
+`authenticated_durable_submit`, `batch_header`, `node_info`,
+`preparation_state`, `receipt_lookup`, `submit`; evidence,
+finalizer, and `simulate` bits depend on the daemon
+(`cmd/layerxd/lxp_daemon_lni.c:1311-1334`). [Agentd](Agentd.md)
+consumes receipts and batch evidence from this plane; it does
+not mint balances.
+
+---
+
+## Supervisor socket
+
+The sequencer supervisor listens on
+`RUN_DIR/supervisor.sock` via `socat` `UNIX-LISTEN`, mode
+`660`, group `LAYERX_NODE_LNI_ALLOWED_GID`
+(`platform/hosted/node/supervisor.sh:358-360`). One line per
+connection, 10 second read
+(`platform/hosted/node/supervisor.sh:77-78`):
+
+| Request | Success | Refusal |
+| --- | --- | --- |
+| `reset` | `{"state":"reset","reset_id":"<16 hex>"}` after stop, discard, bootstrap `--force`, restart (`platform/hosted/node/supervisor.sh:80-102`; `platform/hosted/node/supervisor.sh:363-387`) | `supervisor_unavailable` retry 5; `reset_failed` retry 30; `reset_timeout` retry 60 |
+| `status` | `{"state":"running","generation":N}` or `{"state":"stopped","generation":N}` (`platform/hosted/node/supervisor.sh:104-111`) | none |
+| any other line | | `unknown_request` retry never (`platform/hosted/node/supervisor.sh:113-114`) |
+
+Reset coordinates the replica through
+`reset.<id>.stop-replica` / `reset.<id>.replica-stopped`
+(`platform/hosted/node/supervisor.sh:24-28`;
+`platform/hosted/node/supervisor.sh:367-373`). A daemon that
+exits on its own ends the supervisor with status `1`
+(`platform/hosted/node/supervisor.sh:36-37`).
+
+---
+
+## Program listener
+
+`layerxd --serve` binds the program listener only on
+`127.0.0.1` (`cmd/layerxd/lxp_daemon_listener.c:397-408`).
+Hosted port `9401`. `Authorization: Bearer` must match
+`LAYERX_NODE_PROGRAM_BEARER_TOKEN` in length and constant-time
+compare (`cmd/layerxd/lxp_daemon_protocol.c:134-139`;
+`cmd/layerxd/lxp_daemon_protocol.c:888-890`). Duplicate
+`Authorization` or a non-`HTTP/1.1` request line is
+`LXP_ERR_NON_CANONICAL` (`cmd/layerxd/lxp_daemon_listener.c:154-166`).
+GET only (`cmd/layerxd/lxp_daemon_protocol.c:496`).
+
+| Path | Success body |
+| --- | --- |
+| `GET /v1/protocol/account-state/head` | `current`, `receipt_hex`, `receipt_digest`, `state_root`, `observed_sequence`, `observed_at`, `batch_evidence` (`cmd/layerxd/lxp_daemon_protocol.c:267-282`; `cmd/layerxd/lxp_daemon_protocol.c:300-306`) |
+| `GET /v1/receipts/{64 hex}/account-state` | same document for that receipt digest (`cmd/layerxd/lxp_daemon_protocol.c:499-510`) |
+| `GET /v1/programs/account-state/changes?after_sequence={decimal}` | `records[]` of `sequence`, `ordinal`, `program_id`, `activity_type`, `event_type`, `receipt_digest`; `complete_through`; `scanned_through_sequence`; `caught_up` (`cmd/layerxd/lxp_daemon_protocol.c:366-389`; `cmd/layerxd/lxp_daemon_protocol.c:546-551`) |
+| `GET /v1/programs/{64 hex}/account-state?at={decimal}` | `program_id`, `record_hex`, `record_digest`, `receipt_digest`; `at` must equal the feed head (`cmd/layerxd/lxp_daemon_protocol.c:318-342`; `cmd/layerxd/lxp_daemon_protocol.c:553-564`) |
+| `GET /v1/programs/activities/{64 hex}/artifacts?receipt_digest={64 hex}` | `activity_id`, `receipt_digest`, `terminal_payload`, `call_graph` (`cmd/layerxd/lxp_daemon_protocol.c:419-427`; `cmd/layerxd/lxp_daemon_protocol.c:530-544`) |
+| `GET /v1/programs/receipts/by-idempotency/{64 lowercase hex}` | `activity_id`, `receipt` (`cmd/layerxd/lxp_daemon_protocol.c:462-466`; `cmd/layerxd/lxp_daemon_protocol.c:514-528`) |
+| `GET /v1/batches/{64 hex}/receipt-authority?receipt_digest={64 hex}` | `sequencer_public_key`, `batch_evidence` (`cmd/layerxd/lxp_daemon_protocol.c:481-485`; `cmd/layerxd/lxp_daemon_protocol.c:567-580`) |
+
+HTTP mapping after a valid parse
+(`cmd/layerxd/lxp_daemon_protocol.c:888-901`;
+`cmd/layerxd/lxp_daemon_listener.c:214-251`):
+
+| Status | Body | Condition |
+| --- | --- | --- |
+| `200` | route JSON | `LXP_OK` |
+| `401` | `{"error":<LXP_ERR_BAD_SIGNATURE>}` | bearer mismatch |
+| `404` | `{"error":<LXP_ERR_UNKNOWN_ACTIVITY>}` | unknown path or non-GET |
+| `503` | `{"error":<code>}` | any other `lxp_result` |
+| `400` | `{"error":"refused"}` | framing failure before `protocol_route` |
+
+Those two error envelopes differ: routed failures are a
+numeric `error`; parse failures are the string `refused`.
+Missing `changes` query is `LXP_ERR_NON_CANONICAL`
+(`cmd/layerxd/lxp_daemon_protocol.c:546-547`). Uppercase hex
+in an idempotency key is `LXP_ERR_NON_CANONICAL`
+(`cmd/layerxd/lxp_daemon_protocol.c:519-523`). At most four
+program-listener connections
+(`include/layerx/lxp_daemon.h:30`).
+
+The supervisor treats the sequencer as ready when
+`GET /v1/programs/account-state/changes?after_sequence=0`
+returns `HTTP/1.1 200` and a page matching that records
+schema, and the LNI socket exists
+(`platform/hosted/node/supervisor.sh:237-268`).
+
+---
+
+## Replica listener
+
+`layerxd --authority-replica` binds only `127.0.0.1`
+(`cmd/layerxd/lxp_daemon_authority_replica.c:773-778`). Hosted
+port `9402`. Bearer is `Authorization: Bearer` plus
+`LAYERX_AUTHORITY_BEARER_TOKEN`, compared constant-time
+(`cmd/layerxd/lxp_daemon_authority_replica.c:430-439`).
+
+| Method and path | Success | Refusal |
+| --- | --- | --- |
+| `POST /v1/receipt-authority/ingest` | `201` `{"authority_replica_id":"<64 hex>"}` (`cmd/layerxd/lxp_daemon_authority_replica.c:501-536`) | `401` without bearer; `503` on append failure |
+| `GET /v1/batches/{64 hex}/receipt-authority?receipt_digest={64 hex}` | `200` evidence JSON (`cmd/layerxd/lxp_daemon_authority_replica.c:537-557`) | `401`; `404` on miss or malformed selector |
+
+The supervisor treats the replica as ready on `HTTP/1.1 404`
+for the all-zero batch and digest
+(`platform/hosted/node/supervisor.sh:247-249`). The sequencer
+posts ingest to that replica
+(`cmd/layerxd/lxp_daemon_authority_replica.c:916`). Program
+and replica tokens must differ; program address/port must
+differ from replica address/port
+(`platform/hosted/node/bootstrap.sh:339`;
+`cmd/layerxd/lxp_daemon_process.c:3770-3777`).
+
+---
+
+## Mounted paths and env
+
+Sequencer container (`platform/hosted/node/deployment.yaml:32-76`):
+
+| Path | Source |
+| --- | --- |
+| `/var/lib/layerx` | PVC `data` (50Gi) |
+| `/run/layerx` | emptyDir Memory 16Mi |
+| `/run/layerx/keys/sequencer.key` | Secret `layerx-node-keys` |
+| `/run/layerx/keys/treasury.key` | Secret `layerx-node-keys` |
+| `/run/layerx/tokens/program-token` | Secret `layerx-node-tokens` |
+| `/run/layerx/tokens/replica-token` | Secret `layerx-node-tokens` |
+| `/run/layerx/settlement/settlement.env` | ConfigMap `layerx-node-settlement` |
+
+Env from ConfigMap `layerx-node-config`:
+`LAYERX_NODE_NETWORK_ID`, `LAYERX_NODE_ASSET_ID`,
+`LAYERX_NODE_REPLICA_ID`
+(`platform/hosted/node/deployment.yaml:65-68`).
+`paxeer-relay` reads `LAYERX_NODE_PAXEER_RELAY_PORT` from that
+ConfigMap and `LAYERX_NODE_PAXEER_BOUNDARY`
+`paxeer-boundary.layerx-testnet.svc.cluster.local`, with CA
+`/run/layerx/trust/ca.crt`
+(`platform/hosted/node/deployment.yaml:84-90`;
+`platform/hosted/node/deployment.yaml:94`).
+
+TLS Secrets for colocated boundaries:
+`layerx-pending-core-tls`, `layerx-pending-core-admin-tls`,
+`layerx-receipt-authority-tls`, `layerx-agent-boundary-tls`,
+`layerx-internal-ca` (`platform/hosted/node/deployment.yaml:231-235`).
+
+---
+
+## NetworkPolicy
+
+Ingress `layerx-node-ingress`
+(`platform/hosted/node/deployment.yaml:266-284`):
+
+| From | Ports |
+| --- | --- |
+| `app=layerx-testnet-control` | `9443`, `9444`, `9445` |
+| `app=layerx-gateway` | `9443`, `9445`, `9446` |
+| `app=layerx-program-registry` | `9445`, `9446` |
+| `app=layerx-faucet` | `9443` |
+| namespace `layerx-developer`, `app=layerx-webhooks` | `9445`, `9446` |
+| namespace `layerx-developer`, `app=layerx-dashboard-api` | `9445`, `9446` |
+
+Egress `layerx-node-egress`: DNS `53` and `app=paxeer` TCP
+`9443` (`platform/hosted/node/deployment.yaml:286-296`).
+Loopback program/replica/LNI/supervisor sockets do not cross
+the NetworkPolicy.
+
+---
+
+## Tests
+
+`make platform-test-node` syntax-checks `bootstrap.sh`,
+`supervisor.sh`, and `node-test.sh`, then runs
+`platform/hosted/node/tests/node-test.sh`
+(`platform/Makefile.inc:140-142`). That script requires root
+so the LNI client can present a uid other than the daemon
+(`platform/hosted/node/tests/node-test.sh:7-9`;
+`platform/hosted/node/tests/node-test.sh:29-32`). It proves:
+
+- `node.env` network id, run directory mode `0750` and LNI
+  gid, LXGR length `82`, treasury identity line
+  (`platform/hosted/node/tests/node-test.sh:125-130`)
+- LNI handshake as the client uid: network id, role
+  `Sequencer`, sequencer public key, `AccountRead`
+  (`platform/hosted/node/tests/node-test.sh:133-139`)
+- `layerxctl read-state` `evidence=authenticated_node_snapshot`
+  (`platform/hosted/node/tests/node-test.sh:141-146`)
+- treasury balance equals `LAYERX_NODE_TREASURY_BALANCE`
+  (`platform/hosted/node/tests/node-test.sh:148-153`)
+- a signed SEND is `acknowledged` and a repeated canonical
+  submit is byte-identical
+  (`platform/hosted/node/tests/node-test.sh:155-171`)
+- supervisor `status` is `running` generation `1`; `reset`
+  rebuilds genesis (new manifest inode, empty checkpoints)
+  and generation `2`
+  (`platform/hosted/node/tests/node-test.sh:173-195`)
+- stopping the supervisors removes `supervisor.sock` and
+  leaves no `layerxd` processes
+  (`platform/hosted/node/tests/node-test.sh:197-206`)

--- a/docs/wiki/HostedTestnetControl.md
+++ b/docs/wiki/HostedTestnetControl.md
@@ -1,0 +1,465 @@
+# Hosted testnet control
+
+`layerx-testnet-control` is the public status, parameter, and journey
+admission surface for hosted LayerX, and the private funding/reset
+proxy (`platform/hosted/testnet/README.md:3`;
+`platform/hosted/testnet/Cargo.toml:11-13`;
+`platform/hosted/testnet/src/main.rs:1141-1282`). The crate is
+`layerx-platform-testnet`; the library path is `src/lib.rs`; the
+binary path is `src/main.rs`. It is not a protocol node. A developer
+or agent reads `GET /readyz`, `GET /v1/status`, `GET /v1/parameters`,
+and `GET /v1/journeys/{journey}` with no Bearer. Faucet replicas and
+the reset operator call the admin listener.
+
+The image is `ghcr.io/sidiora-labs/layerx-testnet-control:0.1.0`, user
+`4020:4020`, entrypoint `/usr/local/bin/layerx-testnet-control`
+(`platform/hosted/testnet/Dockerfile:6-13`;
+`platform/hosted/testnet/deployment.yaml:80-82`;
+`platform/hosted/tests/beta-cluster.sh:114`). The image also copies
+`run-testnet.sh`, `reset-testnet.sh`, and `render-status.sh` to
+`/opt/layerx/` (`platform/hosted/testnet/Dockerfile:11`). The
+Deployment command is the binary, not `run-testnet.sh`
+(`platform/hosted/testnet/deployment.yaml:82`).
+
+The Deployment has two replicas. Public listen is `0.0.0.0:9443`;
+admin listen is `0.0.0.0:9444`
+(`platform/hosted/testnet/deployment.yaml:72`;
+`platform/hosted/testnet/deployment.yaml:86-87`;
+`platform/hosted/testnet/deployment.yaml:102`). Service
+`layerx-testnet-public` port `443` targets `public-tls` `9443`.
+Service `layerx-testnet-admin` is ClusterIP port `443` targeting
+`admin-tls` `9444`
+(`platform/hosted/testnet/deployment.yaml:116-124`). Ingress
+`layerx-testnet-public` host `testnet.layerx.network` path `/`
+uses backend protocol HTTPS
+(`platform/hosted/testnet/deployment.yaml:183-198`). Bring-up
+port-forwards `19443:443` and exports `LAYERX_TESTNET_URL`
+(`platform/hosted/tests/beta-cluster.sh:81`;
+`platform/hosted/tests/beta-cluster.sh:1114`;
+`platform/hosted/tests/beta-cluster.sh:1258`;
+`platform/hosted/tests/beta-cluster.sh:1278`). Library
+`platform_testnet` names `https://testnet.layerx.network`
+(`platform/hosted/testnet/src/lib.rs:75`).
+
+This page covers that binary, both listeners, journey probes, and the
+funding/reset proxy. Faucet claim HTTP is on
+[Hosted faucet](HostedFaucet.md). Treasury SEND construction is on
+[Hosted core](HostedCore.md). Gateway `/v1` is on
+[Hosted gateway](HostedGateway.md).
+
+---
+
+## TLS
+
+Inbound TLS is rustls with no client authentication on both listeners.
+The certificate is `LAYERX_TESTNET_TLS_CERT_DER`; the PKCS#8 key is
+`LAYERX_TESTNET_TLS_KEY_DER`
+(`platform/hosted/testnet/src/main.rs:762-783`). Each accepted TCP
+connection becomes a rustls `ServerConnection`
+(`platform/hosted/testnet/src/main.rs:1331-1333`). At most 128
+connections are live across both listeners; further accepts are
+dropped (`platform/hosted/testnet/src/main.rs:23`;
+`platform/hosted/testnet/src/main.rs:1320-1322`). Messages are bounded
+at 64 KiB (`platform/hosted/testnet/src/main.rs:20`;
+`platform/hosted/testnet/src/main.rs:951`). Query strings,
+`Transfer-Encoding`, duplicate headers, and a missing `Host` are
+refused (`platform/hosted/testnet/src/main.rs:974-975`;
+`platform/hosted/testnet/src/main.rs:1018-1028`). Incoming headers and
+bodies are zeroized on drop
+(`platform/hosted/testnet/src/main.rs:666-672`).
+
+Outbound HTTPS uses `native_tls` `TlsConnector` with
+`LAYERX_OUTBOUND_CA_DER` and TLS 1.2
+(`platform/hosted/testnet/src/main.rs:890-894`). Component URLs must
+be `https://`. Redis must be `rediss://` with no path
+(`platform/hosted/testnet/src/main.rs:34-43`;
+`platform/hosted/testnet/src/main.rs:1658-1667`). The client writes
+optional `Authorization: Bearer` and optional `Idempotency-Key`
+(`platform/hosted/testnet/src/main.rs:911-918`). Connect timeout is
+3s; I/O timeout is 8s (`platform/hosted/testnet/src/main.rs:21-22`).
+HTTPS upstreams do not present a client certificate.
+
+---
+
+## Tokens
+
+Public routes accept no credential
+(`platform/hosted/testnet/src/main.rs:1141-1175`). Admin routes
+compare `Authorization: Bearer` to the inbound admin token in
+constant time (`platform/hosted/testnet/src/main.rs:1178-1191`).
+
+| Credential | Accepted from | Used as | Never |
+| --- | --- | --- | --- |
+| Control admin token | File `LAYERX_TESTNET_CONTROL_ADMIN_TOKEN_FILE`; mounted `/run/layerx/control-admin/token` (`platform/hosted/testnet/src/main.rs:860`; `platform/hosted/testnet/deployment.yaml:101`; `platform/hosted/testnet/deployment.yaml:110`) | Inbound admin `Authorization: Bearer` | Public listener |
+| Backend admin token | File `LAYERX_TESTNET_BACKEND_ADMIN_TOKEN_FILE`; mounted `/run/layerx/backend-admin/token` (`platform/hosted/testnet/src/main.rs:859`; `platform/hosted/testnet/deployment.yaml:100`; `platform/hosted/testnet/deployment.yaml:109`) | `Authorization: Bearer` to core-admin fund and reset | Presented by humans |
+| Reset token | File `LAYERX_TESTNET_RESET_TOKEN_FILE`; CronJob mounts `/run/layerx/control-admin/token` (`platform/hosted/testnet/deployment.yaml:221`; `platform/hosted/testnet/reset-testnet.sh:6`) | Bearer on `POST /admin/v1/testnet/reset` | Public routes |
+| Status publish token | File `LAYERX_STATUS_TOKEN_FILE`; CronJob mounts `/run/layerx/status/token` (`platform/hosted/testnet/deployment.yaml:248`; `platform/hosted/testnet/render-status.sh:7`) | Bearer on `PUT` to the status publisher | Testnet-control HTTP |
+
+The faucet mounts the same control-admin Secret as
+`LAYERX_TESTNET_ADMIN_TOKEN_FILE`
+(`platform/hosted/testnet/deployment.yaml:148`;
+`platform/hosted/testnet/deployment.yaml:166`;
+`platform/hosted/testnet/deployment.yaml:171`). Bring-up writes
+`control-admin.token` and `backend-admin.token` as distinct files
+(`platform/hosted/tests/beta-cluster.sh:489-490`;
+`platform/hosted/tests/beta-cluster.sh:582-583`). Testnet-control
+sets `LAYERX_TESTNET_IDENTITY_URL` and does not set an identity
+service-token env (`platform/hosted/testnet/deployment.yaml:92`;
+`platform/hosted/testnet/deployment.yaml:83-101`;
+`docs/wiki/HostedIdentity.md`). Identity is probed with
+unauthenticated `GET /readyz` only
+(`platform/hosted/testnet/src/main.rs:1032-1037`;
+`platform/hosted/testnet/src/main.rs:1097`).
+
+---
+
+## Public routes
+
+`public_route` accepts `GET` only. Any other method is `404 not_found`
+(`platform/hosted/testnet/src/main.rs:1141-1143`).
+
+| Method and path | Inputs | Result |
+| --- | --- | --- |
+| `GET /livez` | none | `200` `{"status":"live"}` (`platform/hosted/testnet/src/main.rs:1146`) |
+| `GET /readyz` | none | `200` readiness document when every dependency, every journey, and the release gate are ready; else `503` with the same document (`platform/hosted/testnet/src/main.rs:1147-1152`; `platform/hosted/testnet/src/main.rs:614-624`) |
+| `GET /v1/status` | none | `200` four-component public status (`platform/hosted/testnet/src/main.rs:1154`; `platform/hosted/testnet/src/main.rs:627-655`) |
+| `GET /v1/parameters` | none | `200` `network`, `network_id`, `package_semver`, `lxp_wire_protocol_version`, `reset_schedule` (`platform/hosted/testnet/src/main.rs:1155-1163`) |
+| `GET /v1/journeys/funding` | none | Journey admission (`platform/hosted/testnet/src/main.rs:229`; `platform/hosted/testnet/src/main.rs:1165-1171`) |
+| `GET /v1/journeys/payment` | none | Journey admission (`platform/hosted/testnet/src/main.rs:230`) |
+| `GET /v1/journeys/receipt-inspection` | none | Journey admission (`platform/hosted/testnet/src/main.rs:231`) |
+| `GET /v1/journeys/programs` | none | Journey admission (`platform/hosted/testnet/src/main.rs:232`) |
+
+`GET /v1/journeys/settlement` is not a route
+(`platform/hosted/testnet/src/main.rs:1498`). Unknown GET paths are
+`404 not_found` (`platform/hosted/testnet/src/main.rs:1173`).
+
+`GET /v1/parameters` body:
+
+- `network` `layerx-testnet`
+- `network_id` `TESTNET_NETWORK_ID` (`402`)
+- `package_semver` from the running crate
+- `lxp_wire_protocol_version` `LXP_WIRE_PROTOCOL_VERSION`
+- `reset_schedule` `09:00 UTC on the first Tuesday of every month`
+
+(`platform/hosted/testnet/src/main.rs:1155-1163`;
+`platform/hosted/testnet/src/lib.rs:3-4`;
+`platform/hosted/testnet/src/lib.rs:79`). ConfigMap
+`layerx-testnet-release` stores `reset-schedule`
+`0 9 * * 2; operator executes only on days 1-7`
+(`platform/hosted/testnet/deployment.yaml:11`). Those two schedule
+strings differ. The parameters handler does not read the ConfigMap.
+
+`GET /v1/status` keys are `service`, `state`, `package_semver`,
+`lxp_wire_protocol_version`, `network_id`, `components`
+(`platform/hosted/testnet/src/main.rs:687-694`;
+`platform/hosted/testnet/src/main.rs:1626-1636`). `service` is
+`layerx-hosted-testnet`. `components` is exactly `testnet`,
+`gateway`, `core`, `paxeer`, each `{name, state}`
+(`platform/hosted/testnet/src/main.rs:642-654`;
+`platform/hosted/testnet/src/main.rs:1642-1651`). Component `testnet`
+is `ready` or `degraded` from the release gate. `gateway`, `core`,
+and `paxeer` are `ready` or `unavailable` from the matching
+dependency probe. Gateway `GET /v1/status` is a different shape
+(`docs/wiki/HostedGateway.md`).
+
+---
+
+## Journeys and probes
+
+A journey is ready only when every dependency in its declared set
+probes successfully (`platform/hosted/testnet/src/main.rs:242-268`;
+`platform/hosted/testnet/src/main.rs:455-472`).
+
+| Journey | Route | Dependencies |
+| --- | --- | --- |
+| `funding` | `/v1/journeys/funding` | `identity`, `faucet`, `redis`, `core_admin`, `core` (`platform/hosted/testnet/src/main.rs:244-250`) |
+| `payment` | `/v1/journeys/payment` | `identity`, `gateway`, `core`, `receipt_authority` (`platform/hosted/testnet/src/main.rs:251-256`) |
+| `receipt_inspection` | `/v1/journeys/receipt-inspection` | `gateway`, `receipt_authority`, `core` (`platform/hosted/testnet/src/main.rs:257-261`) |
+| `programs` | `/v1/journeys/programs` | `gateway`, `registry`, `core`, `receipt_authority` (`platform/hosted/testnet/src/main.rs:262-267`) |
+
+Admission JSON flattens `JourneyView` plus `admitted`
+(`platform/hosted/testnet/src/main.rs:711-716`;
+`platform/hosted/testnet/src/main.rs:486-490`). Ready is HTTP 200 with
+`admitted` true, `ready` true, empty `failing`. Degraded is HTTP 503
+with `admitted` false and `failing` names
+(`platform/hosted/testnet/src/main.rs:1165-1171`). Hosted smoke
+requires `.admitted == true and .ready == true and (.failing | length) == 0`
+(`platform/hosted/testnet/tests/hosted-smoke.sh:38-49`).
+
+Probe kinds (`platform/hosted/testnet/src/main.rs:1094-1105`):
+
+| Dependency | Probe |
+| --- | --- |
+| `identity`, `faucet`, `core`, `receipt_authority`, `gateway`, `paxeer` | Unauthenticated `GET /readyz`, HTTP 200 only (`platform/hosted/testnet/src/main.rs:1032-1037`) |
+| `core_admin` | TLS handshake, no HTTP (`platform/hosted/testnet/src/main.rs:1040-1044`) |
+| `registry` | TCP connect; the detail string names client-certificate TLS beyond the probe (`platform/hosted/testnet/src/main.rs:1047-1053`) |
+| `redis` | TLS then `PING`; `+PONG` or `-NOAUTH` is success (`platform/hosted/testnet/src/main.rs:1056-1091`) |
+
+Global `/readyz` is ready only when all nine dependencies succeed,
+all four journeys are ready, and `ReleaseGate::verify` matches
+package semver and wire version
+(`platform/hosted/testnet/src/main.rs:519-555`;
+`platform/hosted/testnet/src/main.rs:1556-1569`). A Paxeer miss
+degrades global state while leaving journeys ready
+(`platform/hosted/testnet/src/main.rs:1571-1579`). The readiness
+document includes `release`, `dependencies`, and `journeys`
+(`platform/hosted/testnet/src/main.rs:728-737`). `state` is `ready`
+or `degraded` (`platform/hosted/testnet/src/main.rs:562-567`).
+
+`config` refuses boot when `TestnetConfig::validate` fails
+(`platform/hosted/testnet/src/main.rs:794-799`;
+`platform/hosted/testnet/src/lib.rs:33-52`). The readiness document
+can still represent a degraded release in tests
+(`platform/hosted/testnet/src/main.rs:1599-1619`). Those two gates
+differ.
+
+In-cluster URLs (`platform/hosted/testnet/deployment.yaml:88-96`):
+
+- Core `https://layerx-pending-core.layerx-testnet.svc.cluster.local:9443`
+- Core admin `https://layerx-pending-core-admin.layerx-testnet.svc.cluster.local:9444`
+- Gateway `https://layerx-gateway.layerx-testnet.svc.cluster.local:443`
+- Paxeer `https://paxeer-boundary.layerx-testnet.svc.cluster.local:9443`
+- Identity `https://layerx-identity.layerx-testnet.svc.cluster.local:9443`
+- Faucet `https://layerx-faucet-public.layerx-testnet.svc.cluster.local:443`
+- Receipt authority `https://layerx-receipt-authority.layerx-testnet.svc.cluster.local:9443`
+- Registry `https://layerx-program-registry.layerx-testnet.svc.cluster.local:9420`
+- Redis `rediss://layerx-faucet-redis.layerx-testnet.svc.cluster.local:6379`
+
+Testnet-control does not write Redis. It shares the faucet Redis
+listener for the `redis` probe. Persistence for claims is the faucet
+store (`docs/wiki/HostedFaucet.md`). Persistence for fund/reset is
+the core journal (`docs/wiki/HostedCore.md`).
+
+---
+
+## Admin routes
+
+Served only on the admin listener
+(`platform/hosted/testnet/src/main.rs:1342-1346`;
+`platform/hosted/testnet/src/main.rs:1381-1392`). There is no admin
+`/livez` or `/readyz`. Deployment probes use the public port
+(`platform/hosted/testnet/deployment.yaml:103-104`).
+
+Every admin request requires the inbound Bearer, then
+`Content-Type: application/json`, then `Idempotency-Key` 1–128
+alnum/`-`/`_`/`.`/`:` (`platform/hosted/testnet/src/main.rs:1194-1225`;
+`platform/hosted/testnet/src/main.rs:1202-1225`).
+
+| Method and path | Inputs | Upstream |
+| --- | --- | --- |
+| `POST /admin/v1/testnet/fund` | JSON `funding_id`, `did`, `public_key`, `amount` with `deny_unknown_fields` (`platform/hosted/testnet/src/main.rs:740-747`; `platform/hosted/testnet/src/main.rs:1228-1255`) | Core-admin `POST /admin/v1/testnet/fund` with the backend admin token and the same body and idempotency key |
+| `POST /admin/v1/testnet/reset` | JSON `{}` (`platform/hosted/testnet/src/main.rs:1257-1264`) | Core-admin `POST /admin/v1/testnet/reset` |
+
+Fund validation: `funding_id` is a valid key; `did` starts with
+`did:` and length ≤ 512; `public_key` is 64 ASCII hex; `amount != 0`
+(`platform/hosted/testnet/src/main.rs:1235-1248`). Failure is
+`400 invalid_argument`. Before proxying, the handler probes the
+funding journey; a degraded set is `503 journey_degraded` with
+`journey`, `failing`, and `retry` `after`
+(`platform/hosted/testnet/src/main.rs:1250-1253`;
+`platform/hosted/testnet/src/main.rs:427-435`). Reset does not probe
+journeys. Reset body other than `{}` is `400 invalid_argument`.
+
+Upstream HTTP 200 or 202 is returned unchanged. Upstream 400–499 is
+returned unchanged. Any other outcome is
+`503 core_unavailable` with `retry` `after`
+(`platform/hosted/testnet/src/main.rs:1268-1281`). Testnet-control
+does not rewrite core 5xx to 422. Core admin itself rewrites many
+admin 5xx to 422 (`docs/wiki/HostedCore.md`). Those two mappings
+differ.
+
+---
+
+## Treasury SEND funding path
+
+The faucet does not submit a SEND. It posts the funding command to
+testnet-control admin (`platform/hosted/faucet/src/main.rs:861-876`;
+`platform/hosted/testnet/deployment.yaml:147`). Testnet-control
+authenticates the control-admin token, validates the command, requires
+the funding journey, and POSTs the same JSON to
+
+`https://layerx-pending-core-admin.layerx-testnet.svc.cluster.local:9444/admin/v1/testnet/fund`
+
+with `LAYERX_TESTNET_BACKEND_ADMIN_TOKEN_FILE`
+(`platform/hosted/testnet/src/main.rs:1255`;
+`platform/hosted/testnet/src/main.rs:1268-1274`;
+`platform/hosted/testnet/deployment.yaml:89`).
+
+Core `fund` / `fund_send` builds an owner-authorised Asset SEND
+(ordinal `SEND_ACTIVITY` `5`) from the treasury seed, submits it on
+LNI, and waits for a receipt
+(`platform/hosted/core/src/lib.rs:19-20`;
+`platform/hosted/core/src/lib.rs:105-110`;
+`platform/hosted/core/src/main.rs:1471-1571`;
+`docs/wiki/HostedCore.md`). Source and destination accounts are
+`agent:<did>:main`. A 200 core body is `funding_id`, `state`
+`funded`, `transaction_id`. A 202 core body is `state` `pending`.
+The faucet accepts only `state == "funded"` as
+`FundingResult::Funded`; `pending` is `Unknown` → `202 still_checking`
+(`platform/hosted/faucet/src/main.rs:889-890`;
+`platform/hosted/faucet/src/main.rs:990`).
+
+Core additionally requires `did == did:layerx:` plus the lowercase
+public key and refuses the treasury DID
+(`platform/hosted/core/src/main.rs:1475-1484`). Testnet-control does
+not apply those two checks. The faucet does not either. Those three
+DID alphabets differ.
+
+---
+
+## Config keys
+
+| Key | Role |
+| --- | --- |
+| `LAYERX_TESTNET_PUBLIC_LISTEN` | Public bind; default `0.0.0.0:9443` (`platform/hosted/testnet/src/main.rs:801-804`; `platform/hosted/testnet/deployment.yaml:86`) |
+| `LAYERX_TESTNET_ADMIN_LISTEN` | Admin bind; default `0.0.0.0:9444` (`platform/hosted/testnet/src/main.rs:805-808`; `platform/hosted/testnet/deployment.yaml:87`) |
+| `LAYERX_TESTNET_TLS_CERT_DER` | Inbound server certificate DER; mounted `/run/layerx/tls/server.crt.der` |
+| `LAYERX_TESTNET_TLS_KEY_DER` | Inbound PKCS#8 key DER; mounted `/run/layerx/tls/server.key.der` |
+| `LAYERX_OUTBOUND_CA_DER` | Trust bundle; mounted `/run/layerx/tls/ca.crt.der` |
+| `LAYERX_PENDING_PACKAGE_SEMVER` | Pending package; ConfigMap `layerx-testnet-release` key `package-semver` (`platform/hosted/testnet/src/main.rs:788-789`; `platform/hosted/testnet/deployment.yaml:84`) |
+| `LAYERX_PENDING_WIRE_PROTOCOL_VERSION` | Pending wire `u16`; ConfigMap key `lxp-wire-protocol-version` (`platform/hosted/testnet/src/main.rs:790-793`; `platform/hosted/testnet/deployment.yaml:85`) |
+| `LAYERX_TESTNET_CORE_URL` | Core HTTPS origin |
+| `LAYERX_TESTNET_CORE_ADMIN_URL` | Core-admin HTTPS origin |
+| `LAYERX_TESTNET_GATEWAY_URL` | Gateway HTTPS origin |
+| `LAYERX_TESTNET_PAXEER_URL` | Paxeer-boundary HTTPS origin |
+| `LAYERX_TESTNET_IDENTITY_URL` | Identity HTTPS origin |
+| `LAYERX_TESTNET_FAUCET_URL` | Faucet HTTPS origin |
+| `LAYERX_TESTNET_RECEIPT_AUTHORITY_URL` | Receipt-authority HTTPS origin |
+| `LAYERX_TESTNET_REGISTRY_URL` | Program-registry HTTPS origin |
+| `LAYERX_TESTNET_REDIS_URL` | `rediss://` origin |
+| `LAYERX_TESTNET_BACKEND_ADMIN_TOKEN_FILE` | Bearer to core-admin; mounted `/run/layerx/backend-admin/token` |
+| `LAYERX_TESTNET_CONTROL_ADMIN_TOKEN_FILE` | Inbound admin Bearer; mounted `/run/layerx/control-admin/token` |
+
+Secret files are read, trailing CR/LF stripped, and refused when empty
+or longer than 4096 bytes (`platform/hosted/testnet/src/main.rs:749-759`).
+Volume mounts are TLS Secret `layerx-testnet-control-tls` at
+`/run/layerx/tls`, `layerx-testnet-backend-admin` at
+`/run/layerx/backend-admin`, and `layerx-testnet-control-admin` at
+`/run/layerx/control-admin`
+(`platform/hosted/testnet/deployment.yaml:107-114`).
+
+`run-testnet.sh` requires the same keys then `exec`s the binary
+(`platform/hosted/testnet/run-testnet.sh:3-24`). The Deployment does
+not use that script.
+
+---
+
+## Cluster CronJobs
+
+CronJob `layerx-testnet-reset` runs `/opt/layerx/reset-testnet.sh`
+(`platform/hosted/testnet/deployment.yaml:200-225`). The script POSTs
+`{}` to `$LAYERX_TESTNET_ADMIN_URL/admin/v1/testnet/reset` with the
+reset token and one idempotency key per calendar month, and requires
+JSON `state == "reset"` with a non-empty `reset_id`
+(`platform/hosted/testnet/reset-testnet.sh:13-33`). It exits `0`
+without calling the admin URL when the UTC day-of-month is greater
+than 7 (`platform/hosted/testnet/reset-testnet.sh:10-12`).
+
+CronJob `layerx-testnet-status-publisher` runs
+`/opt/layerx/render-status.sh`
+(`platform/hosted/testnet/deployment.yaml:227-252`). The script GETs
+`$LAYERX_TESTNET_STATUS_URL` (`/v1/status` on
+`layerx-testnet-public`), checks the four-component shape, and PUTs
+that body to `$LAYERX_STATUS_PUBLISH_URL`
+(`platform/hosted/testnet/render-status.sh:15-38`).
+`status.json` lists the same four component ids
+(`platform/hosted/testnet/status.json:3-8`). The status publisher
+Service is not in this repository; `topology-check.sh` reports that
+edge as `external` (`platform/hosted/tests/topology-check.sh:29-32`).
+
+---
+
+## Callers the NetworkPolicy admits
+
+Admin ingress admits TCP 9444 from `app=layerx-faucet` and
+`app=layerx-testnet-reset`. Public ingress admits TCP 9443 from
+namespace `ingress-nginx` and `app=layerx-testnet-status-publisher`
+(`platform/hosted/testnet/deployment.yaml:254-264`). Egress is
+`layerx-plane: trusted-boundary` on 9443 / 9444 / 9445, gateway 9443,
+faucet 9443, faucet-redis 6379, program-registry 9420, and DNS 53
+(`platform/hosted/testnet/deployment.yaml:266-284`). Gateway ingress
+admits `app=layerx-testnet-control` on 9443
+(`docs/wiki/HostedGateway.md`). Node ingress admits
+`app=layerx-testnet-control` on 9443 / 9444 / 9445
+(`platform/hosted/node/deployment.yaml:273-274`).
+
+`topology-check.sh` default manifests include
+`platform/hosted/testnet/deployment.yaml`
+(`platform/hosted/tests/topology-check.sh:21`;
+`platform/hosted/tests/topology-check.sh:87`). Beta-cluster apply
+order is testnet, then gateway, then registry, then developer
+(`platform/hosted/tests/beta-cluster.sh:868-872`).
+
+---
+
+## Typed refusals
+
+Public and admin JSON refusals use `{"error":{"code":…}}`
+(`platform/hosted/testnet/src/main.rs:1143`;
+`platform/hosted/testnet/src/main.rs:1204-1280`). There is no
+`Retry-After` header (`platform/hosted/testnet/src/main.rs:1295-1310`).
+Faucet refusals set `Retry-After` when a delay is present
+(`docs/wiki/HostedFaucet.md`). Those two header behaviors differ.
+
+| HTTP | Code | Listener | Condition |
+| --- | --- | --- | --- |
+| 400 | `invalid_request` | both | Request framing failed (`platform/hosted/testnet/src/main.rs:1334-1339`) |
+| 400 | `content_type_required` | admin | `Content-Type` is not `application/json` (`platform/hosted/testnet/src/main.rs:1209-1212`) |
+| 400 | `idempotency_key_required` | admin | Missing `Idempotency-Key` (`platform/hosted/testnet/src/main.rs:1215-1218`) |
+| 400 | `invalid_idempotency_key` | admin | Key fails `valid_key` (`platform/hosted/testnet/src/main.rs:1221-1224`) |
+| 400 | `invalid_argument` | admin | Fund JSON/fields rejected, or reset body is not `{}` (`platform/hosted/testnet/src/main.rs:1229-1262`) |
+| 401 | `unauthorized` | admin | Missing or mismatched Bearer (`platform/hosted/testnet/src/main.rs:1203-1207`) |
+| 404 | `not_found` | public | Non-GET, or unknown GET path (`platform/hosted/testnet/src/main.rs:1142-1143`; `platform/hosted/testnet/src/main.rs:1173`) |
+| 404 | `not_found` | admin | Method/path is not fund or reset (`platform/hosted/testnet/src/main.rs:1266`) |
+| 503 | `journey_degraded` | admin | Funding journey probe failed (`platform/hosted/testnet/src/main.rs:1250-1253`) |
+| 503 | `core_unavailable` | admin | Upstream not 200/202/4xx (`platform/hosted/testnet/src/main.rs:1278-1280`) |
+
+`GET /readyz` and journey GETs use 503 with the readiness or
+admission document, not `core_unavailable`. JSON serialization
+failure is `500` `serialization_failure`
+(`platform/hosted/testnet/src/main.rs:1285-1291`). Reason phrase for
+any unlisted status is `Service Unavailable`
+(`platform/hosted/testnet/src/main.rs:1296-1302`).
+
+---
+
+## Tests
+
+Portable crate tests (no cluster):
+
+| Test | Proves |
+| --- | --- |
+| `package_and_wire_versions_are_independent_release_gates` | `TestnetConfig::validate` accepts matching pending package and wire, refuses either mismatch (`platform/hosted/testnet/src/lib.rs:88-107`) |
+| `dependency_reports_are_indexed_by_dependency` | Reports index equals `Dependency::ALL` (`platform/hosted/testnet/src/main.rs:1435-1442`) |
+| `journeys_declare_their_dependency_sets` | Exact four journeys and four routes; settlement is absent (`platform/hosted/testnet/src/main.rs:1444-1498`) |
+| `journey_readiness_is_the_conjunction_of_its_declared_dependencies` | Identity miss degrades only journeys that declare it (`platform/hosted/testnet/src/main.rs:1501-1529`) |
+| `degraded_journey_names_every_failing_dependency_once` | Funding names `faucet` then `core`; refusal code `journey_degraded` (`platform/hosted/testnet/src/main.rs:1532-1552`) |
+| `global_ready_needs_every_journey_every_dependency_and_the_release` | Nine dependencies and four journeys; Paxeer miss degrades global state only (`platform/hosted/testnet/src/main.rs:1555-1595`) |
+| `release_mismatch_degrades_the_global_state_without_touching_journeys` | Package mismatch → public `testnet` component `degraded` (`platform/hosted/testnet/src/main.rs:1598-1619`) |
+| `public_status_keeps_the_published_four_component_shape` | Keys and component names `testnet`, `gateway`, `core`, `paxeer` (`platform/hosted/testnet/src/main.rs:1622-1654`) |
+| `redis_endpoint_requires_the_rediss_scheme` | `rediss://` only, no path; `https` parse rejects `rediss` (`platform/hosted/testnet/src/main.rs:1657-1672`) |
+
+Hosted smoke (`platform/hosted/testnet/tests/hosted-smoke.sh`):
+
+- Testnet `GET /readyz` is 200, `state == "ready"`, nine named
+  dependencies ready, four journeys ready
+  (`platform/hosted/testnet/tests/hosted-smoke.sh:52-65`)
+- `GET /v1/parameters` is 200 and matches readiness network id,
+  package, and wire
+  (`platform/hosted/testnet/tests/hosted-smoke.sh:89-96`)
+- Journeys `funding`, `payment`, `receipt-inspection`, `programs`
+  are admitted in that order
+  (`platform/hosted/testnet/tests/hosted-smoke.sh:101`;
+  `platform/hosted/testnet/tests/hosted-smoke.sh:113`;
+  `platform/hosted/testnet/tests/hosted-smoke.sh:134`;
+  `platform/hosted/testnet/tests/hosted-smoke.sh:151`)
+
+Make:
+
+| Target | Testnet use |
+| --- | --- |
+| `platform-test` | workspace `cargo test`, including `layerx-platform-testnet` (`platform/Makefile.inc:112-113`) |
+| `platform-test-tooling` | `cargo test -p layerx-platform-testnet` and `sh -n` of `run-testnet.sh`, `reset-testnet.sh`, `render-status.sh`, `hosted-smoke.sh` (`platform/Makefile.inc:119-121`) |
+| `platform-hosted-smoke` | requires `LAYERX_TESTNET_URL` and `LAYERX_FAUCET_URL` (`platform/Makefile.inc:161-173`) |
+| `platform-hosted-topology-check` | default manifests include testnet (`platform/Makefile.inc:177-178`; `platform/hosted/tests/topology-check.sh:21`) |
+| `platform-beta-cluster-up` | waits until testnet `GET /readyz` has `state == "ready"` and every journey ready (`platform/hosted/tests/beta-cluster.sh:1286-1287`) |


### PR DESCRIPTION
Adds four code-cited wiki pages for the remaining hosted services: HostedFaucet, HostedTestnetControl, HostedNode and HostedAgentBoundary, linked from Home.md alongside the other Hosted pages.

Docs only; no code or check changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
