### PR TITLE
Add the LXSP security provider server for the Human component

### DIFF
--- a/human/Cargo.lock
+++ b/human/Cargo.lock
@@ -325,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +912,29 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "layerx-human-security-provider"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "data-encoding",
+ "ed25519-dalek",
+ "getrandom 0.3.4",
+ "hmac",
+ "layerx-human-service",
+ "layerx-programs-registry",
+ "layerx-proof",
+ "layerx-wire",
+ "rustix",
+ "serde",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "signal-hook",
+ "subtle",
  "zeroize",
 ]
 
@@ -1673,6 +1702,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/human/Cargo.toml
+++ b/human/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/layerx-human-security-provider",
     "crates/layerx-human-service",
     "crates/layerx-human-identity-provider",
     "crates/layerx-human-kms",

--- a/human/crates/layerx-human-security-provider/Cargo.toml
+++ b/human/crates/layerx-human-security-provider/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "layerx-human-security-provider"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+layerx-human-service = { path = "../layerx-human-service" }
+layerx-programs.workspace = true
+layerx-proof.workspace = true
+layerx-wire.workspace = true
+base64.workspace = true
+getrandom.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+subtle.workspace = true
+zeroize.workspace = true
+rustix = { workspace = true, features = ["fs"] }
+hmac = "=0.12.1"
+sha1 = "=0.10.6"
+data-encoding = "=2.9.0"
+signal-hook = "=0.3.18"
+
+[dev-dependencies]
+ed25519-dalek = "=2.2.0"

--- a/human/crates/layerx-human-security-provider/README.md
+++ b/human/crates/layerx-human-security-provider/README.md
@@ -1,0 +1,151 @@
+# LXSP security provider contract
+
+The library and `layerx-human-security-provider` binary serve the existing client
+in `layerx-human-service/src/server/production_auth.rs`, unchanged. Discovery and
+capability ownership remains local to the human service.
+
+## Framing and encodings
+
+Each call opens a new Unix stream and sends one request. Both directions begin
+with a four-byte unsigned big-endian payload length, excluding that prefix.
+The request payload is `LXSP`, version byte `1`, operation byte, a four-byte
+big-endian field count, then fields. Each field is a four-byte big-endian byte
+length followed by exactly that many bytes. Integers carried as fields still
+have the field-length prefix: u32 has length 4, u64 has length 8. Strings are
+UTF-8, without terminators. Optional u64 is either an empty field or eight bytes.
+
+The response has the same structure, replacing operation with result code.
+Code 0 means success; code 1 maps to `SecurityBoundaryError::Refused` immediately
+(the client does not decode the remaining refusal payload). Other result codes,
+wrong magic/version, malformed successful fields, trailing bytes in a successful
+payload, and invalid response lengths map to `InvalidEvidence`. Connection,
+timeout configuration, read and write failures map to `Unavailable`.
+
+Client configuration requires an absolute socket path, nonzero deadline and
+`maximum_frame_bytes` in 64..=1,048,576. The payload, excluding its outer prefix,
+must fit this maximum. Outgoing oversize requests are refused locally. Incoming
+zero-length or oversized responses are invalid evidence. Decoded text fields
+must contain 1..=4096 UTF-8 bytes. Request strings are not similarly validated
+by `call`; the server must validate them. There is no request ID or multiplexing.
+
+## Operations
+
+Here `p` is the UTF-8 `PrincipalId::as_str()`, `now` is a u64 field, and all
+unspecified scalar fields are UTF-8. Response lists below exclude framing.
+
+| Opcode | Request fields | Successful response fields |
+| --- | --- | --- |
+| 0 probe | none | none |
+| 1 status | p | status projection |
+| 2 begin_setup | p, label, now | setup_id, secret, secret_remask_at:u64, otpauth_uri, uri_remask_at:u64, expires_at:u64 |
+| 3 finish_setup | p, setup_id, code, now | method_id, label, enabled_at:u64, last_used_at:optional-u64, backup_remask_at:u64, one or more backup codes |
+| 4 disable | p, method_id, now | status projection |
+| 5 rotate_backup_codes | p, now | backup_remask_at:u64, one or more backup codes |
+| 6 reveal_verified_receipt | p, evidence_id, now | canonical_receipt, remask_at:u64, single byte 0x01 |
+
+A status projection is `backup_codes_remaining:u32, method_count:u32`, followed
+by exactly `method_count` groups of four fields: method_id, label, enabled_at:u64,
+last_used_at:optional-u64. No other LXSP operations exist in this client.
+
+`TimedSecret` and `BackupCodeSet` require remask_at strictly greater than the
+request's now. Empty secrets or backup code lists are invalid. Setup secret and
+receipt are copyable; otpauth URI is not. The client decodes setup expires_at but
+does not enforce its relation to now. Setup lifetime, TOTP algorithm and period,
+clock-skew window, code attempt limits, backup-code consumption, and recovery
+record ingestion are not defined by the LXSP client. `RecoveryEvidenceProvider`
+requires local verification of stored receipts before returning canonical bytes;
+a stored boolean alone does not meet that requirement.
+
+## Authenticator policy
+
+TOTP uses a random 160-bit secret, HMAC-SHA1, six digits, a 30-second period,
+and a ±1-period window. Setup expires after 300 seconds; equality is accepted.
+A principal has one pending setup; beginning another replaces it. A setup admits
+five code attempts, durably counted even when refused, and successful completion
+consumes it. Requests cannot move an account's mutation clock backwards.
+Method secrets and the accepted TOTP counter are retained. The current wire has
+no login-code or backup-code consumption operation, so last_used_at remains
+absent. Each completion or rotation generates ten independent 160-bit backup
+codes, returned once; only SHA-256 digests are retained. Removing the last method
+clears backups. Maximums: 1024 accounts, 16 methods per account, 256-byte labels.
+All disclosures remask after 60 seconds; timestamp overflow is refused.
+
+## Configuration
+
+| Environment variable | Requirement |
+| --- | --- |
+| `LAYERX_HUMAN_SECURITY_PROVIDER_STATE_ROOT` | Required absolute provider-owned state directory; created mode 0700 if absent, parent must exist. |
+| `LAYERX_HUMAN_SECURITY_PROVIDER_TRUST_HISTORY` | Required absolute protected canonical registry sequencer trust-history file, mode 0600, owned by provider UID. |
+| `LAYERX_HUMAN_SECURITY_PROVIDER_SOCKET` | Required absolute UDS path; cluster value `/run/layerx/human/security.sock`. Existing paths are refused. Parent must be owned by provider UID and not group/other writable. |
+| `LAYERX_HUMAN_SECURITY_PROVIDER_ALLOWED_UID` | Required decimal UID of the human service; no default. Checked using Linux SO_PEERCRED. |
+| `LAYERX_HUMAN_SECURITY_PROVIDER_DEADLINE_SECONDS` | Optional integer 1–60, default 5; total request/response I/O deadline. |
+
+The socket is 0660. The human service also needs filesystem access via the
+socket's owner/group and parent directories. The listener handles one active
+connection at a time, with an OS-bounded backlog, frames at most 1 MiB, at most
+four request fields and at most 4096 bytes per field. One request per connection.
+SIGTERM and SIGINT stop accepting and interrupt pending I/O within 100 ms;
+shutdown removes only the socket inode this process created. A stale socket
+following SIGKILL requires operator removal after checking no provider owns it.
+
+## Durable file layout
+
+All state files are regular, single-link, provider-owned 0600 files. Paths with
+symlink components are refused. `writer.lock` is held with an exclusive flock
+for the process lifetime, including administration. `snapshot.json` is a
+canonical initial empty snapshot. `initialized` commits its SHA-256 digest.
+`00000000000000000001.json` and subsequent numbered files are canonical state
+records with sequence and previous-record digest. `head` commits the latest
+sequence and digest, detecting a missing journal tail. `transaction.tmp` is the
+exclusive temporary file used by atomic rename. Files are fsynced before rename;
+the state directory is fsynced afterward. Initial root creation fsyncs its parent.
+
+Startup replays every record, validates bounds and account clocks, verifies all
+stored recovery proofs, and checks snapshot, marker, chain and head consistency.
+Each operation repeats consistency checks; failure permanently withdraws probe
+success for that process. Incomplete writes, unexpected files and corruption
+fail closed, including a crash between a journal rename and head publication.
+Operator restoration of a consistent backup is required; the server does not
+silently discard an ambiguous transaction. Limits are 4096 transactions and
+16 MiB per record, after which mutation is refused. No automatic compaction is
+provided. Permissions protect secret material; hashes detect corruption, not
+malicious rewriting of the whole state by its privileged owner. Rollback of an
+entire consistent backup cannot be detected without an external monotonic anchor.
+
+## Recovery administration
+
+Stop the provider (administration requires the same exclusive writer lock), then:
+
+```sh
+layerx-human-security-provider ingest-recovery-receipt /protected/recovery.json
+```
+
+This command needs only STATE_ROOT and TRUST_HISTORY. It runs as the state
+owner and requires an owner-only, single-link 0600 receipt file. The file is
+compact canonical JSON, with keys in exactly this order, no whitespace or final
+newline, no unknown fields:
+
+```json
+{"version":1,"principal":"alice","evidence_id":"recovery-1","canonical_receipt":"BASE64","receipt_proof":"BASE64","header":"BASE64","header_signature":"BASE64"}
+```
+
+All binary strings use canonical padded standard base64. `canonical_receipt` is
+the real `layerx_wire::receipt::encode` output, `receipt_proof` is
+`layerx_proof::merkle::encode_proof`, `header` is the encoded batch header and
+`header_signature` is its 64-byte Ed25519 signature. The receipt string must fit
+the client's 4096-byte text bound; the entire admin file is bounded to 32 KiB.
+The trusted administrator supplies the principal/evidence association; this
+association is not a claim made by the protocol receipt itself. It is durably
+bound at ingestion, and conflicting reassignment of the same pair is refused.
+Identical re-ingestion is idempotent. Maximum: 1024 principals with 64 receipts
+each. Receipt bytes are returned exactly as the ingested canonical base64 string.
+
+`ProtocolDeploymentVerifier::from_protected_history` and
+`verify_historical_protocol_head` verify the real receipt signature, successful
+protocol result, Merkle inclusion, signed header, batch identity and selected
+historical trust anchor. Stored material is reverified on replay and reveal;
+there is no stored boolean standing in for verification. Historical receipts
+have no current-head staleness limit. Trust history retains the registry's exact
+canonical binary format and revoked-anchor semantics. Unverifiable material is
+refused and never stored. The runtime serves LXSP operations 0–6 only; ingestion
+is not a new wire operation.

