### PR TITLE
Use Sidiora Labs registry for hosted images

### DIFF
--- a/docs/wiki/HostedInternal.md
+++ b/docs/wiki/HostedInternal.md
@@ -17,7 +17,7 @@ durable observe adapter behind `journeys`, `payments`, `approvals`, and
 `platform/hosted/internal/Cargo.toml:11-17`;
 `platform/hosted/internal/src/lib.rs:21-23`).
 
-The image is `ghcr.io/centra-ai/layerx-internal:0.1.0`, user
+The image is `ghcr.io/sidiora-labs/layerx-internal:0.1.0`, user
 `4020:4020`. The build produces both binaries. The image `ENTRYPOINT`
 is `/usr/local/bin/layerx-kms`; event-source Deployments set
 `command: [/usr/local/bin/layerx-event-source]`

--- a/docs/wiki/HostedWebhooks.md
+++ b/docs/wiki/HostedWebhooks.md
@@ -28,14 +28,14 @@ dashboard.
 
 ## Deployment
 
-The image is `ghcr.io/centra-ai/layerx-webhooks:0.1.0`
+The image is `ghcr.io/sidiora-labs/layerx-webhooks:0.1.0`
 (`platform/hosted/webhooks/deployment.yaml:69`;
 `platform/hosted/tests/beta-cluster.sh:118`). Dashboard images in the
-same list also use `ghcr.io/centra-ai/...`
+same list also use `ghcr.io/sidiora-labs/...`
 (`platform/hosted/tests/beta-cluster.sh:119-120`). Testnet, gateway, faucet, registry, node, boundary, identity, and paxd
 images in that list use `ghcr.io/sidiora-labs/...`
-(`platform/hosted/tests/beta-cluster.sh:114-117, 121-128`). Those two
-registry prefixes differ. The Dockerfile builds
+(`platform/hosted/tests/beta-cluster.sh:114-117, 121-128`). These images share the same
+registry prefix. The Dockerfile builds
 `-p layerx-platform-webhooks --bin layerx-webhooks`, copies
 `/src/platform/target/release/layerx-webhooks`, sets `USER 65532:65532`,
 and entrypoint `/usr/local/bin/layerx-webhooks`

--- a/platform/hosted/internal/deployment.yaml
+++ b/platform/hosted/internal/deployment.yaml
@@ -96,7 +96,7 @@ spec:
       securityContext: {runAsUser: 4020, runAsGroup: 4020, fsGroup: 4020}
       containers:
         - name: kms
-          image: ghcr.io/centra-ai/layerx-internal:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-internal:0.1.0
           command: [/usr/local/bin/layerx-kms]
           env:
             - {name: LAYERX_KMS_LISTEN, value: "0.0.0.0:9443"}
@@ -157,7 +157,7 @@ spec:
       securityContext: {runAsUser: 4020, runAsGroup: 4020, fsGroup: 4020}
       containers:
         - name: journeys
-          image: ghcr.io/centra-ai/layerx-internal:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-internal:0.1.0
           command: [/usr/local/bin/layerx-event-source]
           env:
             - {name: LAYERX_EVENTS_LISTEN, value: "0.0.0.0:9443"}
@@ -229,7 +229,7 @@ spec:
       securityContext: {runAsUser: 4020, runAsGroup: 4020, fsGroup: 4020}
       containers:
         - name: payments
-          image: ghcr.io/centra-ai/layerx-internal:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-internal:0.1.0
           command: [/usr/local/bin/layerx-event-source]
           env:
             - {name: LAYERX_EVENTS_LISTEN, value: "0.0.0.0:9443"}
@@ -301,7 +301,7 @@ spec:
       securityContext: {runAsUser: 4020, runAsGroup: 4020, fsGroup: 4020}
       containers:
         - name: approvals
-          image: ghcr.io/centra-ai/layerx-internal:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-internal:0.1.0
           command: [/usr/local/bin/layerx-event-source]
           env:
             - {name: LAYERX_EVENTS_LISTEN, value: "0.0.0.0:9443"}
