### PR TITLE
Serve the human agent authority routes from the receipt authority

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -1348,6 +1348,7 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.3",
+ "layerx-agentd",
  "layerx-client",
  "layerx-proof",
  "layerx-types",

--- a/platform/hosted/authority/Cargo.toml
+++ b/platform/hosted/authority/Cargo.toml
@@ -19,15 +19,16 @@ layerx-wire.workspace = true
 rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 subtle.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
+layerx-agentd = { path = "../../../agent/crates/layerx-agentd" }
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 layerx-types.workspace = true
 native-tls.workspace = true
-sha2.workspace = true
 
 [lints]
 workspace = true

--- a/platform/hosted/authority/README.md
+++ b/platform/hosted/authority/README.md
@@ -1,0 +1,307 @@
+# Receipt authority and the human agent contract
+
+The binary dispatches all eight `/v1/agent/*` routes with a dedicated scoped
+credential and protected policy. Registry and authorized-batch have successful
+responses. Core-clock succeeds with two distinct retained verified headers.
+Balance-context, identity, capability-scope, budget-state and key-policy refuse
+when the sources described below cannot establish the requested facts. These
+refusals do not constitute complete successful-route coverage.
+
+Sources: `agent/crates/layerx-agentd/src/human_runtime.rs`, especially
+`RemoteHumanAuthority`, its `HumanAuthorityBoundary` implementation,
+`CoreLeaseAttestation::map`, and the decoding helpers; registry constraints come
+from `agent/crates/layerx-types/src/payload.rs` and `limits.rs`.
+
+## Transport, encoding, and errors
+
+Every request is GET over HTTPS with `Authorization: Bearer <token>`. Every route
+has required `tenant` and `principal` query parameters. Strings are UTF-8 bytes
+percent-encoded except ASCII alphanumeric and `-_.~`; spaces are `%20`, not `+`.
+The client sends no body. Route-specific parameters are listed below.
+
+The connection constructor requires an `https://` endpoint, a token of at least
+32 bytes, a nonzero deadline, and a response limit in `1..=1_048_576` bytes.
+It removes trailing slashes from the endpoint. The limit applies to the entire
+JSON response, including all field names and hex text. The authority's existing
+HTTP parser separately limits incoming headers to 16 KiB, requires HTTP/1.1 and
+Host, and refuses bodies, duplicate headers, and transfer encoding.
+
+In the tables, `H32` means a JSON string of exactly 64 ASCII hexadecimal
+characters encoding 32 bytes, with no `0x` prefix; both cases are accepted.
+`HEX` means a nonempty, even-length ASCII hex string, with a decoder limit of
+2,097,152 characters, additionally constrained by the whole-response limit.
+`U64`, `U16`, `U8`, and `U32` mean unsigned JSON integers of those widths, not
+strings. `DEC128` means a JSON string parsed by Rust as `u128`; servers should
+emit unsigned base-10 digits. Boolean fields are JSON booleans.
+
+The client accepts HTTP success statuses and parses a JSON value. Missing fields,
+wrong types, invalid hex, invalid integer ranges, invalid JSON, an oversized
+Content-Length, or a successfully read body exceeding its limit produce
+`HumanOperationError::Refused`. Transport failure or failure reading the body
+produces `HumanOperationError::Unavailable`.
+
+**Every non-success HTTP status, including 503, currently produces `Refused`.**
+The error JSON and Retry-After header are not parsed. Registry converts Refused
+to `CoreStateError::Unverified` and Unavailable to `CoreStateError::Unavailable`.
+Identity converts them to `IdentityError::Unverified` and
+`IdentityError::BoundaryUnavailable`, respectively. Other routes return the human
+operation error directly. A service returning 503 for durable-state failure
+cannot cause the current client to return Unavailable without a client change.
+
+All fields below are required. The client does not reject unknown JSON fields.
+No route parses a separate signature field: public keys and evidence digests
+are not signatures. Canonical hex fields are opaque bytes to the route decoder;
+the server must establish their authority before returning them.
+
+## Routes
+
+All paths below have the prefix `/v1/agent/`.
+
+| Route | Additional query parameters | Response fields |
+| --- | --- | --- |
+| `registry` | None | `modules`: array of objects containing `module_id`: U16 and `activity_types`: array of U32 |
+| `authorized-batch` | `activity_id`: H32 | `batch_id`, `asset`, `previous_state_root`, `resulting_state_root`, `sequencer_public_key`: H32 |
+| `balance-context` | None | `account_id`, `asset_id`, `sequencer_id`, `sequencer_public_key`: H32; `currency`, `observed_at`: strings; `age_seconds`, `maximum_age_seconds`, `first_batch_number`, `last_batch_number`: U64 |
+| `identity` | `did`: percent-encoded DID text | `authorities`: array of `{kind: string, id: H32}`; `canonical_core_bytes`: HEX; `head_sequence`, `revocation_sequence`: U64; `verification_level`: string; `frozen`: boolean |
+| `core-clock` | None | `lower_unix_ms`, `lower_sequence`, `upper_unix_ms`, `upper_sequence`, `observed_head_sequence`: U64; `canonical_attestation`: HEX |
+| `capability-scope` | `did`: percent-encoded DID; `authority`, `action_key`, `capability_id`: H32 | `activity_types`: array of U16; `counterparties`, `assets`: arrays of H32; `amount_ceiling`: DEC128; `expiry_sequence`, `observed_sequence`: U64; `enforceable_dimensions`: array of strings; `verification`: U8; `evidence_digest`: H32 |
+| `budget-state` | `budget_id`: H32 | `revocation_sequence`, `observed_head_sequence`, `age_sequences`, `maximum_age_sequences`: U64; `verification`: U8; `evidence_digest`, `receipt_digest`, `checkpoint_digest`, `asset`: H32; `remaining`: DEC128 |
+| `key-policy` | `did`: percent-encoded DID; `recovery`: literal `true` or `false` | `policy_revision`, `required_delay_seconds`, `maximum_delay_seconds`, `effective_sequence`, `observed_head_sequence`, `age_sequences`, `maximum_age_sequences`: U64; `verification`: U8; `evidence_digest`, `checkpoint_digest`: H32 |
+
+### Registry
+
+The outer array must contain 1 to 32 modules, with no duplicate module IDs.
+Closed module IDs are 1 through 9 (Asset, Escrow, Budget, Stream, Service, Perps,
+Governance, Bridge, Programs). Consequently only nine distinct entries can
+currently be accepted. Each activity array has 1 to 64 entries, strictly
+increasing with no duplicates. Each packed activity is
+`(module_id << 16) | ordinal`, with ordinal in `1..=65535`, and its module must
+match the containing registration. Array order between modules is not checked.
+
+### Authorized batch and balance context
+
+Authorized-batch constructs `AuthorizedBatch` from the five fields; the route
+decoder does not itself verify a signature or correlate the answer to the
+requested activity. The existing authority verifier can produce these fields
+by verifying the signed header, receipt inclusion, execution batch identity,
+and receipt outcome. Access still needs a durable principal-to-activity binding;
+knowing an activity ID must not authorize access to another principal's facts.
+
+Currency must have 1 to 32 UTF-8 bytes and observed_at 1 to 64 bytes. No timestamp
+format or currency alphabet is validated by this decoder. Sequencer authorization
+is constructed from its ID, public key, and inclusive batch-number endpoints.
+The tuple contains account and asset identity and freshness metadata, not an
+account balance. The decoder adds no nonzero or freshness comparisons here;
+that does not authorize a server to invent freshness or sequencer authority.
+
+### Identity
+
+Authorities must be nonempty. Allowed `kind` values are `primary_key`,
+`session_key`, and `capability_grant`. There is no per-array limit beyond the
+response bound, and the decoder does not deduplicate the array.
+`verification_level` must be one of `sequencer_signed`, `batch_included`,
+`state_proven`, `checkpoint_finalised`, or `settlement_anchored`.
+Canonical bytes must be nonempty. Later identity validation rejects frozen
+identities and a zero revocation sequence; owner installation additionally
+requires checkpoint-finalised evidence. An operator-provisioned policy is not,
+by itself, proof of checkpoint finality.
+
+### Core clock
+
+The decoder requires integer fields and nonempty canonical bytes. Lease mapping
+then requires increasing wall-clock and sequence anchors, a nonzero lower
+sequence, and observed head in the inclusive anchor sequence interval. Requested
+wall bounds must lie within the anchor wall interval and be increasing.
+It maps the lower bound with floor and upper bound with ceiling using checked
+integer arithmetic. The resulting upper sequence must be strictly greater than
+both the observed head and the resulting lower sequence. Overflow refuses.
+
+A single signed historical header timestamp is insufficient. In particular,
+setting the upper sequence to the observed head cannot authorize a lease: the
+mapped upper sequence cannot exceed that anchor, while the client requires it
+to exceed the observed head. Extrapolating a future sequence from a local wall
+clock would introduce an authority assertion absent from the verified evidence.
+
+### Capability scope
+
+Allowed dimensions are `activity_type`, `counterparty`, `asset`, `amount`,
+`rate`, `purpose`, and `expiry`. Arrays are collected into sets, so duplicates
+are collapsed. The route decoder accepts any U8 verification rank, but capability
+installation requires rank 4 or 5, nonzero observed sequence and evidence digest,
+and a requested expiry after the observed sequence. It also applies
+`assert_narrowing` against the returned scope.
+
+Installation checks the evidence digest against SHA-256 of six length-prefixed
+parts. Each prefix is the part length as four big-endian bytes. Parts, in order:
+ASCII `layerx-human/agent-create/agent-evidence/v1`; byte `05`; action_key (32
+bytes); capability_id (32 bytes); observed_sequence (8 big-endian bytes);
+verification (one byte). This request-binding digest is not a signature or a
+substitute for verified policy evidence.
+
+### Budget state
+
+The decoder requires nonzero revocation_sequence; observed_head_sequence at least
+revocation_sequence; verification 4 or 5; nonzero evidence_digest, receipt_digest,
+checkpoint_digest and asset; positive maximum_age_sequences; and age_sequences
+no greater than maximum_age_sequences. Remaining may be zero. It does not check
+that age equals the head/observation difference or recompute the digests.
+
+### Key policy
+
+The decoder requires positive policy_revision, required_delay_seconds,
+effective_sequence and maximum_age_sequences; maximum_delay_seconds at least
+required_delay_seconds; observed_head_sequence at least effective_sequence;
+verification 4 or 5; nonzero evidence_digest and checkpoint_digest; and
+age_sequences no greater than maximum_age_sequences. Recovery and ordinary
+rotation are distinct requests and must select explicitly provisioned policy.
+
+## Configuration and durable evidence
+
+| Environment | Required configuration |
+| --- | --- |
+| `LAYERX_AUTHORITY_HUMAN_AGENT_TOKEN_FILE` | Absolute canonical path to `human-agent.token`; 32..4096 ASCII bytes in `0x21..0x7e`, no trailing newline. Must differ from every legacy service token. |
+| `LAYERX_AUTHORITY_HUMAN_AGENT_TENANT` | One nonempty tenant bound to the token. |
+| `LAYERX_AUTHORITY_HUMAN_AGENT_PRINCIPAL` | One nonempty principal bound to the token. |
+| `LAYERX_AUTHORITY_PRINCIPAL_POLICY_FILE` | Absolute canonical path to Secret key `principal-policy.json`, schema below. |
+| `LAYERX_AUTHORITY_MODULE_REGISTRY_FILE` | Same protected module registry file consumed by the gateway. |
+| `LAYERX_AUTHORITY_CORE_CLOCK_HORIZON` | Required positive u64 sequence horizon. |
+| `LAYERX_AUTHORITY_STATE_ROOT` | Existing absolute canonical persistent directory, owned by the authority UID, mode 0700. Dedicated to retained receipt records. |
+
+These variables form one configuration group. If all are absent, legacy receipt
+service operation remains available and human routes return 503. Partial
+configuration prevents startup. The human token is never accepted through the
+legacy service-token list. Authentication compares token bytes in constant time;
+a correctly authenticated request for any other tenant/principal receives 403.
+An absent principal receives 404. Query keys are unique; unexpected keys refuse.
+
+Protected provisioning and evidence files use the trust-history rules: absolute
+canonical path, no symlink components, regular file owned by the process UID,
+no group or other permissions, bounded reads, and identical inode, ownership,
+mode, links, size, mtime and ctime before/after opening and reading. Mount real
+files at these paths; projected Secret symlinks do not satisfy these rules.
+Policy and registry files are bounded to 16 MiB. The policy is parsed and pinned
+by SHA-256 at startup. Every authenticated request re-reads it with protected
+checks and compares the digest. Missing, invalid or changed policy returns 503;
+installing or changing policy requires a restart. Faults do not authorize stale
+in-memory policy.
+
+Verified activity lookups retain canonical receipts and replica documents under
+`STATE_ROOT/<activity-id>.json`. Writes use an exclusive mode-0600 pending file,
+file fsync, rename and directory fsync before answering success. Existing records
+must match exactly. An interrupted pending write, malformed record, signature
+failure, changed network, duplicate sequence or unprotected file refuses further
+human evidence answers. Each request replays the receipt, header signature,
+inclusion and execution-identity verifiers. Cached authorized-batch responses
+use the same verified records. Upstream relay documents alone are not retained
+because they do not carry a verified receipt.
+
+The clock uses the two highest distinct signed header end sequences. Both time
+and sequence must increase. The upper sequence is head plus configured horizon;
+the upper timestamp adds floor(horizon * measured milliseconds / measured
+sequences), using checked integer arithmetic. A zero-duration extension or any
+overflow returns 503. No SystemTime rate is used. Canonical attestation bytes are
+the JSON encoding of domain `layerx-human/core-clock/v1`, both original headers
+and signatures, horizon and derived upper coordinates. This encoding is an
+operator-authorized extrapolation, not a new sequencer signature.
+
+## Principal policy schema
+
+All object fields are required; unknown fields and duplicate principal pairs
+or DID/capability bindings refuse the policy. H32 fields are nonzero 64-digit
+hexadecimal identifiers. Provision lowercase hexadecimal consistently; bindings
+compare exact text. The file is an object with `principals`, an array of:
+
+```text
+{
+  tenant: string,
+  principal: string,
+  account_id: H32,
+  asset_id: H32,
+  activities: [H32],
+  budgets: [H32],
+  maximum_age_seconds: positive U64,
+  maximum_age_sequences: positive U64,
+  identities: [{
+    did: string,
+    authorities: [{kind: primary_key|session_key|capability_grant, id: H32}],
+    revocation_sequence: positive U64,
+    frozen: boolean,
+    evidence: {activity_id: H32, receipt_digest: H32},
+    capabilities: [{
+      authority: H32,
+      action_key: H32,
+      capability_id: H32,
+      activity_types: [U16],
+      counterparties: [H32],
+      assets: [H32],
+      amount_ceiling: unsigned decimal string,
+      expiry_sequence: positive U64,
+      enforceable_dimensions: [activity_type|counterparty|asset|amount|rate|purpose|expiry],
+      evidence: {activity_id: H32, receipt_digest: H32}
+    }],
+    rotation: KeyPolicy,
+    recovery: KeyPolicy
+  }]
+}
+KeyPolicy = {
+  policy_revision: positive U64,
+  required_delay_seconds: positive U64,
+  maximum_delay_seconds: U64 >= required_delay_seconds,
+  effective_sequence: positive U64,
+  evidence: {activity_id: H32, receipt_digest: H32}
+}
+```
+
+Every evidence activity must be in that principal's activity list. Capability
+authority must be explicitly listed in its DID authorities. Receipt digests are
+the protocol digest of canonical unsigned receipts, checked against retained
+verified evidence. Empty capability lists deny every capability. Rotation and
+recovery select separate explicit policy entries. Refusal codes distinguish
+missing policy, missing binding, missing receipt evidence, stale evidence and
+missing state/checkpoint proof.
+
+## Remaining evidence refusals
+
+The canonical gateway file currently has exactly
+`{"modules":[{"module":9,"ordinals":[1,7]}]}` shape. Authority returns exactly
+these registrations, packing each activity as `(module << 16) | ordinal`, and
+`revision` is SHA-256 of the original file bytes. It does not infer registrations
+from receipts or inject Programs ordinals. The gateway currently injects
+Programs ordinals and limits registrations to eight, while the agent supports
+nine module IDs. Those differences require resolution by the gateway owner.
+There is no currency field in the gateway schema and it denies unknown fields.
+Consequently balance-context returns 503 `registry_currency_metadata_unavailable`.
+
+Budget receipt fields do not encode budget revocation state. Replica documents
+provide batch inclusion, not checkpoint certificates. Budget-state returns 503
+`budget_revocation_and_checkpoint_evidence_unavailable`. Balance and budget
+refusals include an `evidence` object: bound account/asset, latest held account
+balance as `remaining`, observed header head (null when no headers are held),
+account observation sequence (null when absent), actual receipt digest array,
+empty checkpoint digest array, and SHA-256 of the canonical held-evidence
+inventory. An account with no receipt evidence reports `remaining: "0"` without
+inventing a receipt, checkpoint, revocation sequence or head. An empty inventory
+hash identifies the empty inventory; it is not a receipt or checkpoint digest.
+
+Identity and capability routes resolve the provisioned binding and verify its
+receipt reference, but a transfer/deploy receipt cannot prove identity or
+capability state. They return 503 `identity_state_proof_unavailable` or
+`capability_state_proof_unavailable`. Key-policy likewise refuses with
+`key_policy_checkpoint_evidence_unavailable`; it does not label a provisioned
+policy as checkpoint-finalised. Supporting successful answers requires the
+corresponding verified state and checkpoint evidence interface. The real client
+collapses these 503 statuses to Refused, as described above.
+
+The real-client TLS regression starts the real authority binary and invokes
+`RemoteHumanAuthority` in an isolated subprocess. It currently fails before the
+first request: agentd enables only ureq native TLS, while its client chooses the
+default Rustls provider, which is not compiled. No test-only dependency feature
+is added to hide this production mismatch. The agent owner must select the
+compiled provider and configure CA trust before the client assertions can run.
+
+A separate real-server wire test verifies registry and cached authorized-batch
+success from an unmodified real-node receipt fixture, all remaining route
+refusals, token separation, wrong tenant, and missing/changed policy. It does not
+replace the failing real-client regression or claim all-eight-route happy-path
+coverage. The live two-header clock test remains unqualified. See the feature
+qualification ledger and worktree `qual-logs/hm2/` for exact executed outcomes.