--- a/human/crates/layerx-human-security-provider/src/lib.rs
+++ b/human/crates/layerx-human-security-provider/src/lib.rs
@@ -1,0 +1,47 @@
+mod state;
+mod transport;
+
+pub use state::{ingest_recovery_receipt, RecoveryReceipt, Store};
+pub use transport::{serve, Config};
+
+use std::io;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    Refused,
+    Corrupt,
+    Configuration,
+    Io(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Refused => "operation refused",
+            Self::Corrupt => "security state is inconsistent",
+            Self::Configuration => "invalid security provider configuration",
+            Self::Io(_) => "security provider I/O failure",
+        })
+    }
+}
+impl std::error::Error for Error {}
+
+fn text(bytes: &[u8]) -> Result<&str> {
+    let value = std::str::from_utf8(bytes).map_err(|_| Error::Refused)?;
+    if value.is_empty() || value.len() > 4096 || value.chars().any(char::is_control) {
+        return Err(Error::Refused);
+    }
+    Ok(value)
+}
+fn number(bytes: &[u8]) -> Result<u64> {
+    Ok(u64::from_be_bytes(
+        bytes.try_into().map_err(|_| Error::Refused)?,
+    ))
+}

--- a/human/crates/layerx-human-security-provider/src/main.rs
+++ b/human/crates/layerx-human-security-provider/src/main.rs
@@ -1,0 +1,32 @@
+use layerx_human_security_provider::{ingest_recovery_receipt, serve, Config, Error, Result};
+use std::path::PathBuf;
+use std::sync::{atomic::AtomicBool, Arc};
+
+fn run() -> Result<()> {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    if args.len() == 2 && args[0] == "ingest-recovery-receipt" {
+        let root = std::env::var_os("LAYERX_HUMAN_SECURITY_PROVIDER_STATE_ROOT")
+            .map(PathBuf::from)
+            .ok_or(Error::Configuration)?;
+        let trust = std::env::var_os("LAYERX_HUMAN_SECURITY_PROVIDER_TRUST_HISTORY")
+            .map(PathBuf::from)
+            .ok_or(Error::Configuration)?;
+        return ingest_recovery_receipt(&root, &trust, &PathBuf::from(&args[1]));
+    }
+    if !args.is_empty() {
+        return Err(Error::Configuration);
+    }
+    let stop = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGTERM, stop.clone())?;
+    signal_hook::flag::register(signal_hook::consts::SIGINT, stop.clone())?;
+    serve(Config::from_env()?, stop)
+}
+fn main() -> std::process::ExitCode {
+    match run() {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/human/crates/layerx-human-security-provider/src/state.rs
+++ b/human/crates/layerx-human-security-provider/src/state.rs
@@ -1,0 +1,646 @@
+use crate::{number, text, Error, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use data_encoding::BASE32_NOPAD;
+use hmac::{Hmac, Mac as _};
+use layerx_human_service::store::PrincipalId;
+use layerx_programs::ProtocolDeploymentVerifier;
+use layerx_proof::merkle::decode_proof;
+use serde::{Deserialize, Serialize};
+use sha1::Sha1;
+use sha2::{Digest as _, Sha256};
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read as _, Write as _};
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _, OpenOptionsExt as _};
+use std::path::{Component, Path, PathBuf};
+use subtle::ConstantTimeEq as _;
+use zeroize::Zeroizing;
+
+const LIMIT: u64 = 16 * 1024 * 1024;
+const MAX_RECORDS: u64 = 4096;
+const SETUP_LIFETIME: u64 = 300;
+const REMASK: u64 = 60;
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryReceipt {
+    pub version: u8,
+    pub principal: String,
+    pub evidence_id: String,
+    pub canonical_receipt: String,
+    pub receipt_proof: String,
+    pub header: String,
+    pub header_signature: String,
+}
+impl RecoveryReceipt {
+    fn verify(&self, trust: &Path) -> Result<()> {
+        if self.version != 1 {
+            return Err(Error::Refused);
+        }
+        PrincipalId::new(self.principal.clone()).map_err(|_| Error::Refused)?;
+        text(self.evidence_id.as_bytes())?;
+        text(self.canonical_receipt.as_bytes())?;
+        let receipt = decode64(&self.canonical_receipt)?;
+        let decoded = layerx_wire::receipt::decode(&receipt).map_err(|_| Error::Refused)?;
+        if layerx_wire::receipt::encode(&decoded).map_err(|_| Error::Refused)? != receipt {
+            return Err(Error::Refused);
+        }
+        let proof = decode_proof(&decode64(&self.receipt_proof)?).map_err(|_| Error::Refused)?;
+        let signature: [u8; 64] = decode64(&self.header_signature)?
+            .try_into()
+            .map_err(|_| Error::Refused)?;
+        let _ = protected_read(trust, LIMIT)?;
+        ProtocolDeploymentVerifier::from_protected_history(trust, 1)
+            .map_err(|_| Error::Refused)?
+            .verify_historical_protocol_head(&receipt, &proof, &decode64(&self.header)?, &signature)
+            .map_err(|_| Error::Refused)?;
+        Ok(())
+    }
+}
+fn decode64(value: &str) -> Result<Vec<u8>> {
+    let bytes = STANDARD.decode(value).map_err(|_| Error::Refused)?;
+    if STANDARD.encode(&bytes) != value {
+        return Err(Error::Refused);
+    }
+    Ok(bytes)
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Account {
+    clock: u64,
+    methods: BTreeMap<String, Method>,
+    setup: Option<Setup>,
+    backups: Vec<[u8; 32]>,
+}
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Method {
+    label: String,
+    secret: [u8; 20],
+    enabled_at: u64,
+    counter: u64,
+}
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct Setup {
+    id: String,
+    label: String,
+    secret: [u8; 20],
+    issued_at: u64,
+    expires_at: u64,
+    attempts: u8,
+}
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct State {
+    accounts: BTreeMap<String, Account>,
+    receipts: BTreeMap<String, BTreeMap<String, RecoveryReceipt>>,
+}
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Record {
+    sequence: u64,
+    previous: [u8; 32],
+    state: State,
+}
+
+pub struct Store {
+    root: PathBuf,
+    trust: PathBuf,
+    lock: File,
+    root_identity: (u64, u64),
+    state: State,
+    sequence: u64,
+    digest: [u8; 32],
+    healthy: bool,
+}
+impl Store {
+    pub fn open(root: &Path, trust: &Path) -> Result<Self> {
+        check_components(root)?;
+        if !root.exists() {
+            fs::DirBuilder::new().mode(0o700).create(root)?;
+            File::open(root.parent().ok_or(Error::Configuration)?)?.sync_all()?;
+        }
+        let metadata = fs::symlink_metadata(root)?;
+        if !metadata.is_dir()
+            || metadata.mode() & 0o777 != 0o700
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+        {
+            return Err(Error::Configuration);
+        }
+        let _ = protected_read(trust, LIMIT)?;
+        ProtocolDeploymentVerifier::from_protected_history(trust, 1)
+            .map_err(|_| Error::Configuration)?;
+        let lock_path = root.join("writer.lock");
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(rustix::fs::OFlags::NOFOLLOW.bits() as i32)
+            .open(&lock_path)?;
+        check_file(&lock.metadata()?)?;
+        rustix::fs::flock(&lock, rustix::fs::FlockOperation::NonBlockingLockExclusive)
+            .map_err(|_| Error::Refused)?;
+        let mut store = Self {
+            root: root.into(),
+            trust: trust.into(),
+            lock,
+            root_identity: (metadata.dev(), metadata.ino()),
+            state: State::default(),
+            sequence: 0,
+            digest: [0; 32],
+            healthy: true,
+        };
+        let entries = fs::read_dir(root)?
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        if entries.iter().all(|name| name == "writer.lock") {
+            let record = Record {
+                sequence: 0,
+                previous: [0; 32],
+                state: State::default(),
+            };
+            let bytes = serde_json::to_vec(&record).map_err(|_| Error::Corrupt)?;
+            store.atomic("snapshot.json", &bytes)?;
+            store.atomic("initialized", &Sha256::digest(&bytes))?;
+            store.atomic("head", &head_bytes(0, Sha256::digest(&bytes).into()))?;
+        }
+        let (state, sequence, digest) = store.replay()?;
+        store.state = state;
+        store.sequence = sequence;
+        store.digest = digest;
+        Ok(store)
+    }
+
+    fn replay(&self) -> Result<(State, u64, [u8; 32])> {
+        let metadata = fs::symlink_metadata(&self.root)?;
+        if !metadata.is_dir()
+            || metadata.file_type().is_symlink()
+            || metadata.mode() & 0o777 != 0o700
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || (metadata.dev(), metadata.ino()) != self.root_identity
+        {
+            return Err(Error::Corrupt);
+        }
+        let lock_metadata = fs::symlink_metadata(self.root.join("writer.lock"))?;
+        check_file(&lock_metadata)?;
+        let held = self.lock.metadata()?;
+        if (held.dev(), held.ino()) != (lock_metadata.dev(), lock_metadata.ino()) {
+            return Err(Error::Corrupt);
+        }
+        let marker = protected_read(&self.root.join("initialized"), 32)?;
+        let initial = protected_read(&self.root.join("snapshot.json"), LIMIT)?;
+        let mut digest: [u8; 32] = Sha256::digest(&initial).into();
+        if marker.as_slice() != digest {
+            return Err(Error::Corrupt);
+        }
+        let record = parse_record(&initial)?;
+        if record.sequence != 0 || record.previous != [0; 32] || record.state != State::default() {
+            return Err(Error::Corrupt);
+        }
+        let mut state = record.state;
+        let mut journals = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let name = entry?
+                .file_name()
+                .into_string()
+                .map_err(|_| Error::Corrupt)?;
+            match name.as_str() {
+                "writer.lock" | "initialized" | "snapshot.json" | "head" => {}
+                _ if name.len() == 25 && name.ends_with(".json") => {
+                    let sequence = name[..20].parse::<u64>().map_err(|_| Error::Corrupt)?;
+                    if name != format!("{sequence:020}.json") {
+                        return Err(Error::Corrupt);
+                    }
+                    journals.push(sequence);
+                }
+                _ => return Err(Error::Corrupt),
+            }
+        }
+        journals.sort_unstable();
+        if journals.len() as u64 > MAX_RECORDS {
+            return Err(Error::Corrupt);
+        }
+        let mut sequence = 0;
+        for next in journals {
+            if next != sequence + 1 {
+                return Err(Error::Corrupt);
+            }
+            let bytes = protected_read(&self.root.join(format!("{next:020}.json")), LIMIT)?;
+            let record = parse_record(&bytes)?;
+            if record.sequence != next || record.previous != digest {
+                return Err(Error::Corrupt);
+            }
+            validate_state(&record.state, &self.trust)?;
+            for (principal, old) in &state.accounts {
+                if record
+                    .state
+                    .accounts
+                    .get(principal)
+                    .is_none_or(|new| new.clock < old.clock)
+                {
+                    return Err(Error::Corrupt);
+                }
+            }
+            state = record.state;
+            sequence = next;
+            digest = Sha256::digest(&bytes).into();
+        }
+        if protected_read(&self.root.join("head"), 40)?.as_slice() != head_bytes(sequence, digest) {
+            return Err(Error::Corrupt);
+        }
+        Ok((state, sequence, digest))
+    }
+    fn consistent(&mut self) -> Result<()> {
+        if !self.healthy {
+            return Err(Error::Corrupt);
+        }
+        match self.replay() {
+            Ok((state, sequence, digest))
+                if sequence == self.sequence && digest == self.digest && state == self.state =>
+            {
+                Ok(())
+            }
+            _ => {
+                self.healthy = false;
+                Err(Error::Corrupt)
+            }
+        }
+    }
+    fn atomic(&self, name: &str, bytes: &[u8]) -> Result<()> {
+        let temp = self.root.join("transaction.tmp");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temp)?;
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        if name == "head" && self.root.join(name).symlink_metadata().is_ok() {
+            let _ = protected_read(&self.root.join(name), 40)?;
+        } else if self.root.join(name).symlink_metadata().is_ok() {
+            return Err(Error::Corrupt);
+        }
+        fs::rename(temp, self.root.join(name))?;
+        File::open(&self.root)?.sync_all()?;
+        Ok(())
+    }
+    fn commit(&mut self, next: State) -> Result<()> {
+        if self.sequence >= MAX_RECORDS {
+            return Err(Error::Refused);
+        }
+        validate_state(&next, &self.trust)?;
+        let sequence = self.sequence + 1;
+        let bytes = Zeroizing::new(
+            serde_json::to_vec(&Record {
+                sequence,
+                previous: self.digest,
+                state: next.clone(),
+            })
+            .map_err(|_| Error::Corrupt)?,
+        );
+        if bytes.len() as u64 > LIMIT {
+            return Err(Error::Refused);
+        }
+        if let Err(error) = self.atomic(&format!("{sequence:020}.json"), &bytes) {
+            self.healthy = false;
+            return Err(error);
+        }
+        let digest = Sha256::digest(&bytes).into();
+        if let Err(error) = self.atomic("head", &head_bytes(sequence, digest)) {
+            self.healthy = false;
+            return Err(error);
+        }
+        self.digest = digest;
+        self.sequence = sequence;
+        self.state = next;
+        Ok(())
+    }
+    pub(crate) fn dispatch(&mut self, op: u8, fields: &[Vec<u8>]) -> Result<Vec<Vec<u8>>> {
+        self.consistent()?;
+        let counts = [0, 1, 3, 4, 3, 2, 3];
+        if counts.get(usize::from(op)) != Some(&fields.len()) {
+            return Err(Error::Refused);
+        }
+        if op == 0 {
+            return Ok(Vec::new());
+        }
+        let principal =
+            PrincipalId::new(text(&fields[0])?.to_owned()).map_err(|_| Error::Refused)?;
+        let p = principal.as_str();
+        if op == 1 {
+            return Ok(status(self.state.accounts.get(p)));
+        }
+        let now = number(fields.last().ok_or(Error::Refused)?)?;
+        let remask = now.checked_add(REMASK).ok_or(Error::Refused)?;
+        if op == 6 {
+            let id = text(&fields[1])?;
+            let receipt = self
+                .state
+                .receipts
+                .get(p)
+                .and_then(|receipts| receipts.get(id))
+                .ok_or(Error::Refused)?;
+            receipt.verify(&self.trust)?;
+            return Ok(vec![
+                receipt.canonical_receipt.as_bytes().to_vec(),
+                remask.to_be_bytes().to_vec(),
+                vec![1],
+            ]);
+        }
+        let mut next = self.state.clone();
+        if next.accounts.len() >= 1024 && !next.accounts.contains_key(p) {
+            return Err(Error::Refused);
+        }
+        let account = next.accounts.entry(p.to_owned()).or_default();
+        if now < account.clock {
+            return Err(Error::Refused);
+        }
+        account.clock = now;
+        let result = match op {
+            2 => {
+                let label = text(&fields[1])?.to_owned();
+                if label.len() > 256 || account.methods.len() >= 16 {
+                    return Err(Error::Refused);
+                }
+                let mut secret = [0; 20];
+                getrandom::fill(&mut secret).map_err(|_| Error::Refused)?;
+                let setup = Setup {
+                    id: random_id()?,
+                    label,
+                    secret,
+                    issued_at: now,
+                    expires_at: now.checked_add(SETUP_LIFETIME).ok_or(Error::Refused)?,
+                    attempts: 0,
+                };
+                let encoded = BASE32_NOPAD.encode(&secret);
+                let uri = format!("otpauth://totp/LayerX:{p}?secret={encoded}&issuer=LayerX&algorithm=SHA1&digits=6&period=30");
+                let result = vec![
+                    setup.id.as_bytes().to_vec(),
+                    encoded.into_bytes(),
+                    remask.to_be_bytes().to_vec(),
+                    uri.into_bytes(),
+                    remask.to_be_bytes().to_vec(),
+                    setup.expires_at.to_be_bytes().to_vec(),
+                ];
+                account.setup = Some(setup);
+                Ok(result)
+            }
+            3 => {
+                let id = text(&fields[1])?;
+                let code = text(&fields[2])?;
+                let setup = account.setup.as_mut().ok_or(Error::Refused)?;
+                if setup.id != id
+                    || now > setup.expires_at
+                    || now < setup.issued_at
+                    || setup.attempts >= 5
+                {
+                    return Err(Error::Refused);
+                }
+                setup.attempts += 1;
+                let counter = (now / 30).saturating_sub(1)..=(now / 30).saturating_add(1);
+                let mut matched = None;
+                for counter in counter {
+                    if bool::from(
+                        totp(&setup.secret, counter)?
+                            .as_bytes()
+                            .ct_eq(code.as_bytes()),
+                    ) {
+                        matched = Some(counter);
+                    }
+                }
+                if let Some(counter) = matched {
+                    let method = Method {
+                        label: setup.label.clone(),
+                        secret: setup.secret,
+                        enabled_at: now,
+                        counter,
+                    };
+                    let method_id = random_id()?;
+                    let mut result = vec![
+                        method_id.as_bytes().to_vec(),
+                        method.label.as_bytes().to_vec(),
+                        now.to_be_bytes().to_vec(),
+                        Vec::new(),
+                        remask.to_be_bytes().to_vec(),
+                    ];
+                    if account.methods.contains_key(&method_id) {
+                        return Err(Error::Refused);
+                    }
+                    account.methods.insert(method_id, method);
+                    account.setup = None;
+                    result.extend(backups(account)?);
+                    Ok(result)
+                } else {
+                    Err(Error::Refused)
+                }
+            }
+            4 => {
+                let id = text(&fields[1])?;
+                if account.methods.remove(id).is_none() {
+                    return Err(Error::Refused);
+                }
+                if account.methods.is_empty() {
+                    account.backups.clear();
+                }
+                Ok(status(Some(account)))
+            }
+            5 => {
+                if account.methods.is_empty() {
+                    return Err(Error::Refused);
+                }
+                let mut result = vec![remask.to_be_bytes().to_vec()];
+                result.extend(backups(account)?);
+                Ok(result)
+            }
+            _ => Err(Error::Refused),
+        };
+        self.commit(next)?;
+        result
+    }
+}
+fn parse_record(bytes: &[u8]) -> Result<Record> {
+    let record: Record = serde_json::from_slice(bytes).map_err(|_| Error::Corrupt)?;
+    if serde_json::to_vec(&record).map_err(|_| Error::Corrupt)? != bytes {
+        return Err(Error::Corrupt);
+    }
+    Ok(record)
+}
+fn validate_state(state: &State, trust: &Path) -> Result<()> {
+    if state.accounts.len() > 1024 || state.receipts.len() > 1024 {
+        return Err(Error::Corrupt);
+    }
+    for (p, account) in &state.accounts {
+        PrincipalId::new(p.clone()).map_err(|_| Error::Corrupt)?;
+        if account.methods.len() > 16
+            || !matches!(account.backups.len(), 0 | 10)
+            || (account.methods.is_empty() && !account.backups.is_empty())
+        {
+            return Err(Error::Corrupt);
+        }
+        for (id, method) in &account.methods {
+            text(id.as_bytes())?;
+            text(method.label.as_bytes())?;
+            if method.label.len() > 256
+                || method.enabled_at > account.clock
+                || method.counter > account.clock / 30 + 1
+            {
+                return Err(Error::Corrupt);
+            }
+        }
+        if let Some(setup) = &account.setup {
+            text(setup.id.as_bytes())?;
+            text(setup.label.as_bytes())?;
+            if setup.label.len() > 256
+                || setup.issued_at.checked_add(SETUP_LIFETIME) != Some(setup.expires_at)
+                || setup.issued_at > account.clock
+                || setup.attempts > 5
+            {
+                return Err(Error::Corrupt);
+            }
+        }
+    }
+    for (p, receipts) in &state.receipts {
+        if receipts.len() > 64 {
+            return Err(Error::Corrupt);
+        }
+        for (id, receipt) in receipts {
+            if &receipt.principal != p || &receipt.evidence_id != id {
+                return Err(Error::Corrupt);
+            }
+            receipt.verify(trust)?;
+        }
+    }
+    Ok(())
+}
+fn status(account: Option<&Account>) -> Vec<Vec<u8>> {
+    let mut fields = vec![
+        (account.map_or(0, |a| a.backups.len()) as u32)
+            .to_be_bytes()
+            .to_vec(),
+        (account.map_or(0, |a| a.methods.len()) as u32)
+            .to_be_bytes()
+            .to_vec(),
+    ];
+    if let Some(account) = account {
+        for (id, method) in &account.methods {
+            fields.extend([
+                id.as_bytes().to_vec(),
+                method.label.as_bytes().to_vec(),
+                method.enabled_at.to_be_bytes().to_vec(),
+                Vec::new(),
+            ]);
+        }
+    }
+    fields
+}
+fn random_id() -> Result<String> {
+    let mut random = [0; 20];
+    getrandom::fill(&mut random).map_err(|_| Error::Refused)?;
+    Ok(BASE32_NOPAD.encode(&random).to_ascii_lowercase())
+}
+fn backups(account: &mut Account) -> Result<Vec<Vec<u8>>> {
+    let mut codes = Vec::new();
+    account.backups.clear();
+    for _ in 0..10 {
+        let code = random_id()?;
+        let digest: [u8; 32] = Sha256::digest(code.as_bytes()).into();
+        if account.backups.contains(&digest) {
+            return Err(Error::Refused);
+        }
+        account.backups.push(digest);
+        codes.push(code.into_bytes());
+    }
+    Ok(codes)
+}
+fn totp(secret: &[u8; 20], counter: u64) -> Result<String> {
+    let mut mac = Hmac::<Sha1>::new_from_slice(secret).map_err(|_| Error::Refused)?;
+    mac.update(&counter.to_be_bytes());
+    let digest = mac.finalize().into_bytes();
+    let offset = usize::from(digest[19] & 15);
+    let value = (u32::from(digest[offset]) << 24
+        | u32::from(digest[offset + 1]) << 16
+        | u32::from(digest[offset + 2]) << 8
+        | u32::from(digest[offset + 3]))
+        & 0x7fff_ffff;
+    Ok(format!("{:06}", value % 1_000_000))
+}
+pub fn ingest_recovery_receipt(root: &Path, trust: &Path, path: &Path) -> Result<()> {
+    let bytes = protected_read(path, 32768)?;
+    let receipt: RecoveryReceipt = serde_json::from_slice(&bytes).map_err(|_| Error::Refused)?;
+    if serde_json::to_vec(&receipt).map_err(|_| Error::Refused)? != bytes.as_slice() {
+        return Err(Error::Refused);
+    }
+    receipt.verify(trust)?;
+    let mut store = Store::open(root, trust)?;
+    store.consistent()?;
+    let mut next = store.state.clone();
+    let receipts = next.receipts.entry(receipt.principal.clone()).or_default();
+    if let Some(old) = receipts.get(&receipt.evidence_id) {
+        return if old == &receipt {
+            Ok(())
+        } else {
+            Err(Error::Refused)
+        };
+    }
+    receipts.insert(receipt.evidence_id.clone(), receipt);
+    store.commit(next)
+}
+fn check_components(path: &Path) -> Result<()> {
+    if !path.is_absolute() {
+        return Err(Error::Configuration);
+    }
+    let mut current = PathBuf::new();
+    for part in path.components() {
+        if !matches!(part, Component::RootDir | Component::Normal(_)) {
+            return Err(Error::Configuration);
+        }
+        current.push(part);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return Err(Error::Configuration),
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound && current == path => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+fn check_file(metadata: &fs::Metadata) -> Result<()> {
+    if !metadata.is_file()
+        || metadata.mode() & 0o777 != 0o600
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.nlink() != 1
+    {
+        return Err(Error::Configuration);
+    }
+    Ok(())
+}
+fn protected_read(path: &Path, limit: u64) -> Result<Zeroizing<Vec<u8>>> {
+    check_components(path)?;
+    let before = fs::symlink_metadata(path)?;
+    check_file(&before)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(rustix::fs::OFlags::NOFOLLOW.bits() as i32)
+        .open(path)?;
+    let after = file.metadata()?;
+    check_file(&after)?;
+    if (before.dev(), before.ino()) != (after.dev(), after.ino()) || after.len() > limit {
+        return Err(Error::Corrupt);
+    }
+    let mut bytes = Zeroizing::new(Vec::new());
+    file.take(limit + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 != after.len() {
+        return Err(Error::Corrupt);
+    }
+    Ok(bytes)
+}
+
+fn head_bytes(sequence: u64, digest: [u8; 32]) -> Vec<u8> {
+    let mut bytes = sequence.to_be_bytes().to_vec();
+    bytes.extend_from_slice(&digest);
+    bytes
+}

--- a/human/crates/layerx-human-security-provider/src/transport.rs
+++ b/human/crates/layerx-human-security-provider/src/transport.rs
@@ -1,0 +1,265 @@
+use crate::{Error, Result, Store};
+use std::fs;
+use std::io::{Read, Write};
+use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use zeroize::Zeroizing;
+
+const MAX_FRAME: usize = 1_048_576;
+
+pub struct Config {
+    pub state_root: PathBuf,
+    pub trust_history: PathBuf,
+    pub socket: PathBuf,
+    pub allowed_uid: u32,
+    pub deadline: Duration,
+}
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        let path = |name| {
+            std::env::var_os(name)
+                .map(PathBuf::from)
+                .ok_or(Error::Configuration)
+        };
+        let seconds = match std::env::var("LAYERX_HUMAN_SECURITY_PROVIDER_DEADLINE_SECONDS") {
+            Ok(value) => value.parse::<u64>().map_err(|_| Error::Configuration)?,
+            Err(std::env::VarError::NotPresent) => 5,
+            Err(_) => return Err(Error::Configuration),
+        };
+        let config = Self {
+            state_root: path("LAYERX_HUMAN_SECURITY_PROVIDER_STATE_ROOT")?,
+            trust_history: path("LAYERX_HUMAN_SECURITY_PROVIDER_TRUST_HISTORY")?,
+            socket: path("LAYERX_HUMAN_SECURITY_PROVIDER_SOCKET")?,
+            allowed_uid: std::env::var("LAYERX_HUMAN_SECURITY_PROVIDER_ALLOWED_UID")
+                .map_err(|_| Error::Configuration)?
+                .parse()
+                .map_err(|_| Error::Configuration)?,
+            deadline: Duration::from_secs(seconds),
+        };
+        config.validate()?;
+        Ok(config)
+    }
+    fn validate(&self) -> Result<()> {
+        if !self.socket.is_absolute()
+            || !self.state_root.is_absolute()
+            || !self.trust_history.is_absolute()
+            || self.deadline < Duration::from_secs(1)
+            || self.deadline > Duration::from_secs(60)
+        {
+            return Err(Error::Configuration);
+        }
+        Ok(())
+    }
+}
+pub fn serve(config: Config, shutdown: Arc<AtomicBool>) -> Result<()> {
+    config.validate()?;
+    let mut store = Store::open(&config.state_root, &config.trust_history)?;
+    let parent = config.socket.parent().ok_or(Error::Configuration)?;
+    let metadata = fs::symlink_metadata(parent)?;
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != rustix::process::geteuid().as_raw()
+        || metadata.mode() & 0o022 != 0
+    {
+        return Err(Error::Configuration);
+    }
+    if parent.canonicalize()? != parent {
+        return Err(Error::Configuration);
+    }
+    let listener = UnixListener::bind(&config.socket)?;
+    let socket_metadata = fs::symlink_metadata(&config.socket)?;
+    let cleanup = SocketCleanup {
+        path: config.socket.clone(),
+        device: socket_metadata.dev(),
+        inode: socket_metadata.ino(),
+    };
+    fs::set_permissions(&config.socket, fs::Permissions::from_mode(0o660))?;
+    listener.set_nonblocking(true)?;
+    while !shutdown.load(Ordering::Relaxed) {
+        match listener.accept() {
+            Ok((mut stream, _)) => {
+                let deadline = Instant::now() + config.deadline;
+                let peer =
+                    rustix::net::sockopt::socket_peercred(&stream).map_err(|_| Error::Refused)?;
+                if peer.uid.as_raw() != config.allowed_uid {
+                    let _ = send(&mut stream, &frame(1, &[])?, deadline, &shutdown);
+                    discard(&mut stream, deadline, &shutdown);
+                    continue;
+                }
+                let response = receive(&mut stream, deadline, &shutdown)
+                    .and_then(|(op, fields)| store.dispatch(op, &fields));
+                let bytes = match response {
+                    Ok(fields) => frame(0, &fields)?,
+                    Err(_) => frame(1, &[])?,
+                };
+                let _ = send(&mut stream, &bytes, deadline, &shutdown);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    drop(listener);
+    drop(cleanup);
+    Ok(())
+}
+struct SocketCleanup {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+impl Drop for SocketCleanup {
+    fn drop(&mut self) {
+        if fs::symlink_metadata(&self.path)
+            .is_ok_and(|m| (m.dev(), m.ino()) == (self.device, self.inode))
+        {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+fn timeout(deadline: Instant, shutdown: &AtomicBool) -> Result<Duration> {
+    if shutdown.load(Ordering::Relaxed) {
+        return Err(Error::Refused);
+    }
+    let left = deadline
+        .checked_duration_since(Instant::now())
+        .ok_or(Error::Refused)?;
+    if left.is_zero() {
+        return Err(Error::Refused);
+    }
+    Ok(left.min(Duration::from_millis(100)))
+}
+fn receive(
+    stream: &mut UnixStream,
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<(u8, Vec<Vec<u8>>)> {
+    let mut prefix = [0; 4];
+    read(stream, &mut prefix, deadline, shutdown)?;
+    let length = u32::from_be_bytes(prefix) as usize;
+    if !(10..=MAX_FRAME).contains(&length) {
+        return Err(Error::Refused);
+    }
+    let mut payload = Zeroizing::new(vec![0; length]);
+    read(stream, &mut payload, deadline, shutdown)?;
+    if &payload[..5] != b"LXSP\x01" {
+        return Err(Error::Refused);
+    }
+    let op = payload[5];
+    let count = u32::from_be_bytes(payload[6..10].try_into().map_err(|_| Error::Refused)?) as usize;
+    if count > 4 {
+        return Err(Error::Refused);
+    }
+    let mut cursor = 10usize;
+    let mut fields = Vec::new();
+    for _ in 0..count {
+        let end = cursor.checked_add(4).ok_or(Error::Refused)?;
+        let size = u32::from_be_bytes(
+            payload
+                .get(cursor..end)
+                .ok_or(Error::Refused)?
+                .try_into()
+                .map_err(|_| Error::Refused)?,
+        ) as usize;
+        cursor = end;
+        let end = cursor.checked_add(size).ok_or(Error::Refused)?;
+        if size > 4096 {
+            return Err(Error::Refused);
+        }
+        fields.push(payload.get(cursor..end).ok_or(Error::Refused)?.to_vec());
+        cursor = end;
+    }
+    if cursor != payload.len() {
+        return Err(Error::Refused);
+    }
+    Ok((op, fields))
+}
+fn read(
+    stream: &mut UnixStream,
+    mut bytes: &mut [u8],
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<()> {
+    while !bytes.is_empty() {
+        stream.set_read_timeout(Some(timeout(deadline, shutdown)?))?;
+        match stream.read(bytes) {
+            Ok(0) => return Err(Error::Refused),
+            Ok(n) => bytes = &mut bytes[n..],
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::Interrupted
+                        | std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(())
+}
+fn send(
+    stream: &mut UnixStream,
+    mut bytes: &[u8],
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<()> {
+    while !bytes.is_empty() {
+        stream.set_write_timeout(Some(timeout(deadline, shutdown)?))?;
+        match stream.write(bytes) {
+            Ok(0) => return Err(Error::Refused),
+            Ok(n) => bytes = &bytes[n..],
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::Interrupted
+                        | std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(e) => return Err(e.into()),
+        }
+    }
+    Ok(())
+}
+fn frame(code: u8, fields: &[Vec<u8>]) -> Result<Zeroizing<Vec<u8>>> {
+    let mut bytes = Zeroizing::new(vec![0; 4]);
+    bytes.extend_from_slice(b"LXSP\x01");
+    bytes.push(code);
+    bytes.extend_from_slice(&(fields.len() as u32).to_be_bytes());
+    for field in fields {
+        bytes.extend_from_slice(&(field.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(field);
+    }
+    let length = bytes.len() - 4;
+    if length > MAX_FRAME {
+        return Err(Error::Refused);
+    }
+    bytes[..4].copy_from_slice(&(length as u32).to_be_bytes());
+    Ok(bytes)
+}
+
+fn discard(stream: &mut UnixStream, deadline: Instant, shutdown: &AtomicBool) {
+    let mut buffer = [0; 1024];
+    while let Ok(remaining) = timeout(deadline, shutdown) {
+        if stream.set_read_timeout(Some(remaining)).is_err() {
+            break;
+        }
+        match stream.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::Interrupted
+                        | std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(_) => break,
+        }
+    }
+}

--- a/human/crates/layerx-human-security-provider/tests/server.rs
+++ b/human/crates/layerx-human-security-provider/tests/server.rs
@@ -1,0 +1,519 @@
+mod support;
+
+use data_encoding::BASE32_NOPAD;
+use hmac::{Hmac, Mac as _};
+use layerx_human_security_provider::{serve, Config, Store};
+use layerx_human_service::security::{
+    AuthenticatorProvider, RecoveryEvidenceProvider, SecurityBoundaryError,
+};
+use layerx_human_service::server::production_auth::{
+    RemoteSecurityProvider, SecurityProviderConfig,
+};
+use layerx_human_service::store::PrincipalId;
+use sha1::Sha1;
+use std::fs::{self, OpenOptions};
+use std::io::{Read as _, Write as _};
+use std::os::unix::fs::{
+    DirBuilderExt as _, MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _,
+};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+static NEXT: AtomicU64 = AtomicU64::new(0);
+struct Fixture {
+    root: PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "lxsp-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::DirBuilder::new().mode(0o700).create(&root).unwrap();
+        let (history, receipt) = support::evidence();
+        private(&root.join("trust"), &history);
+        private(
+            &root.join("receipt"),
+            &serde_json::to_vec(&receipt).unwrap(),
+        );
+        Self { root }
+    }
+    fn state(&self) -> PathBuf {
+        self.root.join("state")
+    }
+    fn trust(&self) -> PathBuf {
+        self.root.join("trust")
+    }
+    fn socket(&self) -> PathBuf {
+        self.root.join("socket")
+    }
+    fn client(&self) -> RemoteSecurityProvider {
+        RemoteSecurityProvider::new(SecurityProviderConfig {
+            socket: self.socket(),
+            deadline: Duration::from_secs(3),
+            maximum_frame_bytes: 1_048_576,
+        })
+        .unwrap()
+    }
+    fn start(&self, uid: u32) -> Running {
+        let stop = Arc::new(AtomicBool::new(false));
+        let config = Config {
+            state_root: self.state(),
+            trust_history: self.trust(),
+            socket: self.socket(),
+            allowed_uid: uid,
+            deadline: Duration::from_secs(1),
+        };
+        let shutdown = stop.clone();
+        let thread = std::thread::spawn(move || serve(config, shutdown));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !self.socket().exists() {
+            assert!(!thread.is_finished(), "server exited before binding");
+            assert!(Instant::now() < deadline);
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        Running {
+            stop,
+            thread: Some(thread),
+        }
+    }
+    fn ingest(&self) -> std::process::Output {
+        Command::new(env!("CARGO_BIN_EXE_layerx-human-security-provider"))
+            .arg("ingest-recovery-receipt")
+            .arg(self.root.join("receipt"))
+            .env("LAYERX_HUMAN_SECURITY_PROVIDER_STATE_ROOT", self.state())
+            .env("LAYERX_HUMAN_SECURITY_PROVIDER_TRUST_HISTORY", self.trust())
+            .output()
+            .unwrap()
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        fs::remove_dir_all(&self.root).unwrap();
+    }
+}
+struct Running {
+    stop: Arc<AtomicBool>,
+    thread: Option<std::thread::JoinHandle<layerx_human_security_provider::Result<()>>>,
+}
+impl Drop for Running {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        self.thread.take().unwrap().join().unwrap().unwrap();
+    }
+}
+fn private(path: &Path, bytes: &[u8]) {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .unwrap();
+    file.write_all(bytes).unwrap();
+    file.sync_all().unwrap();
+}
+fn principal() -> PrincipalId {
+    PrincipalId::new("alice").unwrap()
+}
+fn uid() -> u32 {
+    rustix::process::geteuid().as_raw()
+}
+fn code(secret: &str, now: u64) -> String {
+    let secret = BASE32_NOPAD.decode(secret.as_bytes()).unwrap();
+    let mut mac = Hmac::<Sha1>::new_from_slice(&secret).unwrap();
+    mac.update(&(now / 30).to_be_bytes());
+    let hash = mac.finalize().into_bytes();
+    let offset = usize::from(hash[19] & 15);
+    let number = u32::from_be_bytes(hash[offset..offset + 4].try_into().unwrap()) & 0x7fff_ffff;
+    format!("{:06}", number % 1_000_000)
+}
+
+#[test]
+fn all_authenticator_operations_expiry_equality_and_restart() {
+    let fixture = Fixture::new();
+    let server = fixture.start(uid());
+    let mut client = fixture.client();
+    let p = principal();
+    client.probe().unwrap();
+    assert!(client.status(&p).unwrap().methods.is_empty());
+    assert!(client.rotate_backup_codes(&p, 1000).is_err());
+    let setup = client.begin_setup(&p, "Phone", 1000).unwrap();
+    assert_eq!(setup.expires_at, 1300);
+    assert_eq!(setup.secret.remask_at(), 1060);
+    assert!(setup.secret.copyable());
+    assert!(!setup.otpauth_uri.copyable());
+    assert!(setup
+        .otpauth_uri
+        .expose()
+        .contains("algorithm=SHA1&digits=6&period=30"));
+    let setup_code = code(setup.secret.expose(), 1300);
+    drop(server);
+    let server = fixture.start(uid());
+    let enabled = client
+        .finish_setup(&p, &setup.setup_id, &setup_code, 1300)
+        .unwrap();
+    assert_eq!(enabled.method.label, "Phone");
+    assert_eq!(enabled.method.enabled_at, 1300);
+    assert_eq!(enabled.method.last_used_at, None);
+    assert_eq!(enabled.backup_codes.expose().len(), 10);
+    assert_eq!(enabled.backup_codes.remask_at(), 1360);
+    assert_eq!(
+        client
+            .finish_setup(&p, &setup.setup_id, &setup_code, 1300)
+            .unwrap_err(),
+        SecurityBoundaryError::Refused
+    );
+    let rotated = client.rotate_backup_codes(&p, 1300).unwrap();
+    assert_ne!(rotated.expose(), enabled.backup_codes.expose());
+    drop(server);
+    let _server = fixture.start(uid());
+    let status = client.status(&p).unwrap();
+    assert_eq!(status.methods, vec![enabled.method.clone()]);
+    assert_eq!(status.backup_codes_remaining, 10);
+    assert!(client.disable(&p, &enabled.method.id, 1299).is_err());
+    let status = client.disable(&p, &enabled.method.id, 1300).unwrap();
+    assert_eq!(status.backup_codes_remaining, 0);
+    assert!(status.methods.is_empty());
+    let expired = client.begin_setup(&p, "Tablet", 2000).unwrap();
+    assert_eq!(
+        client
+            .finish_setup(
+                &p,
+                &expired.setup_id,
+                &code(expired.secret.expose(), 2301),
+                2301
+            )
+            .unwrap_err(),
+        SecurityBoundaryError::Refused
+    );
+    assert!(client.begin_setup(&p, "Overflow", u64::MAX).is_err());
+    assert_eq!(fs::metadata(fixture.state()).unwrap().mode() & 0o777, 0o700);
+    assert_eq!(
+        fs::metadata(fixture.socket()).unwrap().mode() & 0o777,
+        0o660
+    );
+    for entry in fs::read_dir(fixture.state()).unwrap() {
+        assert_eq!(entry.unwrap().metadata().unwrap().mode() & 0o777, 0o600);
+    }
+}
+
+#[test]
+fn attempts_and_principal_binding_survive_restart() {
+    let fixture = Fixture::new();
+    let server = fixture.start(uid());
+    let mut client = fixture.client();
+    let setup = client.begin_setup(&principal(), "Phone", 1000).unwrap();
+    assert!(client
+        .finish_setup(
+            &PrincipalId::new("bob").unwrap(),
+            &setup.setup_id,
+            &code(setup.secret.expose(), 1000),
+            1000
+        )
+        .is_err());
+    for _ in 0..4 {
+        assert!(client
+            .finish_setup(&principal(), &setup.setup_id, "invalid", 1000)
+            .is_err());
+    }
+    drop(server);
+    let server = fixture.start(uid());
+    assert!(client
+        .finish_setup(&principal(), &setup.setup_id, "invalid", 1000)
+        .is_err());
+    drop(server);
+    let _server = fixture.start(uid());
+    assert!(client
+        .finish_setup(
+            &principal(),
+            &setup.setup_id,
+            &code(setup.secret.expose(), 1000),
+            1000
+        )
+        .is_err());
+    let replacement = client.begin_setup(&principal(), "New", 1001).unwrap();
+    assert!(client
+        .finish_setup(
+            &principal(),
+            &setup.setup_id,
+            &code(setup.secret.expose(), 1001),
+            1001
+        )
+        .is_err());
+    client
+        .finish_setup(
+            &principal(),
+            &replacement.setup_id,
+            &code(replacement.secret.expose(), 1001),
+            1001,
+        )
+        .unwrap();
+}
+
+#[test]
+fn verified_admin_ingest_reveal_and_tamper_refusal() {
+    let fixture = Fixture::new();
+    assert!(fixture.ingest().status.success());
+    assert!(fixture.ingest().status.success());
+    let server = fixture.start(uid());
+    let client = fixture.client();
+    let receipt = client
+        .reveal_verified_receipt(&principal(), "recovery-1", 100)
+        .unwrap();
+    assert_eq!(receipt.expose(), support::evidence().1.canonical_receipt);
+    assert_eq!(receipt.remask_at(), 160);
+    assert!(client
+        .reveal_verified_receipt(&PrincipalId::new("bob").unwrap(), "recovery-1", 100)
+        .is_err());
+    assert!(client
+        .reveal_verified_receipt(&principal(), "absent", 100)
+        .is_err());
+    assert!(!fixture.ingest().status.success());
+    drop(server);
+    let server = fixture.start(uid());
+    assert_eq!(
+        client
+            .reveal_verified_receipt(&principal(), "recovery-1", 101)
+            .unwrap()
+            .expose(),
+        receipt.expose()
+    );
+    drop(server);
+    let mut bad = support::evidence().1;
+    let replacement = if bad.header_signature.starts_with('A') {
+        "B"
+    } else {
+        "A"
+    };
+    bad.header_signature.replace_range(..1, replacement);
+    fs::write(
+        fixture.root.join("receipt"),
+        serde_json::to_vec(&bad).unwrap(),
+    )
+    .unwrap();
+    assert!(!fixture.ingest().status.success());
+    fs::set_permissions(
+        fixture.root.join("receipt"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    assert!(!fixture.ingest().status.success());
+}
+
+#[test]
+fn wrong_uid_and_malformed_frames_are_refused() {
+    let fixture = Fixture::new();
+    let server = fixture.start(uid().checked_add(1).unwrap());
+    assert_eq!(
+        fixture.client().probe(),
+        Err(SecurityBoundaryError::Refused)
+    );
+    drop(server);
+    let _server = fixture.start(uid());
+    let payloads: Vec<Vec<u8>> = vec![
+        b"WRNG\x01\x00\x00\x00\x00\x00".to_vec(),
+        b"LXSP\x02\x00\x00\x00\x00\x00".to_vec(),
+        b"LXSP\x01\xff\x00\x00\x00\x00".to_vec(),
+        b"LXSP\x01\x00\xff\xff\xff\xff".to_vec(),
+        b"LXSP\x01\x00\x00\x00\x00\x00x".to_vec(),
+        b"LXSP\x01\x01\x00\x00\x00\x01\xff\xff\xff\xff".to_vec(),
+        b"LXSP\x01\x01\x00\x00\x00\x01\x00\x00\x00\x01\xff".to_vec(),
+    ];
+    for payload in payloads {
+        let mut stream = UnixStream::connect(fixture.socket()).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream
+            .write_all(&(payload.len() as u32).to_be_bytes())
+            .unwrap();
+        stream.write_all(&payload).unwrap();
+        let mut response = [0; 14];
+        stream.read_exact(&mut response).unwrap();
+        assert_eq!(&response, b"\x00\x00\x00\x0aLXSP\x01\x01\x00\x00\x00\x00");
+    }
+    for length in [0u32, 1_048_577, u32::MAX] {
+        let mut stream = UnixStream::connect(fixture.socket()).unwrap();
+        stream.write_all(&length.to_be_bytes()).unwrap();
+        let mut response = [0; 14];
+        stream.read_exact(&mut response).unwrap();
+        assert_eq!(response[9], 1);
+    }
+    fixture.client().probe().unwrap();
+}
+
+#[test]
+fn slow_partial_frame_has_total_deadline() {
+    let fixture = Fixture::new();
+    let _server = fixture.start(uid());
+    let mut stream = UnixStream::connect(fixture.socket()).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .unwrap();
+    stream.write_all(&10u32.to_be_bytes()).unwrap();
+    let start = Instant::now();
+    for byte in b"LXSP" {
+        if stream.write_all(&[*byte]).is_err() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(350));
+    }
+    let mut response = [0; 1];
+    assert!(matches!(stream.read(&mut response), Ok(0) | Err(_)));
+    assert!(start.elapsed() < Duration::from_secs(2));
+    fixture.client().probe().unwrap();
+}
+
+#[test]
+fn corruption_withdraws_readiness_and_refuses_replay() {
+    for target in [
+        "initialized",
+        "snapshot.json",
+        "head",
+        "00000000000000000001.json",
+    ] {
+        let fixture = Fixture::new();
+        let server = fixture.start(uid());
+        fixture
+            .client()
+            .begin_setup(&principal(), "Phone", 100)
+            .unwrap();
+        let path = fixture.state().join(target);
+        let original = fs::read(&path).unwrap();
+        fs::write(&path, b"corrupt").unwrap();
+        assert!(fixture.client().probe().is_err());
+        fs::write(&path, &original).unwrap();
+        assert!(fixture.client().probe().is_err());
+        drop(server);
+        fs::write(&path, b"corrupt").unwrap();
+        assert!(Store::open(&fixture.state(), &fixture.trust()).is_err());
+    }
+}
+
+#[test]
+fn missing_tail_incomplete_initialization_symlinks_and_writer_lock_refuse() {
+    let fixture = Fixture::new();
+    let server = fixture.start(uid());
+    fixture
+        .client()
+        .begin_setup(&principal(), "Phone", 100)
+        .unwrap();
+    assert!(Store::open(&fixture.state(), &fixture.trust()).is_err());
+    drop(server);
+    fs::remove_file(fixture.state().join("00000000000000000001.json")).unwrap();
+    assert!(Store::open(&fixture.state(), &fixture.trust()).is_err());
+    let partial = Fixture::new();
+    fs::DirBuilder::new()
+        .mode(0o700)
+        .create(partial.state())
+        .unwrap();
+    private(&partial.state().join("transaction.tmp"), b"partial");
+    assert!(Store::open(&partial.state(), &partial.trust()).is_err());
+    let linked = Fixture::new();
+    std::os::unix::fs::symlink(fixture.state(), linked.state()).unwrap();
+    assert!(Store::open(&linked.state(), &linked.trust()).is_err());
+    let bad_mode = Fixture::new();
+    fs::DirBuilder::new()
+        .mode(0o755)
+        .create(bad_mode.state())
+        .unwrap();
+    assert!(Store::open(&bad_mode.state(), &bad_mode.trust()).is_err());
+}
+
+#[test]
+fn binary_configuration_and_signal_shutdown() {
+    let fixture = Fixture::new();
+    let binary = env!("CARGO_BIN_EXE_layerx-human-security-provider");
+    let configured = || {
+        let mut command = Command::new(binary);
+        command
+            .env("LAYERX_HUMAN_SECURITY_PROVIDER_STATE_ROOT", fixture.state())
+            .env(
+                "LAYERX_HUMAN_SECURITY_PROVIDER_TRUST_HISTORY",
+                fixture.trust(),
+            )
+            .env("LAYERX_HUMAN_SECURITY_PROVIDER_SOCKET", fixture.socket())
+            .env(
+                "LAYERX_HUMAN_SECURITY_PROVIDER_ALLOWED_UID",
+                uid().to_string(),
+            );
+        command
+    };
+    assert!(!configured()
+        .env_remove("LAYERX_HUMAN_SECURITY_PROVIDER_ALLOWED_UID")
+        .output()
+        .unwrap()
+        .status
+        .success());
+    for seconds in ["0", "61", "invalid"] {
+        assert!(!configured()
+            .env("LAYERX_HUMAN_SECURITY_PROVIDER_DEADLINE_SECONDS", seconds)
+            .output()
+            .unwrap()
+            .status
+            .success());
+    }
+    for signal in [rustix::process::Signal::TERM, rustix::process::Signal::INT] {
+        let mut child = configured().spawn().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while fixture.client().probe().is_err() {
+            assert!(child.try_wait().unwrap().is_none());
+            assert!(Instant::now() < deadline);
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        rustix::process::kill_process(
+            rustix::process::Pid::from_raw(child.id() as i32).unwrap(),
+            signal,
+        )
+        .unwrap();
+        while child.try_wait().unwrap().is_none() {
+            assert!(Instant::now() < deadline);
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(child.wait().unwrap().success());
+        assert!(!fixture.socket().exists());
+    }
+}
+
+#[test]
+fn stored_recovery_is_reverified_against_protected_trust() {
+    let fixture = Fixture::new();
+    assert!(fixture.ingest().status.success());
+    let server = fixture.start(uid());
+    fixture.client().probe().unwrap();
+    let mut history = fs::read(fixture.trust()).unwrap();
+    let public_offset = b"LayerX/sequencer-trust-history/v1\0".len() + 4 + 2 + 4 + 8 + 32;
+    history[public_offset] ^= 1;
+    fs::write(fixture.trust(), history).unwrap();
+    assert!(fixture
+        .client()
+        .reveal_verified_receipt(&principal(), "recovery-1", 100)
+        .is_err());
+    assert!(fixture.client().probe().is_err());
+    drop(server);
+    assert!(Store::open(&fixture.state(), &fixture.trust()).is_err());
+}
+
+#[test]
+fn protected_state_files_reject_symlinks_hardlinks_and_public_modes() {
+    for mode in 0..3 {
+        let fixture = Fixture::new();
+        drop(Store::open(&fixture.state(), &fixture.trust()).unwrap());
+        let snapshot = fixture.state().join("snapshot.json");
+        match mode {
+            0 => {
+                let original = fixture.root.join("original");
+                fs::rename(&snapshot, &original).unwrap();
+                std::os::unix::fs::symlink(original, &snapshot).unwrap();
+            }
+            1 => fs::hard_link(&snapshot, fixture.root.join("alias")).unwrap(),
+            _ => fs::set_permissions(&snapshot, fs::Permissions::from_mode(0o644)).unwrap(),
+        }
+        assert!(Store::open(&fixture.state(), &fixture.trust()).is_err());
+    }
+}

--- a/human/crates/layerx-human-security-provider/tests/support/mod.rs
+++ b/human/crates/layerx-human-security-provider/tests/support/mod.rs
@@ -1,0 +1,141 @@
+use layerx_wire::encode::Encoder;
+fn encode_program_receipt(
+    activity_id: [u8; 32],
+    batch_id: [u8; 32],
+    batch_number: u64,
+    timestamp: u64,
+    resulting_state_root: [u8; 32],
+    activity_root: [u8; 32],
+    signature: Option<[u8; 64]>,
+) -> Vec<u8> {
+    let mut encoder = Encoder::new(4_096);
+    assert_eq!(encoder.structure_header_version(0x5201, 2), Ok(()));
+    assert_eq!(encoder.u16(2), Ok(()));
+    assert_eq!(encoder.bytes(&activity_id, 32), Ok(()));
+    assert_eq!(encoder.u64(batch_number), Ok(()));
+    assert_eq!(encoder.bytes(&[0x11; 32], 32), Ok(()));
+    assert_eq!(encoder.bytes(&resulting_state_root, 32), Ok(()));
+    assert_eq!(encoder.bytes(&activity_root, 32), Ok(()));
+    assert_eq!(encoder.i32(0), Ok(()));
+    assert_eq!(encoder.sequence_length(0, 512), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.bytes(&batch_id, 32), Ok(()));
+    assert_eq!(encoder.u16(9), Ok(()));
+    assert_eq!(encoder.u32(2), Ok(()));
+    assert_eq!(encoder.u32(0), Ok(()));
+    assert_eq!(encoder.u8(0), Ok(()));
+    assert_eq!(encoder.bytes(&[0; 32], 32), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.bytes(&[0; 32], 32), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.u64(0), Ok(()));
+    assert_eq!(encoder.bytes(&[0; 32], 32), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.u128(0), Ok(()));
+    assert_eq!(encoder.bytes(&[0; 32], 32), Ok(()));
+    assert_eq!(encoder.bytes(&[0x13; 32], 32), Ok(()));
+    assert_eq!(encoder.bytes(&[0x14; 32], 32), Ok(()));
+    assert_eq!(encoder.u64(timestamp), Ok(()));
+    assert_eq!(encoder.u8(u8::from(signature.is_some())), Ok(()));
+    if let Some(signature) = signature {
+        assert_eq!(encoder.bytes(&signature, 64), Ok(()));
+    }
+    encoder.finish()
+}
+
+fn encode_header(
+    batch_number: u64,
+    timestamp: u64,
+    resulting_state_root: [u8; 32],
+    activity_root: [u8; 32],
+    receipt_root: [u8; 32],
+    sequencer_id: [u8; 32],
+    epoch: u64,
+) -> Vec<u8> {
+    let mut encoder = Encoder::new(354);
+    assert_eq!(encoder.structure_header_version(0x1701, 2), Ok(()));
+    assert_eq!(encoder.u8(15), Ok(()));
+    assert_eq!(encoder.tag(1, 15), Ok(()));
+    assert_eq!(encoder.u16(2), Ok(()));
+    assert_eq!(encoder.tag(2, 15), Ok(()));
+    assert_eq!(encoder.u32(42), Ok(()));
+    assert_eq!(encoder.tag(3, 15), Ok(()));
+    assert_eq!(encoder.u64(epoch), Ok(()));
+    assert_eq!(encoder.tag(4, 15), Ok(()));
+    assert_eq!(encoder.u64(batch_number), Ok(()));
+    assert_eq!(encoder.tag(5, 15), Ok(()));
+    assert_eq!(encoder.u64(batch_number), Ok(()));
+    assert_eq!(encoder.tag(6, 15), Ok(()));
+    assert_eq!(encoder.u64(batch_number), Ok(()));
+    assert_eq!(encoder.tag(7, 15), Ok(()));
+    assert_eq!(encoder.bytes(&[0x11; 32], 32), Ok(()));
+    assert_eq!(encoder.tag(8, 15), Ok(()));
+    assert_eq!(encoder.bytes(&resulting_state_root, 32), Ok(()));
+    assert_eq!(encoder.tag(9, 15), Ok(()));
+    assert_eq!(encoder.bytes(&activity_root, 32), Ok(()));
+    assert_eq!(encoder.tag(10, 15), Ok(()));
+    assert_eq!(encoder.bytes(&receipt_root, 32), Ok(()));
+    assert_eq!(encoder.tag(11, 15), Ok(()));
+    assert_eq!(encoder.bytes(&[0x15; 32], 32), Ok(()));
+    assert_eq!(encoder.tag(12, 15), Ok(()));
+    assert_eq!(encoder.bytes(&[0x16; 32], 32), Ok(()));
+    assert_eq!(encoder.tag(13, 15), Ok(()));
+    assert_eq!(encoder.bytes(&[0x17; 32], 32), Ok(()));
+    assert_eq!(encoder.tag(14, 15), Ok(()));
+    assert_eq!(encoder.u64(timestamp), Ok(()));
+    assert_eq!(encoder.tag(15, 15), Ok(()));
+    assert_eq!(encoder.bytes(&sequencer_id, 32), Ok(()));
+    encoder.finish()
+}
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::{Signer as _, SigningKey};
+use layerx_human_security_provider::RecoveryReceipt;
+use layerx_proof::merkle::{build_proof, encode_proof};
+use layerx_wire::hash::{batch_header_digest, execution_batch_id, receipt_digest};
+
+pub fn evidence() -> (Vec<u8>, RecoveryReceipt) {
+    let key = SigningKey::from_bytes(&[37; 32]);
+    let public = key.verifying_key().to_bytes();
+    let activity = [42; 32];
+    let batch = execution_batch_id([0x11; 32], activity, 1, 1).unwrap();
+    let timestamp = 1_700_000_000_000;
+    let unsigned = encode_program_receipt(activity, batch, 1, timestamp, [23; 32], [24; 32], None);
+    let signature = key.sign(&receipt_digest(&unsigned).unwrap()).to_bytes();
+    let receipt = encode_program_receipt(
+        activity,
+        batch,
+        1,
+        timestamp,
+        [23; 32],
+        [24; 32],
+        Some(signature),
+    );
+    let (proof, root) = build_proof(&[&receipt], 0).unwrap();
+    let header = encode_header(1, timestamp, [23; 32], [24; 32], root, public, 2);
+    let header_signature = key.sign(&batch_header_digest(&header).unwrap()).to_bytes();
+    let mut history = b"LayerX/sequencer-trust-history/v1\0".to_vec();
+    history.extend_from_slice(&1u16.to_be_bytes());
+    history.extend_from_slice(&0u16.to_be_bytes());
+    history.extend_from_slice(&2u16.to_be_bytes());
+    history.extend_from_slice(&42u32.to_be_bytes());
+    history.extend_from_slice(&2u64.to_be_bytes());
+    history.extend_from_slice(&public);
+    history.extend_from_slice(&public);
+    history.extend_from_slice(&1u64.to_be_bytes());
+    history.extend_from_slice(&100u64.to_be_bytes());
+    history.push(0);
+    history.extend_from_slice(&0u64.to_be_bytes());
+    (
+        history,
+        RecoveryReceipt {
+            version: 1,
+            principal: "alice".into(),
+            evidence_id: "recovery-1".into(),
+            canonical_receipt: STANDARD.encode(receipt),
+            receipt_proof: STANDARD.encode(encode_proof(&proof)),
+            header: STANDARD.encode(header),
+            header_signature: STANDARD.encode(header_signature),
+        },
+    )
+}

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4694,3 +4694,34 @@ symbol = "Server State RemoteIdentityProvider"
 observed = "cargo test --locked --manifest-path human/Cargo.toml -p layerx-human-identity-provider exits 0 with 11 tests passing, zero ignored; qual-logs/hm3/test-final.log. Tests compile the unchanged identity_dispatch.rs source with the actual service types and exercise its RemoteIdentityProvider over real Unix sockets. Separate real-server and real-binary tests cover malformed frames, UID refusal, atomic snapshot replay, protected file and directory refusal, committed-state corruption, missing-snapshot refusal, owner-only device enrollment, crash restart and SIGTERM. Owned Rust files pass rustfmt --check --edition 2021 --config skip_children=true; qual-logs/hm3/fmt-owned-check.log. The no-deps all-target Clippy diagnostic exits 101 solely on five existing diagnostics in the imported identity_dispatch.rs source at lines 147, 191 and 192; qual-logs/hm3/clippy-owned-final.log. No lint allowances, assertions or client source were changed."
 assumption = "Runtime tests validate the provider and original client wire exchange, not automatic enrollment integration or a deployed cluster. Required workspace formatting and dependency Clippy gates remain blocked as recorded in observation.3.7.21. Environment uses CARGO_BUILD_JOBS=16, MAKEFLAGS=-j16, the pinned Rust 1.91.1 toolchain and human/target."
 severity = "note"
+[observation.6.4.159]
+task = "6.4"
+file = "human/crates/layerx-human-service/src/server/production_auth.rs"
+symbol = "RemoteSecurityProvider AuthDiscoveryIndex RecoveryEvidenceProvider"
+observed = "RemoteSecurityProvider sends only LXSP opcodes 0 through 6: probe, status, begin_setup, finish_setup, disable, rotate_backup_codes and reveal_verified_receipt. Registration, assertion, step-up, account and session bindings and resolutions use the separate local AuthDiscoveryIndex. Authorization and capability consumption also use local state and send no LXSP frames. Discovery resolution is repeatable. No receipt ingestion opcode is defined."
+assumption = "A server implementation and real-client tests for remote discovery, single-use ceremony consumption, session and capability operations require a client wire extension and production caller changes outside the security-provider crate. Recovery ingestion requires a canonical receipt and verification-input contract. No server build or test gate has run."
+severity = "blocker"
+
+[observation.6.4.160]
+task = "6.4"
+file = "human/crates/layerx-human-service/src/server/production_auth.rs human/crates/layerx-human-service/src/server/production_components.rs human/crates/layerx-human-service/src/server/schema.rs"
+symbol = "RemoteSecurityProvider clippy"
+observed = "cargo clippy --locked --manifest-path human/Cargo.toml -p layerx-human-security-provider --all-targets -- -D warnings exits 101 in layerx-human-service with 436 lint errors; qual-logs/hm4/clippy.log. Examples include many_single_char_names in production_auth.rs, unnested_or_patterns in production_components.rs and schema.rs, and missing_errors_doc on existing public APIs. A duplicate invocation waiting on the same build directory was terminated with exit 143; qual-logs/hm4/clippy-initial.log."
+assumption = "The existing human-service dependency is outside the provider crate ownership. Its code and lint configuration remain unchanged. The exact required gate is not qualified."
+severity = "blocker"
+
+[observation.6.4.161]
+task = "6.4"
+file = "human/Cargo.toml human/crates/layerx-human-security-provider"
+symbol = "cargo-fmt cg-guard"
+observed = "cargo fmt --all --check --manifest-path human/Cargo.toml exits 1 with differences in 86 existing out-of-scope files and no differences in layerx-human-security-provider; qual-logs/hm4/fmt-all.log and qual-logs/hm4/fmt-paths.txt. cg brief and cg guard exit 1 because the clone is not initialized as a Codify project; qual-logs/hm4/cg-brief.log and qual-logs/hm4/cg-guard.log."
+assumption = "The workspace format command is a report gate. Out-of-scope source formatting, Codify initialization, task status changes and cluster or image gates are not performed."
+severity = "blocker"
+
+[observation.6.4.162]
+task = "6.4"
+file = "human/crates/layerx-human-security-provider human/Cargo.toml human/Cargo.lock"
+symbol = "LXSP Store RemoteSecurityProvider ingest_recovery_receipt"
+observed = "The provider implements existing LXSP operations 0 through 6, durable authenticator setup and attempt counters, TOTP verification, backup rotation, SO_PEERCRED admission, bounded I/O, signal shutdown and owner-only verified recovery ingestion. cargo test --locked --manifest-path human/Cargo.toml -p layerx-human-security-provider exits 0 twice with all 10 real-client and binary integration tests passing; qual-logs/hm4/test.log and qual-logs/hm4/test-final.log. Tests cover expiry equality, replay, missing journal tails, corruption, protected file modes and links, exclusive locking, malformed frames, wrong UID, total I/O limits, both shutdown signals, real signed receipt ingestion and reveal, signature tampering and trust-history changes. cargo fmt --check --manifest-path human/Cargo.toml -p layerx-human-security-provider exits 0; qual-logs/hm4/fmt-owned-check.log. The final locked Clippy rerun exits 101 with the same 436 existing human-service errors; qual-logs/hm4/clippy-final.log."
+assumption = "The existing client and local discovery/capability code remain unchanged. The revised operations-only scope and administrative ingestion contract supersede the client-extension dependency described in observation 6.4.159. cargo update --workspace --manifest-path human/Cargo.toml exits 0 and adds only the new member and four dependencies, preserving every previously locked package version; qual-logs/hm4/lock-minimal.log. Environment: CARGO_BUILD_JOBS=16 MAKEFLAGS=-j16 with the worktree-default human/target directory. Full qualification remains blocked by observation 6.4.160; no task status is changed."
+severity = "blocker"


### PR DESCRIPTION
Adds the `layerx-human-security-provider` crate and binary: the server side of the LXSP Unix-socket protocol (operations 0..6) exactly as the unchanged `RemoteSecurityProvider` client in `layerx-human-service` speaks it. Durable protected state uses an initialization marker, snapshot, hash-linked replay records, atomic writes with file and directory fsync, 0600 files under a 0700 provider-owned root, symlink checks and an exclusive writer lock; corruption withdraws readiness. TOTP setup, attempts, accepted counters and backup digests persist. Recovery evidence is ingested through an owner-only `ingest-recovery-receipt` command that verifies real protocol receipts against the protected registry trust history. The README documents formats, limits and recovery from interrupted writes.

Verification (build server, `CARGO_BUILD_JOBS=16`):
- `cargo test --locked --manifest-path human/Cargo.toml -p layerx-human-security-provider`: exit 0, 10 integration tests driving the real client and real binary over temporary sockets
- `cargo fmt --check --manifest-path human/Cargo.toml -p layerx-human-security-provider`: exit 0
- `cargo clippy --locked --manifest-path human/Cargo.toml -p layerx-human-security-provider --all-targets -- -D warnings`: exit 101 because of 436 pre-existing errors in the `layerx-human-service` dependency; no provider lint result is claimed. Those errors are being fixed in a separate branch.
- `git diff --check`: exit 0
- Lock: adds the member and four dependencies with no existing version changes

Not run: image and cluster gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)