@@ -373,7 +373,7 @@ spec:
       securityContext: {runAsUser: 4020, runAsGroup: 4020, fsGroup: 4020}
       containers:
         - name: programs
-          image: ghcr.io/centra-ai/layerx-internal:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-internal:0.1.0
           command: [/usr/local/bin/layerx-event-source]
           env:
             - {name: LAYERX_EVENTS_LISTEN, value: "0.0.0.0:9443"}

--- a/platform/hosted/tests/beta-cluster.sh
+++ b/platform/hosted/tests/beta-cluster.sh
@@ -115,9 +115,9 @@ image_source() {
         layerx-gateway) printf 'ghcr.io/sidiora-labs/layerx-gateway:0.1.0 platform/hosted/gateway/Dockerfile' ;;
         layerx-faucet) printf 'ghcr.io/sidiora-labs/layerx-faucet:0.1.0 platform/hosted/faucet/Dockerfile' ;;
         layerx-program-registry) printf 'ghcr.io/sidiora-labs/layerx-program-registry:0.1.0 platform/hosted/registry/Dockerfile' ;;
-        layerx-webhooks) printf 'ghcr.io/centra-ai/layerx-webhooks:0.1.0 platform/hosted/webhooks/Dockerfile' ;;
-        layerx-dashboard) printf 'ghcr.io/centra-ai/layerx-dashboard:0.1.0 platform/hosted/dashboard/Dockerfile' ;;
-        layerx-dashboard-web) printf 'ghcr.io/centra-ai/layerx-dashboard-web:0.1.0 platform/hosted/dashboard/web/Dockerfile' ;;
+        layerx-webhooks) printf 'ghcr.io/sidiora-labs/layerx-webhooks:0.1.0 platform/hosted/webhooks/Dockerfile' ;;
+        layerx-dashboard) printf 'ghcr.io/sidiora-labs/layerx-dashboard:0.1.0 platform/hosted/dashboard/Dockerfile' ;;
+        layerx-dashboard-web) printf 'ghcr.io/sidiora-labs/layerx-dashboard-web:0.1.0 platform/hosted/dashboard/web/Dockerfile' ;;
         layerx-node) printf 'ghcr.io/sidiora-labs/layerx-node:0.1.0 platform/hosted/node/Dockerfile' ;;
         layerx-core-boundary) printf 'ghcr.io/sidiora-labs/layerx-core-boundary:0.1.0 platform/hosted/core/Dockerfile' ;;
         layerx-receipt-authority) printf 'ghcr.io/sidiora-labs/layerx-receipt-authority:0.1.0 platform/hosted/authority/Dockerfile' ;;

--- a/platform/hosted/webhooks/deployment.yaml
+++ b/platform/hosted/webhooks/deployment.yaml
@@ -68,7 +68,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: webhooks
-          image: ghcr.io/centra-ai/layerx-webhooks:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-webhooks:0.1.0
           envFrom: [{ configMapRef: { name: layerx-developer-hosted } }]
           env:
             - { name: LAYERX_WEBHOOKS_COMPONENT_URL, value: "https://layerx-agent-boundary.layerx-testnet.svc:9443" }
@@ -136,7 +136,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: api
-          image: ghcr.io/centra-ai/layerx-dashboard:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-dashboard:0.1.0
           envFrom: [{ configMapRef: { name: layerx-developer-hosted } }]
           ports: [{ name: https, containerPort: 9445 }]
           readinessProbe: { httpGet: { scheme: HTTPS, path: /healthz, port: https }, periodSeconds: 10 }
@@ -182,7 +182,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: web
-          image: ghcr.io/centra-ai/layerx-dashboard-web:0.1.0
+          image: ghcr.io/sidiora-labs/layerx-dashboard-web:0.1.0
           ports: [{ name: http, containerPort: 3000 }]
           readinessProbe: { httpGet: { path: /, port: http }, periodSeconds: 10 }
           resources:

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4813,6 +4813,12 @@ file = "human/Cargo.lock platform/Cargo.lock"
 symbol = "ureq native-tls connector dependency"
 observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
 assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