--- a/platform/hosted/authority/src/human.rs
+++ b/platform/hosted/authority/src/human.rs
@@ -1,0 +1,758 @@
+use super::{by_activity, hex, json, protected, refusal, Config, Request, Response};
+use layerx_platform_authority::{
+    authorized_batch_by_activity, parse_replica_evidence, receipt_locator, AuthorityFacts,
+};
+use layerx_proof::inclusion::SequencerAuthorization;
+use layerx_wire::receipt::{decode, decode_batch_header};
+use serde::{Deserialize, Serialize};
+use serde_json::{json as value, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use subtle::ConstantTimeEq;
+use zeroize::Zeroizing;
+
+const MAX_FILE: u64 = 16 * 1024 * 1024;
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Policy {
+    principals: Vec<PrincipalPolicy>,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PrincipalPolicy {
+    tenant: String,
+    principal: String,
+    account_id: String,
+    asset_id: String,
+    activities: Vec<String>,
+    budgets: Vec<String>,
+    maximum_age_seconds: u64,
+    maximum_age_sequences: u64,
+    identities: Vec<Identity>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceReference {
+    activity_id: String,
+    receipt_digest: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Identity {
+    did: String,
+    authorities: Vec<Authority>,
+    revocation_sequence: u64,
+    frozen: bool,
+    evidence: EvidenceReference,
+    capabilities: Vec<ScopeBinding>,
+    rotation: KeyPolicy,
+    recovery: KeyPolicy,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Authority {
+    kind: String,
+    id: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ScopeBinding {
+    authority: String,
+    action_key: String,
+    capability_id: String,
+    activity_types: Vec<u16>,
+    counterparties: Vec<String>,
+    assets: Vec<String>,
+    amount_ceiling: String,
+    expiry_sequence: u64,
+    enforceable_dimensions: Vec<String>,
+    evidence: EvidenceReference,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct KeyPolicy {
+    policy_revision: u64,
+    required_delay_seconds: u64,
+    maximum_delay_seconds: u64,
+    effective_sequence: u64,
+    evidence: EvidenceReference,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Registry {
+    modules: Vec<Module>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Module {
+    module: u16,
+    ordinals: Vec<u16>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Record {
+    receipt_hex: String,
+    replica_document: Value,
+}
+
+struct Verified {
+    record: Record,
+    facts: AuthorityFacts,
+    receipt_digest: [u8; 32],
+    header: Vec<u8>,
+    header_signature: [u8; 64],
+    timestamp_ms: u64,
+    last_sequence: u64,
+}
+
+pub(super) struct Human {
+    token: Zeroizing<Vec<u8>>,
+    tenant: String,
+    principal: String,
+    policy_path: PathBuf,
+    policy_digest: Option<[u8; 32]>,
+    policy: Option<Policy>,
+    registry_path: PathBuf,
+    state_root: PathBuf,
+    horizon: u64,
+    records: Mutex<()>,
+}
+
+fn required(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|_| format!("{name} is required"))
+}
+
+fn digest(bytes: &[u8]) -> [u8; 32] {
+    Sha256::digest(bytes).into()
+}
+
+fn valid_digest(value: &str) -> bool {
+    hex::decode32(value).is_ok_and(|id| id != [0; 32])
+}
+
+fn reference_valid(reference: &EvidenceReference, principal: &PrincipalPolicy) -> bool {
+    valid_digest(&reference.receipt_digest) && principal.activities.contains(&reference.activity_id)
+}
+
+fn policy_valid(policy: &Policy) -> bool {
+    let mut pairs = BTreeSet::new();
+    policy.principals.iter().all(|p| {
+        !p.tenant.is_empty()
+            && !p.principal.is_empty()
+            && pairs.insert((&p.tenant, &p.principal))
+            && valid_digest(&p.account_id)
+            && valid_digest(&p.asset_id)
+            && p.maximum_age_seconds > 0
+            && p.maximum_age_sequences > 0
+            && p.activities
+                .iter()
+                .chain(&p.budgets)
+                .all(|id| valid_digest(id))
+            && unique(&p.activities)
+            && unique(&p.budgets)
+            && p.identities
+                .iter()
+                .map(|i| &i.did)
+                .collect::<BTreeSet<_>>()
+                .len()
+                == p.identities.len()
+            && p.identities.iter().all(|i| identity_valid(i, p))
+    })
+}
+
+fn unique<T: Ord>(values: &[T]) -> bool {
+    values.iter().collect::<BTreeSet<_>>().len() == values.len()
+}
+
+fn identity_valid(i: &Identity, p: &PrincipalPolicy) -> bool {
+    !i.did.is_empty()
+        && i.revocation_sequence > 0
+        && !i.authorities.is_empty()
+        && reference_valid(&i.evidence, p)
+        && i.authorities.iter().all(|a| {
+            valid_digest(&a.id)
+                && matches!(
+                    a.kind.as_str(),
+                    "primary_key" | "session_key" | "capability_grant"
+                )
+        })
+        && i.capabilities
+            .iter()
+            .map(|c| (&c.authority, &c.action_key, &c.capability_id))
+            .collect::<BTreeSet<_>>()
+            .len()
+            == i.capabilities.len()
+        && i.capabilities.iter().all(|c| {
+            valid_digest(&c.authority)
+                && valid_digest(&c.action_key)
+                && valid_digest(&c.capability_id)
+                && i.authorities.iter().any(|a| a.id == c.authority)
+                && c.amount_ceiling.parse::<u128>().is_ok()
+                && !c.amount_ceiling.is_empty()
+                && c.amount_ceiling.bytes().all(|b| b.is_ascii_digit())
+                && c.expiry_sequence > 0
+                && reference_valid(&c.evidence, p)
+                && c.assets
+                    .iter()
+                    .chain(&c.counterparties)
+                    .all(|id| valid_digest(id))
+                && c.enforceable_dimensions.iter().all(|d| {
+                    matches!(
+                        d.as_str(),
+                        "activity_type"
+                            | "counterparty"
+                            | "asset"
+                            | "amount"
+                            | "rate"
+                            | "purpose"
+                            | "expiry"
+                    )
+                })
+        })
+        && [&i.rotation, &i.recovery].iter().all(|k| {
+            k.policy_revision > 0
+                && k.required_delay_seconds > 0
+                && k.maximum_delay_seconds >= k.required_delay_seconds
+                && k.effective_sequence > 0
+                && reference_valid(&k.evidence, p)
+        })
+}
+
+fn root_valid(path: &Path) -> Result<(), ()> {
+    let metadata = fs::symlink_metadata(path).map_err(|_| ())?;
+    if !path.is_absolute()
+        || fs::canonicalize(path).map_err(|_| ())? != path
+        || !metadata.is_dir()
+        || metadata.mode() & 0o077 != 0
+        || metadata.uid() != fs::metadata("/proc/self").map_err(|_| ())?.uid()
+    {
+        return Err(());
+    }
+    Ok(())
+}
+
+impl Human {
+    pub(super) fn load(tokens: &[Zeroizing<String>]) -> Result<Option<Self>, String> {
+        if std::env::var_os("LAYERX_AUTHORITY_HUMAN_AGENT_TOKEN_FILE").is_none() {
+            let partial = [
+                "HUMAN_AGENT_TENANT",
+                "HUMAN_AGENT_PRINCIPAL",
+                "PRINCIPAL_POLICY_FILE",
+                "MODULE_REGISTRY_FILE",
+                "CORE_CLOCK_HORIZON",
+                "STATE_ROOT",
+            ]
+            .iter()
+            .any(|suffix| std::env::var_os(format!("LAYERX_AUTHORITY_{suffix}")).is_some());
+            return if partial {
+                Err("incomplete human authority configuration".to_owned())
+            } else {
+                Ok(None)
+            };
+        }
+        let path = PathBuf::from(required("LAYERX_AUTHORITY_HUMAN_AGENT_TOKEN_FILE")?);
+        let token = Zeroizing::new(
+            protected::read(&path, 4096)
+                .map_err(|()| "human token file is unavailable or unprotected")?,
+        );
+        if token.len() < 32
+            || !token.iter().all(|b| (0x21..=0x7e).contains(b))
+            || tokens
+                .iter()
+                .any(|other| bool::from(other.as_bytes().ct_eq(&token)))
+        {
+            return Err("human token must be distinct and contain 32..4096 printable bytes without whitespace".to_owned());
+        }
+        let policy_path = PathBuf::from(required("LAYERX_AUTHORITY_PRINCIPAL_POLICY_FILE")?);
+        let loaded = protected::read(&policy_path, MAX_FILE)
+            .ok()
+            .and_then(|bytes| {
+                let policy: Policy = serde_json::from_slice(&bytes).ok()?;
+                policy_valid(&policy).then(|| (digest(&bytes), policy))
+            });
+        let (policy_digest, policy) = loaded.map_or((None, None), |(d, p)| (Some(d), Some(p)));
+        let horizon = required("LAYERX_AUTHORITY_CORE_CLOCK_HORIZON")?
+            .parse::<u64>()
+            .map_err(|_| "core clock horizon must be an integer")?;
+        if horizon == 0 {
+            return Err("core clock horizon must be positive".to_owned());
+        }
+        let state_root = PathBuf::from(required("LAYERX_AUTHORITY_STATE_ROOT")?);
+        root_valid(&state_root)
+            .map_err(|()| "state root must be an existing protected authority-owned directory")?;
+        let tenant = required("LAYERX_AUTHORITY_HUMAN_AGENT_TENANT")?;
+        let principal = required("LAYERX_AUTHORITY_HUMAN_AGENT_PRINCIPAL")?;
+        if tenant.is_empty() || principal.is_empty() {
+            return Err("human tenant and principal must be nonempty".to_owned());
+        }
+        Ok(Some(Self {
+            token,
+            tenant,
+            principal,
+            policy_path,
+            policy_digest,
+            policy,
+            registry_path: PathBuf::from(required("LAYERX_AUTHORITY_MODULE_REGISTRY_FILE")?),
+            state_root,
+            horizon,
+            records: Mutex::new(()),
+        }))
+    }
+
+    fn principal(&self) -> Result<&PrincipalPolicy, Response> {
+        let bytes = protected::read(&self.policy_path, MAX_FILE)
+            .map_err(|()| unavailable("policy_unavailable"))?;
+        if Some(digest(&bytes)) != self.policy_digest {
+            return Err(unavailable("policy_changed_restart_required"));
+        }
+        self.policy
+            .as_ref()
+            .ok_or_else(|| unavailable("policy_unavailable"))?
+            .principals
+            .iter()
+            .find(|p| p.tenant == self.tenant && p.principal == self.principal)
+            .ok_or_else(|| refusal(404, "principal_not_provisioned", None))
+    }
+
+    pub(super) fn retain(
+        &self,
+        receipt: &[u8],
+        document: &[u8],
+        config: &Config,
+    ) -> Result<(), ()> {
+        let _guard = self.records.lock().map_err(|_| ())?;
+        root_valid(&self.state_root)?;
+        let record = Record {
+            receipt_hex: hex::encode(receipt),
+            replica_document: serde_json::from_slice(document).map_err(|_| ())?,
+        };
+        let verified = verify(record.clone(), &config.authorization, config)?;
+        let path = self
+            .state_root
+            .join(format!("{}.json", hex::encode(&verified.facts.activity_id)));
+        let bytes = serde_json::to_vec(&record).map_err(|_| ())?;
+        if path.try_exists().map_err(|_| ())? {
+            if protected::read(&path, MAX_FILE)? != bytes {
+                return Err(());
+            }
+            return Ok(());
+        }
+        let temporary = self.state_root.join(".receipt.pending");
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)
+            .map_err(|_| ())?;
+        file.write_all(&bytes)
+            .and_then(|()| file.sync_all())
+            .map_err(|_| ())?;
+        fs::rename(&temporary, &path).map_err(|_| ())?;
+        File::open(&self.state_root)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|_| ())
+    }
+
+    fn evidence(&self, config: &Config) -> Result<Vec<Verified>, Response> {
+        let _guard = self
+            .records
+            .lock()
+            .map_err(|_| unavailable("state_unavailable"))?;
+        root_valid(&self.state_root).map_err(|()| unavailable("state_unavailable"))?;
+        let mut verified = Vec::new();
+        for entry in fs::read_dir(&self.state_root).map_err(|_| unavailable("state_unavailable"))? {
+            let path = entry.map_err(|_| unavailable("state_unavailable"))?.path();
+            let bytes =
+                protected::read(&path, MAX_FILE).map_err(|()| unavailable("state_unavailable"))?;
+            let record =
+                serde_json::from_slice(&bytes).map_err(|_| unavailable("state_unavailable"))?;
+            let item = verify(record, &config.authorization, config)
+                .map_err(|()| unavailable("state_evidence_refused"))?;
+            if path.file_name().and_then(|s| s.to_str())
+                != Some(format!("{}.json", hex::encode(&item.facts.activity_id)).as_str())
+            {
+                return Err(unavailable("state_evidence_refused"));
+            }
+            verified.push(item);
+        }
+        verified.sort_by_key(|r| r.facts.global_sequence);
+        if verified
+            .windows(2)
+            .any(|pair| pair[0].facts.global_sequence == pair[1].facts.global_sequence)
+        {
+            return Err(unavailable("state_sequence_conflict"));
+        }
+        Ok(verified)
+    }
+}
+
+fn verify(
+    record: Record,
+    authorization: &SequencerAuthorization,
+    config: &Config,
+) -> Result<Verified, ()> {
+    let receipt = hex::decode(&record.receipt_hex).map_err(|_| ())?;
+    let locator = receipt_locator(&receipt).map_err(|_| ())?;
+    let evidence = parse_replica_evidence(
+        &serde_json::to_vec(&record.replica_document).map_err(|_| ())?,
+        config.replica_id,
+        config.sequencer_public_key,
+    )
+    .map_err(|_| ())?;
+    let facts =
+        authorized_batch_by_activity(locator.activity_id, &receipt, &evidence, authorization)
+            .map_err(|_| ())?;
+    let header = decode_batch_header(&evidence.header).map_err(|_| ())?;
+    if header.network_id() != config.protocol_network_id {
+        return Err(());
+    }
+    Ok(Verified {
+        record,
+        facts,
+        receipt_digest: locator.receipt_digest,
+        timestamp_ms: header.timestamp_ms(),
+        last_sequence: header.last_sequence(),
+        header: evidence.header,
+        header_signature: evidence.header_signature,
+    })
+}
+
+fn unavailable(code: &str) -> Response {
+    refusal(503, code, Some(5))
+}
+
+fn query(source: Option<&str>) -> Result<BTreeMap<String, String>, Response> {
+    let mut output = BTreeMap::new();
+    for pair in source
+        .ok_or_else(|| refusal(400, "query_required", None))?
+        .split('&')
+    {
+        let (key, value) = pair
+            .split_once('=')
+            .ok_or_else(|| refusal(400, "invalid_query", None))?;
+        let key = percent_decode(key)?;
+        let value = percent_decode(value)?;
+        if output.insert(key, value).is_some() {
+            return Err(refusal(400, "duplicate_query", None));
+        }
+    }
+    Ok(output)
+}
+
+fn percent_decode(source: &str) -> Result<String, Response> {
+    let mut bytes = Vec::new();
+    let mut offset = 0;
+    while offset < source.len() {
+        let byte = source.as_bytes()[offset];
+        if byte == b'%' {
+            let end = offset + 3;
+            let encoded = source
+                .get(offset + 1..end)
+                .ok_or_else(|| refusal(400, "invalid_query", None))?;
+            bytes.extend(hex::decode(encoded).map_err(|_| refusal(400, "invalid_query", None))?);
+            offset = end;
+        } else {
+            bytes.push(byte);
+            offset += 1;
+        }
+    }
+    String::from_utf8(bytes).map_err(|_| refusal(400, "invalid_query", None))
+}
+
+pub(super) fn route(config: &Config, request: &Request) -> Response {
+    dispatch(config, request).unwrap_or_else(|response| response)
+}
+
+fn dispatch(config: &Config, request: &Request) -> Result<Response, Response> {
+    let human = config
+        .human
+        .as_ref()
+        .ok_or_else(|| unavailable("human_authority_unconfigured"))?;
+    let presented = request
+        .headers
+        .get("authorization")
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or_else(|| refusal(401, "identity_required", None))?;
+    if !bool::from(human.token.as_slice().ct_eq(presented.as_bytes())) {
+        return Err(refusal(401, "identity_required", None));
+    }
+    let params = query(request.query.as_deref())?;
+    if params.get("tenant") != Some(&human.tenant)
+        || params.get("principal") != Some(&human.principal)
+    {
+        return Err(refusal(403, "principal_mismatch", None));
+    }
+    let p = human.principal()?;
+    let name = request
+        .path
+        .strip_prefix("/v1/agent/")
+        .ok_or_else(|| refusal(404, "not_found", None))?;
+    let additional: &[&str] = match name {
+        "registry" | "balance-context" | "core-clock" => &[],
+        "authorized-batch" => &["activity_id"],
+        "identity" => &["did"],
+        "capability-scope" => &["did", "authority", "action_key", "capability_id"],
+        "budget-state" => &["budget_id"],
+        "key-policy" => &["did", "recovery"],
+        _ => return Err(refusal(404, "not_found", None)),
+    };
+    if params.len() != additional.len() + 2
+        || additional.iter().any(|key| !params.contains_key(*key))
+    {
+        return Err(refusal(400, "invalid_query", None));
+    }
+    if name == "registry" {
+        return registry(&human.registry_path);
+    }
+    if name == "authorized-batch" {
+        let activity = &params["activity_id"];
+        authorize_activity(p, activity)?;
+        if let Some(held) = human
+            .evidence(config)?
+            .iter()
+            .find(|e| hex::encode(&e.facts.activity_id) == *activity)
+        {
+            return Ok(json(
+                200,
+                &value!({"batch_id": hex::encode(&held.facts.batch_id), "asset": hex::encode(&held.facts.asset), "previous_state_root": hex::encode(&held.facts.previous_state_root), "resulting_state_root": hex::encode(&held.facts.resulting_state_root), "sequencer_public_key": hex::encode(&held.facts.sequencer_public_key)}),
+            ));
+        }
+        return Ok(by_activity(config, activity));
+    }
+    let evidence = human.evidence(config)?;
+    match name {
+        "core-clock" => clock(&evidence, human.horizon),
+        "balance-context" => {
+            let summary = account_summary(p, &evidence)?;
+            let mut response = unavailable("registry_currency_metadata_unavailable");
+            let mut body = serde_json::from_slice::<Value>(&response.body)
+                .map_err(|_| unavailable("encoding_failed"))?;
+            body["evidence"] = summary;
+            response.body = body.to_string().into_bytes();
+            Ok(response)
+        }
+        "budget-state" => budget(p, &params["budget_id"], &evidence),
+        _ => policy_route(name, &params, p, &evidence),
+    }
+}
+
+fn authorize_activity(p: &PrincipalPolicy, activity: &str) -> Result<(), Response> {
+    if !valid_digest(activity) {
+        return Err(refusal(400, "invalid_activity_id", None));
+    }
+    if !p.activities.iter().any(|id| id == activity) {
+        return Err(refusal(403, "activity_not_bound", None));
+    }
+    Ok(())
+}
+
+fn budget(p: &PrincipalPolicy, id: &str, evidence: &[Verified]) -> Result<Response, Response> {
+    if !p.budgets.iter().any(|bound| bound == id) {
+        return Err(refusal(404, "budget_not_bound", None));
+    }
+    let mut response = unavailable("budget_revocation_and_checkpoint_evidence_unavailable");
+    let mut body = serde_json::from_slice::<Value>(&response.body)
+        .map_err(|_| unavailable("encoding_failed"))?;
+    body["evidence"] = account_summary(p, evidence)?;
+    response.body = body.to_string().into_bytes();
+    Ok(response)
+}
+
+fn registry(path: &Path) -> Result<Response, Response> {
+    let bytes =
+        protected::read(path, MAX_FILE).map_err(|()| unavailable("module_registry_unavailable"))?;
+    let registry: Registry =
+        serde_json::from_slice(&bytes).map_err(|_| unavailable("module_registry_invalid"))?;
+    let mut seen = BTreeSet::new();
+    if registry.modules.is_empty()
+        || registry.modules.len() > 32
+        || registry.modules.iter().any(|m| {
+            !(1..=9).contains(&m.module)
+                || !seen.insert(m.module)
+                || m.ordinals.is_empty()
+                || m.ordinals.len() > 64
+                || m.ordinals.contains(&0)
+                || m.ordinals.windows(2).any(|p| p[0] >= p[1])
+        })
+    {
+        return Err(unavailable("module_registry_invalid"));
+    }
+    let modules: Vec<_> = registry.modules.iter().map(|m| value!({"module_id": m.module,
+        "activity_types": m.ordinals.iter().map(|o| (u32::from(m.module) << 16) | u32::from(*o)).collect::<Vec<_>>() })).collect();
+    Ok(json(
+        200,
+        &value!({"modules": modules, "revision": hex::encode(&digest(&bytes))}),
+    ))
+}
+
+fn clock(evidence: &[Verified], horizon: u64) -> Result<Response, Response> {
+    let mut headers = BTreeMap::new();
+    for item in evidence {
+        if let Some(previous) = headers.insert(item.last_sequence, item) {
+            if previous.header != item.header || previous.header_signature != item.header_signature
+            {
+                return Err(unavailable("header_conflict"));
+            }
+        }
+    }
+    let mut latest = headers.values().rev();
+    let upper = latest
+        .next()
+        .ok_or_else(|| unavailable("clock_anchors_unavailable"))?;
+    let lower = latest
+        .next()
+        .ok_or_else(|| unavailable("clock_anchors_unavailable"))?;
+    let (upper_ms, upper_sequence) = extrapolate(
+        lower.last_sequence,
+        lower.timestamp_ms,
+        upper.last_sequence,
+        upper.timestamp_ms,
+        horizon,
+    )
+    .ok_or_else(|| unavailable("clock_anchors_invalid"))?;
+    let canonical = serde_json::to_vec(&value!({"domain": "layerx-human/core-clock/v1", "lower_header": hex::encode(&lower.header), "lower_signature": hex::encode(&lower.header_signature), "head_header": hex::encode(&upper.header), "head_signature": hex::encode(&upper.header_signature), "horizon": horizon, "upper_unix_ms": upper_ms, "upper_sequence": upper_sequence})).map_err(|_| unavailable("encoding_failed"))?;
+    Ok(json(
+        200,
+        &value!({"lower_unix_ms": lower.timestamp_ms, "lower_sequence": lower.last_sequence,
+        "upper_unix_ms": upper_ms, "upper_sequence": upper_sequence, "observed_head_sequence": upper.last_sequence,
+        "canonical_attestation": hex::encode(&canonical)}),
+    ))
+}
+
+fn extrapolate(
+    lower_sequence: u64,
+    lower_ms: u64,
+    head_sequence: u64,
+    head_ms: u64,
+    horizon: u64,
+) -> Option<(u64, u64)> {
+    if lower_sequence == 0 || horizon == 0 {
+        return None;
+    }
+    let sequences = head_sequence
+        .checked_sub(lower_sequence)
+        .filter(|v| *v > 0)?;
+    let millis = head_ms.checked_sub(lower_ms).filter(|v| *v > 0)?;
+    let extension = u128::from(horizon)
+        .checked_mul(u128::from(millis))?
+        .checked_div(u128::from(sequences))?;
+    let upper_ms = head_ms.checked_add(u64::try_from(extension).ok()?)?;
+    if upper_ms <= head_ms {
+        return None;
+    }
+    Some((upper_ms, head_sequence.checked_add(horizon)?))
+}
+
+fn account_summary(p: &PrincipalPolicy, evidence: &[Verified]) -> Result<Value, Response> {
+    let account = hex::decode32(&p.account_id).map_err(|_| unavailable("policy_invalid"))?;
+    let asset = hex::decode32(&p.asset_id).map_err(|_| unavailable("policy_invalid"))?;
+    let mut balance = 0_u128;
+    let mut account_digests = Vec::new();
+    let mut observed_sequence = None;
+    for item in evidence {
+        let bytes = hex::decode(&item.record.receipt_hex)
+            .map_err(|_| unavailable("state_evidence_refused"))?;
+        let receipt = decode(&bytes).map_err(|_| unavailable("state_evidence_refused"))?;
+        let receipt = receipt
+            .protocol()
+            .ok_or_else(|| unavailable("state_evidence_refused"))?;
+        if receipt.asset() == asset && (receipt.from() == account || receipt.to() == account) {
+            balance = if receipt.to() == account {
+                receipt.credit_balance_after()
+            } else {
+                receipt.debit_balance_after()
+            };
+            account_digests.push(hex::encode(&item.receipt_digest));
+            observed_sequence = Some(item.facts.global_sequence);
+        }
+    }
+    let all: Vec<_> = evidence
+        .iter()
+        .map(|e| hex::encode(&e.receipt_digest))
+        .collect();
+    let canonical = serde_json::to_vec(
+        &value!({"domain": "layerx-human/held-evidence/v1", "receipts": all, "checkpoints": []}),
+    )
+    .map_err(|_| unavailable("encoding_failed"))?;
+    Ok(
+        value!({"account_id": p.account_id, "asset_id": p.asset_id, "remaining": balance.to_string(),
+        "observed_head_sequence": evidence.iter().map(|r| r.last_sequence).max(), "account_observed_sequence": observed_sequence,
+        "receipt_digests": account_digests, "checkpoint_digests": [], "evidence_digest": hex::encode(&digest(&canonical))}),
+    )
+}
+
+fn policy_route(
+    name: &str,
+    params: &BTreeMap<String, String>,
+    p: &PrincipalPolicy,
+    evidence: &[Verified],
+) -> Result<Response, Response> {
+    let identity = p
+        .identities
+        .iter()
+        .find(|i| i.did == params["did"])
+        .ok_or_else(|| refusal(404, "did_not_bound", None))?;
+    let reference = match name {
+        "identity" => &identity.evidence,
+        "capability-scope" => {
+            let c = identity
+                .capabilities
+                .iter()
+                .find(|c| {
+                    c.authority == params["authority"]
+                        && c.action_key == params["action_key"]
+                        && c.capability_id == params["capability_id"]
+                })
+                .ok_or_else(|| refusal(403, "capability_not_bound", None))?;
+            &c.evidence
+        }
+        "key-policy" => match params["recovery"].as_str() {
+            "true" => &identity.recovery.evidence,
+            "false" => &identity.rotation.evidence,
+            _ => return Err(refusal(400, "invalid_recovery", None)),
+        },
+        _ => return Err(refusal(404, "not_found", None)),
+    };
+    let item = evidence
+        .iter()
+        .find(|e| {
+            hex::encode(&e.facts.activity_id) == reference.activity_id
+                && hex::encode(&e.receipt_digest) == reference.receipt_digest
+        })
+        .ok_or_else(|| unavailable("policy_receipt_evidence_unavailable"))?;
+    let head = evidence
+        .iter()
+        .map(|e| e.last_sequence)
+        .max()
+        .ok_or_else(|| unavailable("head_unavailable"))?;
+    if head
+        .checked_sub(item.facts.global_sequence)
+        .is_none_or(|age| age > p.maximum_age_sequences)
+    {
+        return Err(unavailable("policy_evidence_stale"));
+    }
+    Err(unavailable(match name {
+        "identity" => "identity_state_proof_unavailable",
+        "capability-scope" => "capability_state_proof_unavailable",
+        _ => "key_policy_checkpoint_evidence_unavailable",
+    }))
+}
+
+#[cfg(test)]
+#[path = "../tests/support/human_unit.rs"]
+mod tests;

--- a/platform/hosted/authority/src/main.rs
+++ b/platform/hosted/authority/src/main.rs
@@ -1,3 +1,6 @@
+mod human;
+mod protected;
+
 use layerx_client::lni::handshake::{perform, HandshakeConfig};
 use layerx_client::lni::refusal::decode_core_refusal;
 use layerx_client::lni::schema::{decode_envelope, encode_envelope, Capability, Envelope, Version};
@@ -72,6 +75,7 @@ struct Config {
     listen: SocketAddr,
     tls: Arc<ServerConfig>,
     tokens: Vec<Zeroizing<String>>,
+    human: Option<human::Human>,
     replica_address: SocketAddr,
     replica_host: String,
     replica_token: Zeroizing<String>,
@@ -268,6 +272,7 @@ fn config() -> Result<Config, String> {
     Ok(Config {
         listen,
         tls,
+        human: human::Human::load(&tokens)?,
         tokens,
         replica_address,
         replica_host,
@@ -396,6 +401,7 @@ fn write_response(stream: &mut impl Write, response: &Response) -> Result<(), St
         200 => "OK",
         400 => "Bad Request",
         401 => "Unauthorized",
+        403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
         502 => "Bad Gateway",
@@ -654,6 +660,13 @@ fn by_activity(config: &Config, requested: &str) -> Response {
         };
     match authorized_batch_by_activity(activity_id, &receipt, &evidence, &config.authorization) {
         Ok(facts) => {
+            if config
+                .human
+                .as_ref()
+                .is_some_and(|human| human.retain(&receipt, &document, config).is_err())
+            {
+                return refusal(503, "state_persistence_unavailable", Some(5));
+            }
             let mut response = serde_json::json!({
                 "activity_id": requested,
                 "batch_id": hex::encode(&facts.batch_id),
@@ -734,6 +747,9 @@ fn route(config: &Config, request: &Request) -> Response {
     }
     if path == "/readyz" {
         return readiness(config);
+    }
+    if path.starts_with("/v1/agent/") {
+        return human::route(config, request);
     }
     if let Some(batch_id) = path
         .strip_prefix("/v1/batches/")

--- a/platform/hosted/authority/src/protected.rs
+++ b/platform/hosted/authority/src/protected.rs
@@ -1,0 +1,49 @@
+use std::fs::{self, File, Metadata};
+use std::io::Read;
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+pub(super) fn read(path: &Path, maximum: u64) -> Result<Vec<u8>, ()> {
+    if !path.is_absolute() || fs::canonicalize(path).map_err(|_| ())? != path {
+        return Err(());
+    }
+    let uid = fs::metadata("/proc/self").map_err(|_| ())?.uid();
+    let before = fs::symlink_metadata(path).map_err(|_| ())?;
+    if !before.is_file() || before.uid() != uid || before.mode() & 0o077 != 0 {
+        return Err(());
+    }
+    let mut file = File::open(path).map_err(|_| ())?;
+    let opened = file.metadata().map_err(|_| ())?;
+    if !same(&before, &opened) {
+        return Err(());
+    }
+    let mut bytes = Vec::new();
+    file.by_ref()
+        .take(maximum.checked_add(1).ok_or(())?)
+        .read_to_end(&mut bytes)
+        .map_err(|_| ())?;
+    let after = file.metadata().map_err(|_| ())?;
+    let named = fs::symlink_metadata(path).map_err(|_| ())?;
+    if bytes.len() as u64 > maximum
+        || !same(&opened, &after)
+        || !same(&after, &named)
+        || fs::canonicalize(path).map_err(|_| ())? != path
+    {
+        return Err(());
+    }
+    Ok(bytes)
+}
+
+fn same(a: &Metadata, b: &Metadata) -> bool {
+    a.dev() == b.dev()
+        && a.ino() == b.ino()
+        && a.uid() == b.uid()
+        && a.gid() == b.gid()
+        && a.mode() == b.mode()
+        && a.nlink() == b.nlink()
+        && a.size() == b.size()
+        && a.mtime() == b.mtime()
+        && a.mtime_nsec() == b.mtime_nsec()
+        && a.ctime() == b.ctime()
+        && a.ctime_nsec() == b.ctime_nsec()
+}

--- a/platform/hosted/authority/tests/human_tls.rs
+++ b/platform/hosted/authority/tests/human_tls.rs
@@ -1,0 +1,485 @@
+use layerx_agentd::human::HumanPeer;
+use layerx_agentd::human_runtime::{HumanAuthorityBoundary, RemoteHumanAuthority};
+use layerx_platform_authority::{hex, receipt_locator};
+use layerx_types::ids::Did;
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn must<T, E: std::fmt::Debug>(result: Result<T, E>) -> T {
+    result.unwrap_or_else(|e| panic!("{e:?}"))
+}
+
+fn write(path: &Path, bytes: &[u8]) {
+    must(fs::write(path, bytes));
+    must(fs::set_permissions(path, fs::Permissions::from_mode(0o600)));
+}
+
+fn openssl(root: &Path, arguments: &[&str]) {
+    let result = must(
+        Command::new("openssl")
+            .current_dir(root)
+            .args(arguments)
+            .output(),
+    );
+    assert!(
+        result.status.success(),
+        "openssl failed: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+}
+
+struct Server {
+    child: Child,
+    root: PathBuf,
+}
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn prepare_root() -> PathBuf {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../qual-logs/hm2");
+    must(fs::create_dir_all(&root));
+    let mut nonce = [0_u8; 8];
+    must(getrandom::fill(&mut nonce));
+    let root = must(fs::canonicalize(root)).join(format!(
+        "human-tls-{}-{}",
+        std::process::id(),
+        hex::encode(&nonce)
+    ));
+    must(fs::create_dir(&root));
+    must(fs::set_permissions(
+        &root,
+        fs::Permissions::from_mode(0o700),
+    ));
+    let state = root.join("state");
+    must(fs::create_dir(&state));
+    must(fs::set_permissions(
+        &state,
+        fs::Permissions::from_mode(0o700),
+    ));
+    openssl(
+        &root,
+        &[
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-nodes",
+            "-keyout",
+            "server.key",
+            "-out",
+            "server.pem",
+            "-days",
+            "1",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "subjectAltName=DNS:localhost,IP:127.0.0.1",
+            "-addext",
+            "basicConstraints=critical,CA:TRUE",
+        ],
+    );
+    openssl(
+        &root,
+        &[
+            "x509",
+            "-in",
+            "server.pem",
+            "-outform",
+            "DER",
+            "-out",
+            "server.der",
+        ],
+    );
+    openssl(
+        &root,
+        &[
+            "pkcs8",
+            "-topk8",
+            "-nocrypt",
+            "-in",
+            "server.key",
+            "-outform",
+            "DER",
+            "-out",
+            "key.der",
+        ],
+    );
+    root
+}
+
+fn seed(root: &Path) {
+    let state = root.join("state");
+    let fixture: Value = must(serde_json::from_str(include_str!(
+        "fixtures/real-program-deploy-receipt.json"
+    )));
+    let text = |key: &str| {
+        fixture[key]
+            .as_str()
+            .unwrap_or_else(|| panic!("fixture field {key}"))
+    };
+    let receipt = must(hex::decode(text("receipt_hex")));
+    let locator = must(receipt_locator(&receipt));
+    let activity = hex::encode(&locator.activity_id);
+    let reference =
+        json!({"activity_id": activity, "receipt_digest": hex::encode(&locator.receipt_digest)});
+    let key_policy = json!({"policy_revision":1,"required_delay_seconds":10,"maximum_delay_seconds":20,"effective_sequence":1,"evidence":reference});
+    let policy = json!({"principals":[{"tenant":"tenant space","principal":"principal","account_id":hex::encode(&[1;32]),"asset_id":hex::encode(&[2;32]),"activities":[activity],"budgets":[hex::encode(&[4;32])],"maximum_age_seconds":60,"maximum_age_sequences":100,"identities":[{"did":"did:layerx:test","authorities":[{"kind":"primary_key","id":hex::encode(&[5;32])}],"revocation_sequence":1,"frozen":false,"evidence":reference,"capabilities":[],"rotation":key_policy,"recovery":key_policy}]}]});
+    write(
+        &root.join("policy.json"),
+        &must(serde_json::to_vec(&policy)),
+    );
+    write(
+        &root.join("modules.json"),
+        br#"{"modules":[{"module":9,"ordinals":[1,7]}]}"#,
+    );
+    write(
+        &root.join("human.token"),
+        b"human-test-token-0000000000000000000000",
+    );
+    write(
+        &root.join("service.token"),
+        b"service-test-token-00000000000000000000",
+    );
+    write(
+        &root.join("replica.token"),
+        b"replica-test-token-00000000000000000000",
+    );
+    let mut encoder = layerx_wire::encode::Encoder::new(64);
+    must(encoder.structure_header(0x4d50));
+    must(encoder.u32(0));
+    must(encoder.u32(1));
+    must(encoder.u8(0));
+    must(encoder.bytes(&[], 1024));
+    let proof = encoder.finish();
+    let record = json!({"receipt_hex": text("receipt_hex"), "replica_document": {
+        "authority_replica_id": hex::encode(&[9;32]), "sequencer_public_key": text("sequencer_public_key_hex"),
+        "batch_evidence": {"header_hex":text("header_hex"),"header_signature":text("header_signature_hex"),"receipt_proof_hex":hex::encode(&proof)}
+    }});
+    write(
+        &state.join(format!("{activity}.json")),
+        &must(serde_json::to_vec(&record)),
+    );
+}
+
+fn launch(root: PathBuf) -> (Server, std::net::SocketAddr) {
+    let state = root.join("state");
+    let fixture: Value = must(serde_json::from_str(include_str!(
+        "fixtures/real-program-deploy-receipt.json"
+    )));
+    let text = |key: &str| {
+        fixture[key]
+            .as_str()
+            .unwrap_or_else(|| panic!("fixture field {key}"))
+    };
+    let listener = must(TcpListener::bind("127.0.0.1:0"));
+    let address = must(listener.local_addr());
+    drop(listener);
+    let output = must(fs::File::create(root.join("server.log")));
+    let child = must(
+        Command::new(env!("CARGO_BIN_EXE_layerx-receipt-authority"))
+            .env_clear()
+            .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+            .env("LAYERX_AUTHORITY_LISTEN", address.to_string())
+            .env("LAYERX_AUTHORITY_TLS_CERT_DER", root.join("server.der"))
+            .env("LAYERX_AUTHORITY_TLS_KEY_DER", root.join("key.der"))
+            .env("LAYERX_AUTHORITY_TOKEN_FILES", root.join("service.token"))
+            .env("LAYERX_AUTHORITY_REPLICA_URL", "http://127.0.0.1:1")
+            .env(
+                "LAYERX_AUTHORITY_REPLICA_BEARER_TOKEN_FILE",
+                root.join("replica.token"),
+            )
+            .env("LAYERX_AUTHORITY_REPLICA_ID", hex::encode(&[9; 32]))
+            .env("LAYERX_AUTHORITY_LNI_SOCKET", root.join("absent.sock"))
+            .env("LAYERX_AUTHORITY_PROTOCOL_NETWORK_ID", "7332")
+            .env("LAYERX_AUTHORITY_NETWORK_ID", "human-authority-test")
+            .env("LAYERX_AUTHORITY_SEQUENCER_ID", text("sequencer_id_hex"))
+            .env(
+                "LAYERX_AUTHORITY_SEQUENCER_PUBLIC_KEY",
+                text("sequencer_public_key_hex"),
+            )
+            .env("LAYERX_AUTHORITY_FIRST_BATCH", "1")
+            .env("LAYERX_AUTHORITY_LAST_BATCH", "100")
+            .env(
+                "LAYERX_AUTHORITY_HUMAN_AGENT_TOKEN_FILE",
+                root.join("human.token"),
+            )
+            .env("LAYERX_AUTHORITY_HUMAN_AGENT_TENANT", "tenant space")
+            .env("LAYERX_AUTHORITY_HUMAN_AGENT_PRINCIPAL", "principal")
+            .env(
+                "LAYERX_AUTHORITY_PRINCIPAL_POLICY_FILE",
+                root.join("policy.json"),
+            )
+            .env(
+                "LAYERX_AUTHORITY_MODULE_REGISTRY_FILE",
+                root.join("modules.json"),
+            )
+            .env("LAYERX_AUTHORITY_CORE_CLOCK_HORIZON", "100")
+            .env("LAYERX_AUTHORITY_STATE_ROOT", &state)
+            .stdout(Stdio::null())
+            .stderr(output)
+            .spawn(),
+    );
+    let mut server = Server { child, root };
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        assert!(
+            must(server.child.try_wait()).is_none(),
+            "authority exited; see {}/server.log",
+            server.root.display()
+        );
+        if TcpStream::connect(address).is_ok() {
+            break;
+        }
+        assert!(Instant::now() < deadline, "authority startup timed out");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    (server, address)
+}
+
+#[test]
+fn real_tls_client_and_durable_refusals() {
+    if std::env::var_os("LAYERX_HUMAN_TLS_CHILD").is_some() {
+        drive_client();
+        return;
+    }
+    let root = prepare_root();
+    seed(&root);
+    let (server, address) = launch(root);
+    let result = must(
+        Command::new(must(std::env::current_exe()))
+            .args([
+                "--exact",
+                "real_tls_client_and_durable_refusals",
+                "--nocapture",
+            ])
+            .env("LAYERX_HUMAN_TLS_CHILD", address.to_string())
+            .env("LAYERX_HUMAN_TLS_ROOT", &server.root)
+            .env("SSL_CERT_FILE", server.root.join("server.pem"))
+            .env("SSL_CERT_DIR", &server.root)
+            .env_remove("HTTPS_PROXY")
+            .env_remove("HTTP_PROXY")
+            .env_remove("ALL_PROXY")
+            .output(),
+    );
+    write(
+        &server.root.join("client.log"),
+        &[result.stdout, result.stderr].concat(),
+    );
+    assert!(
+        result.status.success(),
+        "real client failed; see {}/client.log",
+        server.root.display()
+    );
+}
+
+fn wire_status(root: &Path, path: &str) -> u16 {
+    wire_status_at(
+        root,
+        &must(std::env::var("LAYERX_HUMAN_TLS_CHILD")),
+        path,
+        "human-test-token-0000000000000000000000",
+    )
+}
+
+fn wire_status_at(root: &Path, address: &str, path: &str, token: &str) -> u16 {
+    let certificate = must(native_tls::Certificate::from_pem(&must(fs::read(
+        root.join("server.pem"),
+    ))));
+    let connector = must(
+        native_tls::TlsConnector::builder()
+            .add_root_certificate(certificate)
+            .build(),
+    );
+    let tcp = must(TcpStream::connect(address));
+    must(tcp.set_read_timeout(Some(Duration::from_secs(5))));
+    let mut tls = must(connector.connect("localhost", tcp));
+    must(write!(tls, "GET {path} HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\nConnection: close\r\n\r\n"));
+    let mut response = String::new();
+    must(tls.read_to_string(&mut response));
+    must(
+        response
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or_else(|| panic!("status absent"))
+            .parse(),
+    )
+}
+
+#[test]
+fn real_server_wire_statuses_remain_distinct() {
+    let root = prepare_root();
+    seed(&root);
+    let (server, address) = launch(root);
+    let address = address.to_string();
+    let status = |path: &str| {
+        wire_status_at(
+            &server.root,
+            &address,
+            path,
+            "human-test-token-0000000000000000000000",
+        )
+    };
+    let fixture: Value = must(serde_json::from_str(include_str!(
+        "fixtures/real-program-deploy-receipt.json"
+    )));
+    let receipt = must(hex::decode(
+        fixture["receipt_hex"]
+            .as_str()
+            .unwrap_or_else(|| panic!("receipt")),
+    ));
+    let activity = hex::encode(&must(receipt_locator(&receipt)).activity_id);
+    let base = "tenant=tenant%20space&principal=principal";
+    assert_eq!(status(&format!("/v1/agent/registry?{base}")), 200);
+    assert_eq!(
+        status(&format!(
+            "/v1/agent/authorized-batch?{base}&activity_id={activity}"
+        )),
+        200
+    );
+    assert_eq!(status(&format!("/v1/agent/core-clock?{base}")), 503);
+    assert_eq!(status(&format!("/v1/agent/balance-context?{base}")), 503);
+    assert_eq!(
+        status(&format!(
+            "/v1/agent/identity?{base}&did=did%3Alayerx%3Atest"
+        )),
+        503
+    );
+    assert_eq!(status(&format!("/v1/agent/capability-scope?{base}&did=did%3Alayerx%3Atest&authority={}&action_key={}&capability_id={}", hex::encode(&[5;32]), hex::encode(&[6;32]), hex::encode(&[7;32]))), 403);
+    assert_eq!(
+        status(&format!(
+            "/v1/agent/budget-state?{base}&budget_id={}",
+            hex::encode(&[4; 32])
+        )),
+        503
+    );
+    assert_eq!(
+        status(&format!(
+            "/v1/agent/key-policy?{base}&did=did%3Alayerx%3Atest&recovery=false"
+        )),
+        503
+    );
+    assert_eq!(
+        status("/v1/agent/registry?tenant=other&principal=principal"),
+        403
+    );
+    assert_eq!(
+        wire_status_at(
+            &server.root,
+            &address,
+            &format!("/v1/agent/registry?{base}"),
+            "service-test-token-00000000000000000000"
+        ),
+        401
+    );
+    must(fs::rename(
+        server.root.join("policy.json"),
+        server.root.join("policy.hidden"),
+    ));
+    assert_eq!(status(&format!("/v1/agent/registry?{base}")), 503);
+    must(fs::rename(
+        server.root.join("policy.hidden"),
+        server.root.join("policy.json"),
+    ));
+    assert_eq!(status(&format!("/v1/agent/registry?{base}")), 200);
+    write(&server.root.join("policy.json"), br#"{"principals":[]}"#);
+    assert_eq!(status(&format!("/v1/agent/registry?{base}")), 503);
+}
+
+fn drive_client() {
+    use layerx_agentd::human::HumanOperationError;
+    let endpoint = format!("https://{}", must(std::env::var("LAYERX_HUMAN_TLS_CHILD")));
+    let root = PathBuf::from(must(std::env::var("LAYERX_HUMAN_TLS_ROOT")));
+    let mut client = must(RemoteHumanAuthority::connect(
+        &endpoint,
+        "human-test-token-0000000000000000000000".to_owned(),
+        Duration::from_secs(5),
+        1_048_576,
+    ));
+    let peer = HumanPeer {
+        uid: 1,
+        tenant: "tenant space".to_owned(),
+        principal: "principal".to_owned(),
+    };
+    must(client.registry(&peer));
+    assert_eq!(
+        wire_status(
+            &root,
+            "/v1/agent/core-clock?tenant=tenant%20space&principal=principal"
+        ),
+        503
+    );
+    assert_eq!(
+        wire_status(&root, "/v1/agent/registry?tenant=other&principal=principal"),
+        403
+    );
+    assert_eq!(wire_status(&root, &format!("/v1/agent/capability-scope?tenant=tenant%20space&principal=principal&did=did%3Alayerx%3Atest&authority={}&action_key={}&capability_id={}", hex::encode(&[5;32]), hex::encode(&[6;32]), hex::encode(&[7;32]))), 403);
+    let fixture: Value = must(serde_json::from_str(include_str!(
+        "fixtures/real-program-deploy-receipt.json"
+    )));
+    let receipt = must(hex::decode(
+        fixture["receipt_hex"]
+            .as_str()
+            .unwrap_or_else(|| panic!("receipt")),
+    ));
+    let locator = must(receipt_locator(&receipt));
+    assert_eq!(
+        must(client.authorized_batch(&peer, locator.activity_id)).batch_id(),
+        locator.batch_id
+    );
+    assert!(matches!(
+        client.lease_attestation(&peer),
+        Err(HumanOperationError::Refused)
+    ));
+    assert!(matches!(
+        client.balance_context(&peer),
+        Err(HumanOperationError::Refused)
+    ));
+    let did = must(Did::new(b"did:layerx:test"));
+    assert!(client.core_identity(&peer, &did).is_err());
+    assert!(matches!(
+        client.capability_scope(&peer, &did, [5; 32], [6; 32], [7; 32]),
+        Err(HumanOperationError::Refused)
+    ));
+    assert!(matches!(
+        client.budget_state(&peer, [4; 32]),
+        Err(HumanOperationError::Refused)
+    ));
+    assert!(matches!(
+        client.key_rotation_policy(&peer, &did, false),
+        Err(HumanOperationError::Refused)
+    ));
+    let other = HumanPeer {
+        tenant: "other".to_owned(),
+        ..peer.clone()
+    };
+    assert!(client.registry(&other).is_err());
+    must(fs::rename(
+        root.join("policy.json"),
+        root.join("policy.hidden"),
+    ));
+    assert!(client.registry(&peer).is_err());
+    assert_eq!(
+        wire_status(
+            &root,
+            "/v1/agent/registry?tenant=tenant%20space&principal=principal"
+        ),
+        503
+    );
+    must(fs::rename(
+        root.join("policy.hidden"),
+        root.join("policy.json"),
+    ));
+    must(client.registry(&peer));
+    write(&root.join("policy.json"), br#"{"principals":[]}"#);
+    assert!(client.registry(&peer).is_err());
+}

--- a/platform/hosted/authority/tests/support/human_unit.rs
+++ b/platform/hosted/authority/tests/support/human_unit.rs
@@ -1,0 +1,156 @@
+use super::*;
+use std::os::unix::fs::PermissionsExt;
+
+fn principal() -> PrincipalPolicy {
+    serde_json::from_value(value!({
+        "tenant": "tenant", "principal": "principal", "account_id": hex::encode(&[1;32]), "asset_id": hex::encode(&[2;32]),
+        "activities": [hex::encode(&[3;32])], "budgets": [hex::encode(&[4;32])],
+        "maximum_age_seconds": 60, "maximum_age_sequences": 100,
+        "identities": [{"did": "did:layerx:test", "authorities": [{"kind": "primary_key", "id": hex::encode(&[5;32])}],
+            "revocation_sequence": 1, "frozen": false,
+            "evidence": {"activity_id": hex::encode(&[3;32]), "receipt_digest": hex::encode(&[6;32])},
+            "capabilities": [],
+            "rotation": {"policy_revision": 1, "required_delay_seconds": 10, "maximum_delay_seconds": 20, "effective_sequence": 1,
+                "evidence": {"activity_id": hex::encode(&[3;32]), "receipt_digest": hex::encode(&[6;32])}},
+            "recovery": {"policy_revision": 2, "required_delay_seconds": 20, "maximum_delay_seconds": 40, "effective_sequence": 1,
+                "evidence": {"activity_id": hex::encode(&[3;32]), "receipt_digest": hex::encode(&[6;32])}}
+        }]
+    })).unwrap_or_else(|e| panic!("policy: {e}"))
+}
+
+fn result_status(result: Result<Response, Response>) -> u16 {
+    result.unwrap_or_else(|r| r).status
+}
+
+#[test]
+fn registry_uses_exact_file_bytes_and_refuses_unprotected_invalid_missing_sources() {
+    let root = std::env::temp_dir().join(format!("human-registry-{}", std::process::id()));
+    fs::create_dir(&root).unwrap_or_else(|e| panic!("directory: {e}"));
+    let path = root.join("registry.json");
+    assert_eq!(result_status(registry(&path)), 503);
+    let bytes = br#"{"modules":[{"module":9,"ordinals":[1,7]}]}"#;
+    fs::write(&path, bytes).unwrap_or_else(|e| panic!("registry: {e}"));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+        .unwrap_or_else(|e| panic!("mode: {e}"));
+    let response = registry(&path).unwrap_or_else(|_| panic!("valid registry"));
+    let body: Value =
+        serde_json::from_slice(&response.body).unwrap_or_else(|e| panic!("JSON: {e}"));
+    assert_eq!(body["revision"], hex::encode(&digest(bytes)));
+    assert_eq!(
+        body["modules"][0]["activity_types"],
+        value!([589_825, 589_831])
+    );
+    fs::write(&path, br#"{"modules":[{"module":9,"ordinals":[7,1]}]}"#)
+        .unwrap_or_else(|e| panic!("registry: {e}"));
+    assert_eq!(result_status(registry(&path)), 503);
+    fs::write(&path, bytes).unwrap_or_else(|e| panic!("registry: {e}"));
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+        .unwrap_or_else(|e| panic!("mode: {e}"));
+    assert_eq!(result_status(registry(&path)), 503);
+    fs::remove_dir_all(root).unwrap_or_else(|e| panic!("cleanup: {e}"));
+}
+
+#[test]
+fn authorized_batch_requires_explicit_activity_binding() {
+    let p = principal();
+    assert!(authorize_activity(&p, &hex::encode(&[3; 32])).is_ok());
+    assert_eq!(
+        authorize_activity(&p, &hex::encode(&[8; 32]))
+            .err()
+            .map(|r| r.status),
+        Some(403)
+    );
+    assert_eq!(
+        authorize_activity(&p, "bad").err().map(|r| r.status),
+        Some(400)
+    );
+}
+
+#[test]
+fn balance_context_zero_account_does_not_invent_receipts_or_head() {
+    let summary = account_summary(&principal(), &[]).unwrap_or_else(|_| panic!("zero account"));
+    assert_eq!(summary["remaining"], "0");
+    assert_eq!(summary["receipt_digests"], value!([]));
+    assert_eq!(summary["checkpoint_digests"], value!([]));
+    assert!(summary["observed_head_sequence"].is_null());
+}
+
+#[test]
+fn core_clock_requires_two_anchors_and_checked_measured_rate() {
+    assert_eq!(result_status(clock(&[], 100)), 503);
+    assert_eq!(extrapolate(10, 1000, 20, 3000, 5), Some((4000, 25)));
+    assert_eq!(extrapolate(10, 1000, 10, 3000, 5), None);
+    assert_eq!(extrapolate(10, 1000, 20, 1000, 5), None);
+    assert_eq!(extrapolate(10, 1000, 20, 3000, u64::MAX), None);
+    assert_eq!(extrapolate(0, 1000, 20, 3000, 5), None);
+    assert_eq!(extrapolate(10, 1000, 20, 1001, 1), None);
+}
+
+#[test]
+fn identity_requires_bound_did_and_actual_receipt_evidence() {
+    let params = BTreeMap::from([("did".to_owned(), "did:layerx:test".to_owned())]);
+    assert_eq!(
+        result_status(policy_route("identity", &params, &principal(), &[])),
+        503
+    );
+    let params = BTreeMap::from([("did".to_owned(), "did:layerx:other".to_owned())]);
+    assert_eq!(
+        result_status(policy_route("identity", &params, &principal(), &[])),
+        404
+    );
+}
+
+#[test]
+fn capability_scope_refuses_unlisted_capability() {
+    let params = BTreeMap::from([
+        ("did".to_owned(), "did:layerx:test".to_owned()),
+        ("authority".to_owned(), hex::encode(&[5; 32])),
+        ("action_key".to_owned(), hex::encode(&[6; 32])),
+        ("capability_id".to_owned(), hex::encode(&[7; 32])),
+    ]);
+    assert_eq!(
+        result_status(policy_route("capability-scope", &params, &principal(), &[])),
+        403
+    );
+}
+
+#[test]
+fn budget_state_refuses_missing_revocation_and_checkpoint_with_zero_evidence_summary() {
+    assert_eq!(
+        result_status(budget(&principal(), &hex::encode(&[8; 32]), &[])),
+        404
+    );
+    let response = budget(&principal(), &hex::encode(&[4; 32]), &[])
+        .unwrap_or_else(|_| panic!("bound budget"));
+    assert_eq!(response.status, 503);
+    let body: Value =
+        serde_json::from_slice(&response.body).unwrap_or_else(|e| panic!("JSON: {e}"));
+    assert_eq!(body["evidence"]["remaining"], "0");
+}
+
+#[test]
+fn key_policy_requires_exact_recovery_selector_and_evidence() {
+    for (selector, status) in [("false", 503), ("true", 503), ("TRUE", 400)] {
+        let params = BTreeMap::from([
+            ("did".to_owned(), "did:layerx:test".to_owned()),
+            ("recovery".to_owned(), selector.to_owned()),
+        ]);
+        assert_eq!(
+            result_status(policy_route("key-policy", &params, &principal(), &[])),
+            status
+        );
+    }
+    assert!(policy_valid(&Policy {
+        principals: vec![principal()]
+    }));
+}
+
+#[test]
+fn query_decoding_rejects_duplicates_and_preserves_utf8() {
+    assert!(query(Some("tenant=a&tenant=b")).is_err());
+    assert!(query(Some("did=%FF")).is_err());
+    assert!(query(Some("did=%2")).is_err());
+    let result =
+        query(Some("did=did%3Alayerx%3A%C3%A9%20x")).unwrap_or_else(|_| panic!("valid query"));
+    assert_eq!(result["did"], "did:layerx:é x");
+}

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4725,3 +4725,59 @@ symbol = "LXSP Store RemoteSecurityProvider ingest_recovery_receipt"
 observed = "The provider implements existing LXSP operations 0 through 6, durable authenticator setup and attempt counters, TOTP verification, backup rotation, SO_PEERCRED admission, bounded I/O, signal shutdown and owner-only verified recovery ingestion. cargo test --locked --manifest-path human/Cargo.toml -p layerx-human-security-provider exits 0 twice with all 10 real-client and binary integration tests passing; qual-logs/hm4/test.log and qual-logs/hm4/test-final.log. Tests cover expiry equality, replay, missing journal tails, corruption, protected file modes and links, exclusive locking, malformed frames, wrong UID, total I/O limits, both shutdown signals, real signed receipt ingestion and reveal, signature tampering and trust-history changes. cargo fmt --check --manifest-path human/Cargo.toml -p layerx-human-security-provider exits 0; qual-logs/hm4/fmt-owned-check.log. The final locked Clippy rerun exits 101 with the same 436 existing human-service errors; qual-logs/hm4/clippy-final.log."
 assumption = "The existing client and local discovery/capability code remain unchanged. The revised operations-only scope and administrative ingestion contract supersede the client-extension dependency described in observation 6.4.159. cargo update --workspace --manifest-path human/Cargo.toml exits 0 and adds only the new member and four dependencies, preserving every previously locked package version; qual-logs/hm4/lock-minimal.log. Environment: CARGO_BUILD_JOBS=16 MAKEFLAGS=-j16 with the worktree-default human/target directory. Full qualification remains blocked by observation 6.4.160; no task status is changed."
 severity = "blocker"
+
+[observation.6.4.163]
+task = "6.4"
+file = "platform/hosted/authority/src/main.rs platform/hosted/authority/src/lib.rs agent/crates/layerx-agentd/src/human_runtime.rs"
+symbol = "Config ReplicaDocument AuthorityFacts RemoteHumanAuthority::get CoreLeaseAttestation::map"
+observed = "The receipt authority performs on-demand activity receipt and replica batch-evidence lookups. Config has no durable principal policy store or verified clock source. ReplicaDocument contains replica identity, sequencer key and batch evidence; AuthorityFacts does not contain the complete module registry, budget revocation state or checkpoint-finalised policy evidence. A historical header timestamp does not establish the future upper sequence required by CoreLeaseAttestation::map. RemoteHumanAuthority::get maps every non-success HTTP status, including 503, to Refused; only transport and body-read failures become Unavailable. The derived eight-route wire contract is recorded in platform/hosted/authority/README.md. No runtime routes, token provisioning, policy store or integration tests have been implemented."
+assumption = "Verified registry, budget and clock evidence interfaces must be supplied or specified before the full contract can be implemented without synthetic authority facts. An agent-side status mapping change is required if HTTP 503 must produce Unavailable. Runtime qualification remains unrun because implementation is incomplete. Cluster and image gates are unavailable on this host."
+severity = "blocker"
+
+[observation.6.4.164]
+task = "6.4"
+file = "platform/hosted/gateway/src/main.rs platform/hosted/authority/src/human.rs"
+symbol = "ModuleFile configured_modules registry"
+observed = "Gateway ModuleFile accepts only modules with module and ordinals and denies unknown fields; no currency metadata is available. configured_modules injects Programs ordinals 1, 2 and 7 and limits the module count to eight. Authority preserves the complete provisioned file registrations, reports SHA-256 of its bytes, and refuses balance-context with HTTP 503 when currency metadata cannot be derived."
+assumption = "The gateway owner must supply a shared currency metadata schema and reconcile enabled-set semantics. Authority must not invent currency or silently inject registrations."
+severity = "blocker"
+
+[observation.6.4.165]
+task = "6.4"
+file = "platform/hosted/authority/src/human.rs agent/crates/layerx-wire/src/receipt.rs agent/crates/layerx-agentd/src/human_runtime.rs"
+symbol = "policy_route budget account_summary RemoteHumanAuthority::get"
+observed = "ProtocolReceipt exposes account balances but no budget revocation field; ReplicaDocument supplies signed batch inclusion without checkpoint certificates or identity/capability state proofs. Provisioned bindings and verified receipt references cannot establish checkpoint-finalised state. Authority routes refuse missing state proofs and checkpoint evidence with HTTP 503; balance and budget refusals carry the actual held evidence inventory and zero balances for accounts without receipts. RemoteHumanAuthority collapses all non-2xx responses, including durable faults, to Refused."
+assumption = "Successful identity, capability, budget and key-policy responses need verifiable state and checkpoint evidence tied to the explicit provisioned bindings. No synthetic receipt, checkpoint digest, revocation sequence or verification rank may substitute for missing evidence. The client status collapse remains unchanged under the supplied decision."
+severity = "blocker"
+
+[observation.6.4.166]
+task = "6.4"
+file = "agent/crates/layerx-agentd/Cargo.toml agent/crates/layerx-agentd/src/human_runtime.rs platform/hosted/authority/tests/human_tls.rs"
+symbol = "RemoteHumanAuthority::connect real_tls_client_and_durable_refusals"
+observed = "The real RemoteHumanAuthority client panics before its first HTTPS request: uri scheme is https, provider is Rustls but feature is not enabled: rustls. The agentd ureq dependency disables default features and enables json and native-tls-no-default; RemoteHumanAuthority::connect uses the default TLS provider. cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority exits 101 after 12 library/binary unit tests pass and the real-client TLS test fails. Evidence: qual-logs/hm2/test.log and qual-logs/hm2/human-tls-147340/client.log."
+assumption = "The agent owner must explicitly select the compiled native TLS provider and configure trusted CA roots, or consistently enable and configure Rustls. The authority test must retain the real-client failure; adding a test-only provider feature would hide the deployed client defect."
+severity = "blocker"
+
+[observation.6.4.167]
+task = "6.4"
+file = "platform/hosted/authority/tests/real_node.rs"
+symbol = "identity real_node_authority_serves_verified_facts_and_reflects_replica_loss real_replica_readiness_relay_and_refusals_without_sequencer"
+observed = "cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --test maintenance_identity --test real_node --no-fail-fast exits 101. All five maintenance-identity tests pass. Both real-node tests fail the existing harness assertion requiring root UID: actual 1000, expected 0. Evidence: qual-logs/hm2/existing-integration.log. The configured native binary directory and worktree build/bin also contain no layerxd or layerx-genesis-build binaries."
+assumption = "Live-node qualification needs the existing root harness prerequisite and real native binaries. The assertions remain intact. Cluster and image gates are not run because the host has no cluster or image tooling."
+severity = "blocker"
+
+[observation.6.4.168]
+task = "6.4"
+file = "platform/Cargo.toml"
+symbol = "cargo_fmt_all_check"
+observed = "cargo fmt --all --check --manifest-path platform/Cargo.toml exits 1 with formatting differences in 86 files outside platform/hosted/authority. The full 29073-line report is qual-logs/hm2/fmt-all.log and the unique file inventory is qual-logs/hm2/fmt-paths.log. cargo fmt --check --manifest-path platform/Cargo.toml -p layerx-platform-authority exits 0 in qual-logs/hm2/fmt-owned-check.log."
+assumption = "Formatting outside the authority ownership scope remains unchanged. The aggregate formatting gate is not passing."
+severity = "blocker"
+
+[observation.6.4.169]
+task = "6.4"
+file = "platform/hosted/authority/tests/human_tls.rs platform/hosted/authority/src/human.rs"
+symbol = "real_server_wire_statuses_remain_distinct"
+observed = "cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --test human_tls exits 101: the separate real-server wire-status test passes and the real RemoteHumanAuthority test retains its TLS-provider panic. The wire test verifies registry and cached authorized-batch HTTP 200, wrong-tenant and unlisted-capability HTTP 403, service-token HTTP 401, and missing or changed policy and insufficient clock evidence HTTP 503. Evidence: qual-logs/hm2/tls-final.log. Final cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --all-targets -- -D warnings exits 0 in qual-logs/hm2/clippy-last.log; authority-only cargo fmt --check exits 0 in qual-logs/hm2/fmt-last.log."
+assumption = "The wire test proves server behavior but does not replace the failed real-client integration or establish successful responses for the five evidence-blocked routes. Native prerequisite inspection first encounters EACCES under the ordinary UID; privileged read-only stat then confirms both advertised native binary paths are absent. Evidence: qual-logs/hm2/native-prerequisites.log and qual-logs/hm2/native-root-check.log."
+severity = "blocker"


### PR DESCRIPTION
Implements the `/v1/agent/*` contract that `layerx-agentd` consumes through `RemoteHumanAuthority` in the receipt authority: registry, authorized-batch, balance-context, identity, core-clock, capability-scope, budget-state and key-policy. Authorization is a dedicated constant-time token bound to exactly one tenant/principal pair and separated from the legacy service tokens. Principal policy comes from a protected, SHA-256 pinned policy file re-validated per request; the module registry revision is the digest of the canonical gateway registry file; the core clock is extrapolated from two distinct retained verified batch headers; receipt and replica records persist with file and directory fsync. The README carries the derived wire contract, environment table and policy schema.

Partial by design, recorded in the ledger:
- balance-context cannot report currency because the canonical registry schema has no currency metadata;
- identity, capability-scope, key-policy and budget-state refuse with 503 when the provisioned receipt references cannot establish state or checkpoint evidence (no budget revocation sequence or checkpoint certificate exists yet);
- the real-client TLS regression fails because the client on `main` selects a TLS provider that is not compiled in; the agentd fix is in the `lane/agentd-human-owner` branch (PR 181). The real-server wire test passes.

Verification (build server, `CARGO_BUILD_JOBS=16`):
- `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority --all-targets -- -D warnings`: exit 0
- `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority`: exit 101; three library and nine new unit tests pass, the real-client TLS test fails as described
- `cargo fmt --all --check --manifest-path platform/Cargo.toml`: exit 1 on 86 pre-existing out-of-scope files

Not run: image and cluster gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)