### PR TITLE
Require private CA trust in agentd outbound TLS and add a Human-owner runtime mode

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -728,6 +728,8 @@ dependencies = [
  "layerx-proof",
  "layerx-types",
  "layerx-wire",
+ "native-tls",
+ "openssl",
  "rustix",
  "serde_json",
  "sha2",
@@ -1515,6 +1517,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -1623,6 +1626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/agent/crates/layerx-agentd/Cargo.toml
+++ b/agent/crates/layerx-agentd/Cargo.toml
@@ -17,12 +17,14 @@ layerx-programs-runtime = { path = "../../../programs/crates/layerx-programs-run
 layerx-programs-protocol-adapter = { path = "../../../programs/crates/layerx-programs-protocol-adapter" }
 sha2 = "=0.10.9"
 serde_json = "=1.0.149"
-ureq = { version = "=3.4.0", default-features = false, features = ["json", "native-tls-no-default"] }
+ureq = { version = "=3.4.0", default-features = false, features = ["json", "native-tls"] }
 rustix = { version = "=1.1.4", features = ["net"] }
 zeroize = "=1.9.0"
 getrandom = "=0.3.4"
 
 [dev-dependencies]
+native-tls = "=0.2.15"
+openssl = "=0.10.73"
 ed25519-dalek = "=2.2.0"
 k256 = { version = "=0.13.4", default-features = false, features = ["ecdsa", "std"] }
 

--- a/agent/crates/layerx-agentd/README.md
+++ b/agent/crates/layerx-agentd/README.md
@@ -1,0 +1,38 @@
+# layerx-agentd
+
+`LAYERX_AGENT_MODE` selects `full` (also the default when unset) or
+`human-owner`. Other values, including an empty value, are refused.
+
+Full mode starts the Human owner and the verified Programs reader. Its Programs
+probe, admission journal, protected sequencer history, replica identity and
+credential checks remain required.
+
+Human-owner mode starts only the Human owner. All existing `LAYERX_AGENT_HUMAN_*`
+LNI, peer, authority, session key, store, socket and limit inputs remain required.
+It does not read the Programs probe, admission journal, sequencer history or node
+reader inputs. It reuses `LAYERX_AGENT_PROGRAM_LISTEN` (127.0.0.1 only) and
+`LAYERX_AGENT_PROGRAM_BEARER_TOKEN` (at least 32 bytes, distinct from the Human
+authority bearer) for authenticated `GET /healthz`. Other routes return 404.
+Health returns 200 with `{"ready":true}` only after successful owner startup,
+while its listener thread is running, and after a fresh node LNI handshake and
+an authority registry read for every configured peer. Dependency failure returns
+503 with `{"ready":false}`; owner termination stops the process. Health requests
+retain the existing 16 KiB header bound and 10-second socket timeouts.
+
+`LAYERX_AGENT_HUMAN_AUTHORITY_CA_DER` is required in both modes and names a file
+containing the DER-encoded CA certificate for the Human authority HTTPS endpoint.
+`LAYERX_AGENT_AUTHORITY_CA_DER` is additionally required in full mode and names
+the DER CA file trusted by both Programs read endpoints. Empty or unreadable CA
+files are refused. Clients use Native TLS with only the supplied CA as a trust
+root; hostname verification remains enabled. Human authority endpoints require
+HTTPS; Programs endpoints retain their existing HTTPS or loopback HTTP rule.
+
+TLS tests generate temporary CA and server certificates using the existing
+locked OpenSSL crate and run a real loopback Native TLS server. Both crates were
+already in agent/Cargo.lock; they are direct test dependencies of this crate.
+
+ureq 3.4.0 requires its `native-tls` feature to compile the Native TLS connector;
+`native-tls-no-default` alone leaves HTTPS requests panicking even with an
+explicit provider. Enabling the connector adds the transitive
+`webpki-root-certs` package. Its bundled roots are not selected: the explicit
+`RootCerts::Specific` configuration trusts only the supplied CA.

--- a/agent/crates/layerx-agentd/src/human_owner_mode.rs
+++ b/agent/crates/layerx-agentd/src/human_owner_mode.rs
@@ -1,0 +1,204 @@
+use super::{
+    config, connect_human_authority, connect_human_node, human_lni_limits, human_peers, parse_u64,
+    required, response, serve, start_human_owner, HEADER_LIMIT,
+};
+use std::env;
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+#[derive(Debug, PartialEq, Eq)]
+enum Mode {
+    Full,
+    HumanOwner,
+}
+
+impl Mode {
+    fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value {
+            None | Some("full") => Ok(Self::Full),
+            Some("human-owner") => Ok(Self::HumanOwner),
+            Some(_) => Err("LAYERX_AGENT_MODE is invalid".to_owned()),
+        }
+    }
+}
+
+pub(super) fn run() -> Result<(), String> {
+    let mode = match env::var("LAYERX_AGENT_MODE") {
+        Ok(value) => Mode::parse(Some(&value))?,
+        Err(env::VarError::NotPresent) => Mode::parse(None)?,
+        Err(env::VarError::NotUnicode(_)) => return Err("LAYERX_AGENT_MODE is invalid".to_owned()),
+    };
+    match mode {
+        Mode::Full => config().and_then(serve),
+        Mode::HumanOwner => serve_human_owner(),
+    }
+}
+
+fn dependencies_ready() -> Result<(), String> {
+    let deadline = Duration::from_millis(parse_u64("LAYERX_AGENT_HUMAN_DEADLINE_MS")?);
+    let human_limits = human_lni_limits(deadline)?;
+    let node_limits = layerx_client::lni::transport::Limits {
+        maximum_frame_bytes: human_limits
+            .maximum_frame_bytes
+            .max(layerx_client::evidence::MINIMUM_FINALITY_FRAME_BYTES),
+        ..human_limits
+    };
+    connect_human_node(
+        PathBuf::from(required("LAYERX_AGENT_HUMAN_NODE_LNI")?),
+        node_limits,
+    )?;
+    connect_human_authority(deadline, &human_peers()?)?;
+    Ok(())
+}
+
+fn owner_running(human: &mpsc::Receiver<Result<(), String>>) -> Result<(), String> {
+    match human.try_recv() {
+        Err(mpsc::TryRecvError::Empty) => Ok(()),
+        Ok(Err(error)) => Err(error),
+        Ok(Ok(())) | Err(mpsc::TryRecvError::Disconnected) => {
+            Err("human listener terminated".to_owned())
+        }
+    }
+}
+
+fn serve_human_owner() -> Result<(), String> {
+    let listen = required("LAYERX_AGENT_PROGRAM_LISTEN")?;
+    let bearer = required("LAYERX_AGENT_PROGRAM_BEARER_TOKEN")?;
+    if !listen.starts_with("127.0.0.1:") || bearer.len() < 32 {
+        return Err("human health requires loopback and a bounded credential".to_owned());
+    }
+    if bearer == required("LAYERX_AGENT_HUMAN_AUTHORITY_BEARER")? {
+        return Err("human health and authority credentials must be distinct".to_owned());
+    }
+    let human = start_human_owner()?;
+    let listener = TcpListener::bind(listen)
+        .map_err(|error| format!("human health listener failed: {error}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|error| format!("human health nonblocking setup failed: {error}"))?;
+    loop {
+        owner_running(&human)?;
+        let mut stream = match listener.accept() {
+            Ok((stream, _)) => stream,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(25));
+                continue;
+            }
+            Err(error) => return Err(format!("human health accept failed: {error}")),
+        };
+        stream
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .and_then(|()| stream.set_write_timeout(Some(Duration::from_secs(10))))
+            .map_err(|error| format!("human health connection timeout setup failed: {error}"))?;
+        let _ = serve_health(&mut stream, &bearer, &human);
+    }
+}
+
+fn serve_health(
+    stream: &mut TcpStream,
+    bearer: &str,
+    human: &mpsc::Receiver<Result<(), String>>,
+) -> Result<(), String> {
+    let mut bytes = [0_u8; HEADER_LIMIT];
+    let mut length = 0;
+    while length < bytes.len() && !bytes[..length].windows(4).any(|value| value == b"\r\n\r\n") {
+        let count = stream
+            .read(&mut bytes[length..])
+            .map_err(|error| format!("agent request failed: {error}"))?;
+        if count == 0 {
+            return Err("agent request ended before its headers".to_owned());
+        }
+        length += count;
+    }
+    if !bytes[..length].windows(4).any(|value| value == b"\r\n\r\n") {
+        return response(stream, 431, "{\"error\":\"headers_too_large\"}");
+    }
+    let request = std::str::from_utf8(&bytes[..length])
+        .map_err(|_| "agent request headers are not UTF-8".to_owned())?;
+    let line = request.lines().next().unwrap_or_default();
+    let mut parts = line.split_ascii_whitespace();
+    let method = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or_default();
+    if parts.next() != Some("HTTP/1.1") || parts.next().is_some() || method != "GET" {
+        return response(stream, 400, "{\"error\":\"invalid_request\"}");
+    }
+    if !request
+        .lines()
+        .any(|header| header.strip_prefix("Authorization: Bearer ") == Some(bearer))
+    {
+        return response(stream, 401, "{\"error\":\"unauthorized\"}");
+    }
+    if path != "/healthz" {
+        return response(stream, 404, "{\"error\":\"not_found\"}");
+    }
+    let ready = owner_running(human)
+        .and_then(|()| dependencies_ready())
+        .and_then(|()| owner_running(human))
+        .is_ok();
+    if ready {
+        response(stream, 200, "{\"ready\":true}")
+    } else {
+        response(stream, 503, "{\"ready\":false}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Mode;
+
+    #[test]
+    fn mode_selection_is_explicit_and_closed() {
+        assert_eq!(Mode::parse(None), Ok(Mode::Full));
+        assert_eq!(Mode::parse(Some("full")), Ok(Mode::Full));
+        assert_eq!(Mode::parse(Some("human-owner")), Ok(Mode::HumanOwner));
+        for value in ["", "human", "FULL", "human-owner "] {
+            assert!(Mode::parse(Some(value)).is_err());
+        }
+    }
+
+    #[test]
+    fn health_refuses_terminated_owner_and_preserves_http_boundaries(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use std::io::{Read, Write};
+        use std::net::{TcpListener, TcpStream};
+        use std::sync::mpsc;
+        use std::thread;
+        use std::time::Duration;
+
+        let bearer = "h".repeat(32);
+        let cases = [
+            (format!("GET /healthz HTTP/1.1\r\nAuthorization: Bearer {bearer}\r\n\r\n"), 503, "{\"ready\":false}"),
+            ("GET /healthz HTTP/1.1\r\n\r\n".to_owned(), 401, "unauthorized"),
+            (format!("GET /v1/programs/anything/balances HTTP/1.1\r\nAuthorization: Bearer {bearer}\r\n\r\n"), 404, "not_found"),
+            ("POST /healthz HTTP/1.1\r\n\r\n".to_owned(), 400, "invalid_request"),
+            ("x".repeat(super::HEADER_LIMIT), 431, "headers_too_large"),
+        ];
+        for (request, status, body) in cases {
+            let listener = TcpListener::bind("127.0.0.1:0")?;
+            let address = listener.local_addr()?;
+            let bearer = bearer.clone();
+            let server = thread::spawn(move || -> Result<(), String> {
+                let (mut stream, _) = listener.accept().map_err(|e| e.to_string())?;
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .map_err(|e| e.to_string())?;
+                let (sender, receiver) = mpsc::channel();
+                drop(sender);
+                super::serve_health(&mut stream, &bearer, &receiver)
+            });
+            let mut client = TcpStream::connect(address)?;
+            client.set_read_timeout(Some(Duration::from_secs(5)))?;
+            client.write_all(request.as_bytes())?;
+            let mut response = String::new();
+            client.read_to_string(&mut response)?;
+            server.join().map_err(|_| "health server panicked")??;
+            assert!(response.starts_with(&format!("HTTP/1.1 {status} ")));
+            assert!(response.contains(body));
+        }
+        Ok(())
+    }
+}

--- a/agent/crates/layerx-agentd/src/human_runtime.rs
+++ b/agent/crates/layerx-agentd/src/human_runtime.rs
@@ -230,6 +230,7 @@ impl RemoteHumanAuthority {
         bearer: String,
         deadline: Duration,
         maximum_response_bytes: usize,
+        ca_der: &[u8],
     ) -> Result<Self, HumanOperationError> {
         let endpoint = endpoint.trim_end_matches('/');
         if !endpoint.starts_with("https://")
@@ -240,7 +241,9 @@ impl RemoteHumanAuthority {
         {
             return Err(HumanOperationError::Refused);
         }
+        let tls = crate::outbound_tls::private_ca(ca_der).ok_or(HumanOperationError::Refused)?;
         let config = ureq::Agent::config_builder()
+            .tls_config(tls)
             .timeout_global(Some(deadline))
             .http_status_as_error(false)
             .build();
@@ -3524,3 +3527,7 @@ fn validate_capability<A: HumanAuthorityBoundary>(
     }
     Ok((capability, observed))
 }
+
+#[cfg(test)]
+#[path = "outbound_tls/tests.rs"]
+mod outbound_tls_tests;

--- a/agent/crates/layerx-agentd/src/lib.rs
+++ b/agent/crates/layerx-agentd/src/lib.rs
@@ -35,3 +35,5 @@ pub mod shutdown;
 pub mod sign;
 pub mod store;
 pub mod tenant;
+
+mod outbound_tls;

--- a/agent/crates/layerx-agentd/src/main.rs
+++ b/agent/crates/layerx-agentd/src/main.rs
@@ -17,7 +17,7 @@ use layerx_agentd::human_runtime::{
     HumanAuthorityBoundary, ProductionHumanOperations, RemoteHumanAuthority, UnifiedAgentOwner,
 };
 use layerx_agentd::read::{
-    LayerxdProgramBalanceReader, ProgramBalanceRead, ProgramBalanceReadRoute,
+    LayerxdProgramBalanceReader, ProgramAuthority, ProgramBalanceRead, ProgramBalanceReadRoute,
 };
 use layerx_agentd::session_keys::SessionKeyRegistry;
 use layerx_agentd::store::Store;
@@ -31,6 +31,8 @@ use layerx_programs::{
     ProtocolDeploymentVerifier, Registry,
 };
 
+mod human_owner_mode;
+
 const HEADER_LIMIT: usize = 16 * 1024;
 
 struct Config {
@@ -40,6 +42,7 @@ struct Config {
     node_bearer: String,
     authority_endpoint: String,
     authority_bearer: String,
+    authority_ca_der: Vec<u8>,
     authority_replica_id: [u8; 32],
     sequencer_trust_history: String,
     staleness_ms: u64,
@@ -52,6 +55,14 @@ fn required(name: &str) -> Result<String, String> {
         .ok()
         .filter(|value| !value.is_empty())
         .ok_or_else(|| format!("{name} is required"))
+}
+
+fn read_ca(name: &str) -> Result<Vec<u8>, String> {
+    let bytes = fs::read(required(name)?).map_err(|_| format!("{name} is unreadable"))?;
+    if bytes.is_empty() {
+        return Err(format!("{name} is empty"));
+    }
+    Ok(bytes)
 }
 
 fn parse_u64(name: &str) -> Result<u64, String> {
@@ -183,6 +194,7 @@ fn connect_human_authority(
         required("LAYERX_AGENT_HUMAN_AUTHORITY_MAX_BYTES")?
             .parse()
             .map_err(|_| "human authority bound is invalid")?,
+        &read_ca("LAYERX_AGENT_HUMAN_AUTHORITY_CA_DER")?,
     )
     .map_err(|error| format!("human authority is invalid: {error:?}"))?;
     for (uid, (principal, tenant)) in peers {
@@ -317,6 +329,7 @@ fn config() -> Result<Config, String> {
         node_bearer,
         authority_endpoint: required("LAYERX_AGENT_AUTHORITY_ENDPOINT")?,
         authority_bearer,
+        authority_ca_der: read_ca("LAYERX_AGENT_AUTHORITY_CA_DER")?,
         authority_replica_id: parse_digest("LAYERX_AGENT_AUTHORITY_REPLICA_ID")?,
         sequencer_trust_history: required("LAYERX_AGENT_SEQUENCER_TRUST_HISTORY")?,
         staleness_ms,
@@ -506,9 +519,12 @@ fn serve(config: Config) -> Result<(), String> {
     let reader = LayerxdProgramBalanceReader::connect(
         &config.node_endpoint,
         config.node_bearer,
-        &config.authority_endpoint,
-        config.authority_bearer,
-        config.authority_replica_id,
+        ProgramAuthority {
+            endpoint: &config.authority_endpoint,
+            authorization: config.authority_bearer,
+            replica_id: config.authority_replica_id,
+            ca_der: &config.authority_ca_der,
+        },
         verifier,
         registry,
     )
@@ -552,7 +568,7 @@ fn serve(config: Config) -> Result<(), String> {
 }
 
 fn main() {
-    if let Err(error) = config().and_then(serve) {
+    if let Err(error) = human_owner_mode::run() {
         eprintln!("layerx-agentd: {}", Redacted::boot_diagnostic(&error));
         std::process::exit(2);
     }

--- a/agent/crates/layerx-agentd/src/outbound_tls.rs
+++ b/agent/crates/layerx-agentd/src/outbound_tls.rs
@@ -1,0 +1,15 @@
+use ureq::tls::{Certificate, RootCerts, TlsConfig, TlsProvider};
+
+pub(crate) fn private_ca(ca_der: &[u8]) -> Option<TlsConfig> {
+    if ca_der.is_empty() {
+        return None;
+    }
+    Some(
+        TlsConfig::builder()
+            .provider(TlsProvider::NativeTls)
+            .root_certs(RootCerts::new_with_certs(&[
+                Certificate::from_der(ca_der).to_owned()
+            ]))
+            .build(),
+    )
+}

--- a/agent/crates/layerx-agentd/src/outbound_tls/tests.rs
+++ b/agent/crates/layerx-agentd/src/outbound_tls/tests.rs
@@ -1,0 +1,187 @@
+use std::error::Error;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+use native_tls::{Identity, TlsAcceptor};
+use openssl::asn1::Asn1Time;
+use openssl::bn::{BigNum, MsbOption};
+use openssl::hash::MessageDigest;
+use openssl::pkey::{PKey, Private};
+use openssl::rsa::Rsa;
+use openssl::x509::extension::{
+    BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
+};
+use openssl::x509::{X509NameBuilder, X509};
+
+use crate::human::HumanOperationError;
+use crate::human_runtime::RemoteHumanAuthority;
+
+type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+
+fn certificate(issuer: Option<(&X509, &PKey<Private>)>) -> TestResult<(X509, PKey<Private>)> {
+    let key = PKey::from_rsa(Rsa::generate(2048)?)?;
+    let mut name = X509NameBuilder::new()?;
+    name.append_entry_by_text(
+        "CN",
+        if issuer.is_some() {
+            "localhost"
+        } else {
+            "LayerX test CA"
+        },
+    )?;
+    let name = name.build();
+    let mut cert = X509::builder()?;
+    cert.set_version(2)?;
+    let mut serial = BigNum::new()?;
+    serial.rand(128, MsbOption::MAYBE_ZERO, false)?;
+    cert.set_serial_number(serial.to_asn1_integer()?.as_ref())?;
+    cert.set_subject_name(&name)?;
+    cert.set_issuer_name(issuer.map_or(&name, |(ca, _)| ca.subject_name()))?;
+    cert.set_pubkey(&key)?;
+    cert.set_not_before(Asn1Time::days_from_now(0)?.as_ref())?;
+    cert.set_not_after(Asn1Time::days_from_now(1)?.as_ref())?;
+    if let Some((ca, signing_key)) = issuer {
+        cert.append_extension(BasicConstraints::new().critical().build()?)?;
+        cert.append_extension(
+            KeyUsage::new()
+                .digital_signature()
+                .key_encipherment()
+                .build()?,
+        )?;
+        cert.append_extension(ExtendedKeyUsage::new().server_auth().build()?)?;
+        let san = SubjectAlternativeName::new()
+            .dns("localhost")
+            .build(&cert.x509v3_context(Some(ca), None))?;
+        cert.append_extension(san)?;
+        cert.sign(signing_key, MessageDigest::sha256())?;
+    } else {
+        cert.append_extension(BasicConstraints::new().critical().ca().build()?)?;
+        cert.append_extension(
+            KeyUsage::new()
+                .critical()
+                .key_cert_sign()
+                .crl_sign()
+                .build()?,
+        )?;
+        cert.sign(&key, MessageDigest::sha256())?;
+    }
+    Ok((cert.build(), key))
+}
+
+fn exchange(identity: &Identity, ca: &[u8], host: &str) -> TestResult<(bool, bool)> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let acceptor = TlsAcceptor::new(identity.clone())?;
+    let server = thread::spawn(move || -> Result<bool, String> {
+        let (stream, _) = listener.accept().map_err(|e| e.to_string())?;
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| e.to_string())?;
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .map_err(|e| e.to_string())?;
+        let Ok(mut tls) = acceptor.accept(stream) else {
+            return Ok(false);
+        };
+        let mut request = Vec::new();
+        while !request.ends_with(b"\r\n\r\n") && request.len() < 4096 {
+            let mut byte = [0];
+            if tls.read(&mut byte).map_err(|e| e.to_string())? == 0 {
+                return Ok(false);
+            }
+            request.push(byte[0]);
+        }
+        if !request.starts_with(b"GET / HTTP/1.1\r\n") {
+            return Err("unexpected TLS transport request".to_owned());
+        }
+        tls.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\ntrue")
+            .map_err(|e| e.to_string())?;
+        Ok(true)
+    });
+    let authority = RemoteHumanAuthority::connect(
+        &format!("https://{host}:{port}"),
+        "a".repeat(32),
+        Duration::from_secs(5),
+        1024,
+        ca,
+    )
+    .map_err(|_| "invalid authority configuration")?;
+    let accepted = authority
+        .get("/")
+        .is_ok_and(|value| value == serde_json::Value::Bool(true));
+    let handled = server.join().map_err(|_| "TLS server panicked")??;
+    Ok((accepted, handled))
+}
+
+#[test]
+fn private_ca_is_required_and_hostname_verification_remains_enabled() -> TestResult {
+    let (ca, ca_key) = certificate(None)?;
+    let (other_ca, _) = certificate(None)?;
+    let (server_cert, server_key) = certificate(Some((&ca, &ca_key)))?;
+    let identity = Identity::from_pkcs8(
+        &server_cert.to_pem()?,
+        &server_key.private_key_to_pem_pkcs8()?,
+    )?;
+    assert_eq!(
+        exchange(&identity, &ca.to_der()?, "localhost")?,
+        (true, true)
+    );
+    assert_eq!(
+        exchange(&identity, &other_ca.to_der()?, "localhost")?,
+        (false, false)
+    );
+    assert_eq!(
+        exchange(&identity, &ca.to_der()?, "127.0.0.1")?,
+        (false, false)
+    );
+    Ok(())
+}
+
+#[test]
+fn human_authority_refuses_empty_ca_and_preserves_input_bounds() -> TestResult {
+    assert!(crate::outbound_tls::private_ca(&[]).is_none());
+    let result = RemoteHumanAuthority::connect(
+        "https://localhost",
+        "a".repeat(32),
+        Duration::from_secs(1),
+        1024,
+        &[],
+    );
+    assert!(matches!(result, Err(HumanOperationError::Refused)));
+    let ca = certificate(None)?.0.to_der()?;
+    for (endpoint, bearer, deadline, bound) in [
+        (
+            "http://localhost",
+            "a".repeat(32),
+            Duration::from_secs(1),
+            1024,
+        ),
+        (
+            "https://localhost",
+            "a".repeat(31),
+            Duration::from_secs(1),
+            1024,
+        ),
+        ("https://localhost", "a".repeat(32), Duration::ZERO, 1024),
+        (
+            "https://localhost",
+            "a".repeat(32),
+            Duration::from_secs(1),
+            0,
+        ),
+        (
+            "https://localhost",
+            "a".repeat(32),
+            Duration::from_secs(1),
+            usize::MAX,
+        ),
+    ] {
+        assert!(matches!(
+            RemoteHumanAuthority::connect(endpoint, bearer, deadline, bound, &ca),
+            Err(HumanOperationError::Refused)
+        ));
+    }
+    Ok(())
+}

--- a/agent/crates/layerx-agentd/src/read/mod.rs
+++ b/agent/crates/layerx-agentd/src/read/mod.rs
@@ -26,7 +26,7 @@ pub use program_balances_impl::{
     program_balances_from_protocol, ProgramBalanceFreshness, ProgramBalanceRead,
     ProgramValueBalance, ProtocolProgramBalanceReader,
 };
-pub use program_node::{LayerxdProgramBalanceReader, ProgramBalanceReadRoute};
+pub use program_node::{LayerxdProgramBalanceReader, ProgramAuthority, ProgramBalanceReadRoute};
 
 /// Verifies and serves one checkpoint certificate.
 ///

--- a/agent/crates/layerx-agentd/src/read/program_node.rs
+++ b/agent/crates/layerx-agentd/src/read/program_node.rs
@@ -34,6 +34,14 @@ pub struct LayerxdProgramBalanceReader {
     staleness_limit: u64,
 }
 
+/// Explicit independent authority identity and outbound trust for both read endpoints.
+pub struct ProgramAuthority<'a> {
+    pub endpoint: &'a str,
+    pub authorization: String,
+    pub replica_id: [u8; 32],
+    pub ca_der: &'a [u8],
+}
+
 impl LayerxdProgramBalanceReader {
     /// Connects the running agent route to the production node pair.
     ///
@@ -44,12 +52,16 @@ impl LayerxdProgramBalanceReader {
     pub fn connect(
         endpoint: &str,
         authorization: String,
-        authority_endpoint: &str,
-        authority_authorization: String,
-        authority_replica_id: [u8; 32],
+        authority: ProgramAuthority<'_>,
         verifier: ProtocolDeploymentVerifier,
         registry: Registry,
     ) -> Result<Self, ProtocolAdapterError> {
+        let ProgramAuthority {
+            endpoint: authority_endpoint,
+            authorization: authority_authorization,
+            replica_id: authority_replica_id,
+            ca_der,
+        } = authority;
         let endpoint = endpoint.trim_end_matches('/');
         let authority_endpoint = authority_endpoint.trim_end_matches('/');
         if authorization.is_empty()
@@ -61,7 +73,10 @@ impl LayerxdProgramBalanceReader {
         {
             return Err(ProtocolAdapterError::NonCanonicalView);
         }
+        let tls = crate::outbound_tls::private_ca(ca_der)
+            .ok_or(ProtocolAdapterError::NonCanonicalView)?;
         let config = ureq::Agent::config_builder()
+            .tls_config(tls)
             .timeout_global(Some(Duration::from_secs(30)))
             .http_status_as_error(false)
             .build();
@@ -185,14 +200,16 @@ impl LayerxdProgramBalanceReader {
         if node != independent {
             return Err(ProtocolAdapterError::NonCanonicalView);
         }
-        let verified = self.verifier.verify_current_protocol_head(
-            &receipt_bytes,
-            &independent.receipt_proof,
-            &independent.header,
-            &independent.signature,
-            now_ms,
-        )
-        .map_err(|_| ProtocolAdapterError::NonCanonicalView)?;
+        let verified = self
+            .verifier
+            .verify_current_protocol_head(
+                &receipt_bytes,
+                &independent.receipt_proof,
+                &independent.header,
+                &independent.signature,
+                now_ms,
+            )
+            .map_err(|_| ProtocolAdapterError::NonCanonicalView)?;
         if hex::decode_digest(field(&authority_document, "sequencer_public_key")?)
             .map_err(|_| ProtocolAdapterError::NonCanonicalView)?
             != verified.sequencer_public_key()
@@ -206,8 +223,7 @@ impl LayerxdProgramBalanceReader {
             != verified.receipt_digest()
             || digest != verified.receipt_digest()
             || state_root != verified.state_root()
-            || value["observed_sequence"].as_u64()
-                != Some(verified.freshness().observed_sequence)
+            || value["observed_sequence"].as_u64() != Some(verified.freshness().observed_sequence)
             || value["observed_at"].as_u64() != Some(verified.freshness().observed_at)
         {
             return Err(ProtocolAdapterError::NonCanonicalView);

--- a/agent/crates/layerx-agentd/tests/runtime_mode.rs
+++ b/agent/crates/layerx-agentd/tests/runtime_mode.rs
@@ -1,0 +1,104 @@
+use std::error::Error;
+use std::process::Command;
+
+#[test]
+fn full_requires_program_inputs_while_human_owner_reaches_human_checks(
+) -> Result<(), Box<dyn Error>> {
+    for mode in [None, Some("full"), Some("human-owner")] {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_layerx-agentd"));
+        command
+            .env_clear()
+            .env("LAYERX_AGENT_PROGRAM_LISTEN", "127.0.0.1:0")
+            .env("LAYERX_AGENT_PROGRAM_BEARER_TOKEN", "h".repeat(32))
+            .env("LAYERX_AGENT_HUMAN_AUTHORITY_BEARER", "a".repeat(32));
+        if let Some(mode) = mode {
+            command.env("LAYERX_AGENT_MODE", mode);
+        }
+        let output = command.output()?;
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8(output.stderr)?;
+        let required = if mode == Some("human-owner") {
+            "LAYERX_AGENT_HUMAN_PEERS is required"
+        } else {
+            "LAYERX_AGENT_NODE_BEARER_TOKEN is required"
+        };
+        assert!(
+            stderr.contains(required),
+            "unexpected boot diagnostic: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn full_requires_journal_and_probe_even_when_transport_inputs_are_present(
+) -> Result<(), Box<dyn Error>> {
+    use std::os::unix::fs::DirBuilderExt;
+    let root = std::env::temp_dir().join(format!("layerx-agentd-mode-{}", std::process::id()));
+    std::fs::DirBuilder::new().mode(0o700).create(&root)?;
+    let ca = root.join("ca.der");
+    let generated = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-subj",
+            "/CN=mode-test",
+            "-days",
+            "1",
+            "-outform",
+            "DER",
+            "-out",
+        ])
+        .arg(&ca)
+        .arg("-keyout")
+        .arg(root.join("key.pem"))
+        .output()?;
+    assert!(generated.status.success());
+    for mode in ["full", "human-owner"] {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_layerx-agentd"));
+        command
+            .env_clear()
+            .env("LAYERX_AGENT_MODE", mode)
+            .env("LAYERX_AGENT_PROGRAM_LISTEN", "127.0.0.1:0")
+            .env("LAYERX_AGENT_PROGRAM_BEARER_TOKEN", "h".repeat(32))
+            .env("LAYERX_AGENT_HUMAN_AUTHORITY_BEARER", "a".repeat(32))
+            .env("LAYERX_AGENT_NODE_BEARER_TOKEN", "n".repeat(32))
+            .env("LAYERX_AGENT_AUTHORITY_BEARER_TOKEN", "r".repeat(32))
+            .env("LAYERX_AGENT_PROGRAM_MAX_STALENESS_MS", "1000")
+            .env("LAYERX_AGENT_NODE_ENDPOINT", "http://127.0.0.1:1")
+            .env("LAYERX_AGENT_AUTHORITY_ENDPOINT", "https://localhost:2")
+            .env("LAYERX_AGENT_AUTHORITY_CA_DER", &ca)
+            .env("LAYERX_AGENT_AUTHORITY_REPLICA_ID", "01".repeat(32))
+            .env("LAYERX_AGENT_SEQUENCER_TRUST_HISTORY", root.join("history"));
+        let output = command.output()?;
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8(output.stderr)?;
+        let required = if mode == "full" {
+            "LAYERX_AGENT_DEPLOYMENT_JOURNAL is required"
+        } else {
+            "LAYERX_AGENT_HUMAN_PEERS is required"
+        };
+        assert!(
+            stderr.contains(required),
+            "unexpected boot diagnostic: {stderr}"
+        );
+        command.env("LAYERX_AGENT_DEPLOYMENT_JOURNAL", root.join("journal"));
+        let output = command.output()?;
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8(output.stderr)?;
+        let required = if mode == "full" {
+            "LAYERX_AGENT_PROGRAM_PROBE_ID is required"
+        } else {
+            "LAYERX_AGENT_HUMAN_PEERS is required"
+        };
+        assert!(
+            stderr.contains(required),
+            "unexpected boot diagnostic: {stderr}"
+        );
+    }
+    std::fs::remove_dir_all(root)?;
+    Ok(())
+}

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4781,3 +4781,35 @@ symbol = "real_server_wire_statuses_remain_distinct"
 observed = "cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --test human_tls exits 101: the separate real-server wire-status test passes and the real RemoteHumanAuthority test retains its TLS-provider panic. The wire test verifies registry and cached authorized-batch HTTP 200, wrong-tenant and unlisted-capability HTTP 403, service-token HTTP 401, and missing or changed policy and insufficient clock evidence HTTP 503. Evidence: qual-logs/hm2/tls-final.log. Final cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --all-targets -- -D warnings exits 0 in qual-logs/hm2/clippy-last.log; authority-only cargo fmt --check exits 0 in qual-logs/hm2/fmt-last.log."
 assumption = "The wire test proves server behavior but does not replace the failed real-client integration or establish successful responses for the five evidence-blocked routes. Native prerequisite inspection first encounters EACCES under the ordinary UID; privileged read-only stat then confirms both advertised native binary paths are absent. Evidence: qual-logs/hm2/native-prerequisites.log and qual-logs/hm2/native-root-check.log."
 severity = "blocker"
+
+[observation.6.4.170]
+task = "6.4"
+file = "human/crates/layerx-explorer-index/src/main.rs"
+symbol = "refresh_program LayerxdProgramBalanceReader::connect"
+observed = "The Programs reader now requires ProgramAuthority containing endpoint, authorization, replica_id and explicit ca_der. The explorer caller still supplies the former three separate authority arguments and needs a required DER CA input. The caller lies outside the agentd owned paths; its exact migration is recorded in the untracked NEEDS.md."
+assumption = "The explorer owner must supply the explicit CA and migrate the caller before cross-workspace qualification. Agentd full mode reads LAYERX_AGENT_AUTHORITY_CA_DER; both agentd modes read LAYERX_AGENT_HUMAN_AUTHORITY_CA_DER."
+severity = "blocker"
+
+[observation.6.4.171]
+task = "6.4"
+file = "agent/crates/layerx-agent-api/src/generated.rs programs/vendor/wasmi-0.31.2"
+symbol = "cargo fmt --all --check --manifest-path agent/Cargo.toml"
+observed = "The required workspace formatting check exits 1 with pre-existing differences across untouched workspace and vendor files. Evidence: qual-logs/hm7/fmt.log and qual-logs/hm7/fmt.exit. Unrelated formatting changes were not retained."
+assumption = "Workspace formatting requires a separate change owned by the affected components; the Human owner task does not authorize reformatting them."
+severity = "blocker"
+
+[observation.6.4.172]
+task = "6.4"
+file = "agent/crates/layerx-agentd/tests/support/real_authority.rs"
+symbol = "real authority fixture identity and native binaries"
+observed = "cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd exits 101 after library and health tests pass. budget_create fails at real_authority.rs:326 because the harness requires UID 0 but the process UID is 1000; four subsequent failures report a poisoned fixture lock. Evidence: qual-logs/hm7/test-qualified.log. Privileged executable checks also find neither layerxd nor layerx-genesis-build at /root/lx-lanes/native-bin or worktree build/bin; evidence: qual-logs/hm7/native-prerequisites.log."
+assumption = "The unchanged native harness requires a privileged qualification process and real native binaries. Those prerequisites must be supplied before the aggregate test gate can pass; no assertion or test was relaxed."
+severity = "blocker"
+
+[observation.6.4.173]
+task = "6.4"
+file = "human/Cargo.lock platform/Cargo.lock"
+symbol = "ureq native-tls connector dependency"
+observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
+assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
+severity = "blocker"


### PR DESCRIPTION
agentd built its outbound HTTPS clients without any TLS configuration. The workspace compiles ureq with native-tls only, so the default Rustls provider panicked on the first HTTPS request and no path existed to trust a private CA. This change:

- configures `RemoteHumanAuthority` and the Programs reader with `TlsProvider::NativeTls` and an explicit DER root CA (`LAYERX_AGENT_HUMAN_AUTHORITY_CA_DER`; `LAYERX_AGENT_AUTHORITY_CA_DER` for full mode), refusing empty CA bytes and keeping hostname verification, the https requirement and response bounds intact;
- adds `LAYERX_AGENT_MODE=human-owner`, which starts only the Human owner with all LNI, peer, authority, store, session-key, socket and limit checks, and an authenticated `/healthz` that returns 503 on dependency failure; unset or `full` keeps the existing startup path unchanged;
- enables ureq's `native-tls` feature (the `native-tls-no-default` feature does not compile the connector), which adds `webpki-root-certs` to the lock; explicit roots still trust only the supplied CA;
- documents the configuration in the crate README.

Verification (build server, `CARGO_BUILD_JOBS=16`):
- `cargo clippy --locked --manifest-path agent/Cargo.toml -p layerx-agentd --all-targets -- -D warnings`: exit 0
- `cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd --lib human_runtime::outbound_tls_tests`: exit 0
- `cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd`: exit 101; library and health tests pass, then the pre-existing real-node harness (`budget_create`) refuses a non-root UID and later tests report the poisoned fixture lock. Needs a root rerun.
- `cargo fmt --all --check --manifest-path agent/Cargo.toml`: exit 1 on pre-existing untouched files.

Follow-up recorded in the ledger: `human/crates/layerx-explorer-index` calls the Programs reader with the old signature and must pass a `ProgramAuthority` with a CA; the human and platform lockfiles need the `webpki-root-certs` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)