+[observation.6.8.5]
+task = "6.8"
+file = "platform/hosted/internal/deployment.yaml platform/hosted/webhooks/deployment.yaml platform/hosted/gateway/deployment.yaml platform/hosted/tests/topology-check.sh"
+symbol = "platform-hosted-topology-check"
+observed = "After image registry normalization, make platform-hosted-topology-check exits 2 with 20 failed edges; qual-logs/img1/topology.log. Missing layerx-human Services block journeys and approvals. Gateway ingress denies internal payments and programs. Developer egress does not admit callee pod ports 9443 and 9445, and dashboard inherits webhook URLs from the shared ConfigMap whose callees deny dashboard ingress. These failure classes are also recorded in observation.6.8.4. bash -n platform/hosted/tests/beta-cluster.sh, bash tools/ci/beta-contract-check.sh, make beta-ledger-check and git diff --check exit 0; logs shell-syntax.log, contract.log, ledger.log and diff.log under qual-logs/img1. The repository registry scan excludes historical qualification records and prints no matches, exit 1; qual-logs/img1/registry-scan.log."
+assumption = "The registry reference change preserves image names, version 0.1.0, Dockerfile mappings and manifest rewriting. Service and NetworkPolicy repairs are outside this change. No cluster is run; aggregate topology qualification remains blocked. Codify review and guard cannot run without a local graph; cortex_guard is unavailable."
 severity = "blocker"
 
 [observation.6.6.10]

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4813,6 +4813,8 @@ file = "human/Cargo.lock platform/Cargo.lock"
 symbol = "ureq native-tls connector dependency"
 observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
 assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
+severity = "blocker"
+
 [observation.6.8.5]
 task = "6.8"
 file = "platform/hosted/internal/deployment.yaml platform/hosted/webhooks/deployment.yaml platform/hosted/gateway/deployment.yaml platform/hosted/tests/topology-check.sh"


### PR DESCRIPTION
Replace all 14 foreign registry references in the hosted manifests, cluster image mapping, and wiki pages with `ghcr.io/sidiora-labs/`, retaining image names and `0.1.0` tags. The actual image mapping and manifest rewrite functions pass a focused local check. Historical qualification records remain unchanged.

Qualification is partial: topology reports 20 failed edges involving missing Human Services, internal gateway ingress, developer egress ports, and shared ConfigMap URLs. Recorded in observation.6.8.5; no cluster was run.

Commands run from `/root/lx-lanes/gosdk` with `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`:

| Command | Exit | Log |
| --- | --- | --- |
| `bash -n platform/hosted/tests/beta-cluster.sh` | 0 | `qual-logs/img1/shell-syntax.log` |
| `make platform-hosted-topology-check` | 2 | `qual-logs/img1/topology.log` |
| `bash tools/ci/beta-contract-check.sh` | 0 | `qual-logs/img1/contract.log` |
| `git grep -n centra-ai -- ':!spec/**/qualification.kvx' ':!qual-logs'` | 1 | `qual-logs/img1/registry-scan.log` |
| `make beta-ledger-check` | 0 | `qual-logs/img1/ledger.log` |
| `git diff --check` | 0 | `qual-logs/img1/diff.log` |
| `bash qual-logs/img1/image-rewrite.sh` | 0 | `qual-logs/img1/image-rewrite.log` |
| `make beta-ledger-check` | 0 | `qual-logs/img1/ledger-final.log` |
| `git diff --check` | 0 | `qual-logs/img1/diff-final.log` |

Registry scan exit 1 means no matches and an empty log. The rewrite check extracts the actual functions from beta-cluster.sh and renders only the developer manifest locally. Logs are untracked under this worktree. Codify review/guard are unavailable without a local graph; cortex_guard is unavailable.

🤖 Generated with Codex
