### PR TITLE
Publish pinned settlement evidence for deposits, withdrawals and exits

### DIFF
--- a/contracts/CheckpointRegistry.sol
+++ b/contracts/CheckpointRegistry.sol
@@ -10,6 +10,9 @@ import {Predeploys} from "./deployment/Predeploys.sol";
 import {LayerXComponent} from "./security/LayerXComponent.sol";
 
 contract CheckpointRegistry is LayerXComponent {
+    error CheckpointProposerOnly();
+    error WitnessesAlreadyPublished();
+    error InvalidWitnesses();
     error InvalidConfiguration();
     error InvalidHeader();
     error InvalidCertificate();
@@ -34,6 +37,10 @@ contract CheckpointRegistry is LayerXComponent {
     bytes32 public immutable genesisReceiptRoot;
     bytes32 public immutable genesisCheckpointId;
 
+    uint16 public constant EVIDENCE_VERSION = 1;
+    mapping(bytes32 => address) public checkpointProposer;
+    mapping(bytes32 => bytes32) public witnessesDigest;
+    mapping(bytes32 => bool) public witnessesPublished;
     mapping(bytes32 => bytes32) public finalisedStateRoot;
     mapping(uint64 => bytes32) public checkpointAtBatch;
     mapping(bytes32 => uint64) public registeredAt;
@@ -50,6 +57,8 @@ contract CheckpointRegistry is LayerXComponent {
     uint64 public finalisedLastSequence;
     uint64 public finalisedTimestamp;
     bytes32 public latestFinalisedStateRoot;
+
+    event CheckpointWitnessesPublished(bytes32 indexed checkpointHash, uint16 version, bytes32 witnessesDigest);
 
     event CheckpointRegistered(
         bytes32 indexed checkpointHash,
@@ -179,6 +188,7 @@ contract CheckpointRegistry is LayerXComponent {
             ++valid;
         }
         if (valid < threshold) revert InvalidCertificate();
+        checkpointProposer[digest] = msg.sender;
         finalisedStateRoot[digest] = header.resultingStateRoot;
         checkpointAtBatch[header.batchNumber] = digest;
         registeredAt[digest] = Arithmetic.toUint64(block.timestamp);
@@ -207,6 +217,27 @@ contract CheckpointRegistry is LayerXComponent {
             header.dataAvailabilityRoot,
             checkpointGuarantorSetVersion[digest]
         );
+    }
+
+    function publishCheckpointWitnesses(
+        bytes32 digest,
+        bytes calldata canonicalWithdrawalStateWitnesses,
+        bytes calldata canonicalBalanceWitnesses
+    ) external {
+        if (msg.sender != checkpointProposer[digest]) {
+            revert CheckpointProposerOnly();
+        }
+        if (!isCanonicalCheckpoint(digest)) revert InvalidHeader();
+        if (witnessesPublished[digest]) revert WitnessesAlreadyPublished();
+        if (
+            canonicalWithdrawalStateWitnesses.length == 0 || canonicalBalanceWitnesses.length == 0
+                || canonicalWithdrawalStateWitnesses.length + canonicalBalanceWitnesses.length > 1_000_000
+        ) revert InvalidWitnesses();
+        bytes32 commitment =
+            sha256(abi.encode(digest, EVIDENCE_VERSION, canonicalWithdrawalStateWitnesses, canonicalBalanceWitnesses));
+        witnessesPublished[digest] = true;
+        witnessesDigest[digest] = commitment;
+        emit CheckpointWitnessesPublished(digest, EVIDENCE_VERSION, commitment);
     }
 
     function isFinalised(bytes32 digest, bytes32 stateRoot) external view returns (bool) {

--- a/contracts/custody/LayerXVault.sol
+++ b/contracts/custody/LayerXVault.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.24;
 
+import {CheckpointRegistry} from "../CheckpointRegistry.sol";
+import {IGuarantorEligibility} from "../interfaces/IGuarantorEligibility.sol";
 import {ILayerXAssetRegistry} from "../interfaces/ILayerXAssetRegistry.sol";
 import {SafeTransfer} from "../libraries/SafeTransfer.sol";
 import {Arithmetic} from "../libraries/Arithmetic.sol";
@@ -11,10 +13,20 @@ import {Predeploys} from "../deployment/Predeploys.sol";
 import {Constants} from "../libraries/Constants.sol";
 
 contract LayerXVault is Governed, ReentrancyLock, LayerXComponent {
+    error DepositRootProposerOnly();
+    error InvalidDepositRoot();
+    error DepositRootAlreadyRegistered();
     error InvalidDeposit();
     error InvalidRelease();
     error SettlementModuleOnly();
     error InvalidBondAccounting();
+
+    uint16 public constant EVIDENCE_VERSION = 1;
+    mapping(bytes32 => bytes32) public depositRegistrationDigest;
+    mapping(bytes32 => bool) public depositRootRegistered;
+    event DepositRootRegistered(
+        bytes32 indexed checkpointId, bytes32 indexed depositRoot, bytes32 registrationDigest, uint16 version
+    );
 
     ILayerXAssetRegistry public immutable assetRegistry;
     address public guarantorBond;
@@ -74,6 +86,43 @@ contract LayerXVault is Governed, ReentrancyLock, LayerXComponent {
         ) revert InvalidBondAccounting();
         guarantorBond = bond;
         emit GuarantorBondSet(bond);
+    }
+
+    function registerDepositRoot(
+        bytes calldata canonicalRegistration,
+        bytes calldata ed25519Signature,
+        bytes32[] calldata leafOrdering
+    ) external {
+        bytes memory domain = bytes("LX:PAXEER:DEPOSIT:ROOT:v1");
+        uint256 offset = domain.length;
+        if (
+            canonicalRegistration.length != offset + 134 || ed25519Signature.length != 64 || leafOrdering.length == 0
+                || leafOrdering.length > 4096 || keccak256(canonicalRegistration[:offset]) != keccak256(domain)
+        ) revert InvalidDepositRoot();
+        bytes32 checkpointId = bytes32(canonicalRegistration[offset:offset + 32]);
+        bytes32 stateRoot = bytes32(canonicalRegistration[offset + 32:offset + 64]);
+        bytes32 depositRoot = bytes32(canonicalRegistration[offset + 64:offset + 96]);
+        bytes32 custodyReference = bytes32(canonicalRegistration[offset + 96:offset + 128]);
+        uint32 network = uint32(bytes4(canonicalRegistration[offset + 128:offset + 132]));
+        uint16 protocol = uint16(bytes2(canonicalRegistration[offset + 132:offset + 134]));
+        if (guarantorBond == address(0)) revert DepositRootProposerOnly();
+        address authority = IGuarantorEligibility(guarantorBond).slashingAuthority();
+        if (authority.code.length == 0) revert DepositRootProposerOnly();
+        CheckpointRegistry registry = ICheckpointRegistryAuthority(authority).registry();
+        if (
+            address(registry.guarantorEligibility()) != guarantorBond
+                || registry.checkpointProposer(checkpointId) != msg.sender
+        ) revert DepositRootProposerOnly();
+        if (
+            !registry.isFinalised(checkpointId, stateRoot) || depositRoot == bytes32(0)
+                || custodyReference == bytes32(0) || network != registry.networkId()
+                || protocol != registry.protocolVersion()
+        ) revert InvalidDepositRoot();
+        if (depositRootRegistered[checkpointId]) revert DepositRootAlreadyRegistered();
+        bytes32 commitment = sha256(abi.encode(EVIDENCE_VERSION, canonicalRegistration, ed25519Signature, leafOrdering));
+        depositRootRegistered[checkpointId] = true;
+        depositRegistrationDigest[checkpointId] = commitment;
+        emit DepositRootRegistered(checkpointId, depositRoot, commitment, EVIDENCE_VERSION);
     }
 
     function deposit(bytes32 assetId, uint256 amount, bytes32 beneficiary)
@@ -146,4 +195,8 @@ interface IGuarantorBondAccounting {
     function bondToken() external view returns (address);
     function assetId() external view returns (bytes32);
     function syncCustodiedValue(uint256 value) external;
+}
+
+interface ICheckpointRegistryAuthority {
+    function registry() external view returns (CheckpointRegistry);
 }

--- a/docs/wiki/SettlementEvidence.md
+++ b/docs/wiki/SettlementEvidence.md
@@ -1,0 +1,59 @@
+# Settlement evidence publication
+
+Publication version 1 uses the existing CheckpointRegistry and LayerXVault addresses. It does not change the guarantor certificate, Ed25519 checkpoint authority, custody finality, withdrawal debit or emergency-exit verification rules. Deployment finalization checks both contracts' `EVIDENCE_VERSION()` equals 1. Existing deployed bytecode must be redeployed through the normal suite deployment; editing source does not upgrade it.
+
+## Authority and ABI
+
+`registerCheckpoint` continues to require a valid guarantor certificate. It records its caller in `checkpointProposer(bytes32)`. Only that caller can publish witnesses for the registered canonical checkpoint, once:
+
+```solidity
+publishCheckpointWitnesses(bytes32 checkpointHash, bytes canonicalWithdrawalStateWitnesses, bytes canonicalBalanceWitnesses)
+event CheckpointWitnessesPublished(bytes32 indexed checkpointHash, uint16 version, bytes32 witnessesDigest)
+```
+
+The selector is `0x69929738`. The digest is SHA256 of `abi.encode(checkpointHash, uint16(1), canonicalWithdrawalStateWitnesses, canonicalBalanceWitnesses)`. The full bytes remain in transaction input. Both byte strings must be nonempty and together at most 1,000,000 bytes. Empty vectors have their tag and zero count. `witnessesPublished` refuses repeated publication independently of digest value; `witnessesDigest` exposes the commitment.
+
+```solidity
+registerDepositRoot(bytes canonicalRegistration, bytes ed25519Signature, bytes32[] leafOrdering)
+event DepositRootRegistered(bytes32 indexed checkpointId, bytes32 indexed depositRoot, bytes32 registrationDigest, uint16 version)
+```
+
+The selector is `0x8ff1fac9`. The vault resolves the existing registry through `guarantorBond.slashingAuthority().registry()`, checks its `guarantorEligibility()` equals the configured bond and requires the recorded checkpoint proposer. The same governance-controlled bond/challenge-manager wiring already used for settlement supplies this path; there is no new address or signing key configuration. The registration must match that registry's canonical checkpoint state root, network and protocol. It requires exactly 64 signature bytes and 1–4096 ordered leaf hashes. The contract pins the bytes; Ed25519 verification remains off-chain.
+
+`registrationDigest = SHA256(abi.encode(uint16(1), canonicalRegistration, ed25519Signature, leafOrdering))`. `depositRegistrationDigest(checkpointId)` stores it; `depositRootRegistered(checkpointId)` refuses duplicates, including replacement signatures or orderings. Leaf ordering is Merkle positional order, not sorted hash order. The consumer rejects duplicate leaf hashes and reconstructs the root and index-aware path with `layerx_proof::merkle`.
+
+## Canonical encodings
+
+Integers below are unsigned big-endian. Tags are exact ASCII bytes, with a terminating zero only where explicitly shown. No trailing bytes are accepted. Publication version 1 is independent of the LayerX protocol version selected for proof validation.
+
+Deposit `canonicalRegistration` is exactly the existing `deposit_root_registration_message` output:
+
+```
+"LX:PAXEER:DEPOSIT:ROOT:v1"
+checkpoint_id[32] checkpoint_state_root[32] deposit_root[32]
+custody_reference[32] network_id:u32 protocol_version:u16
+```
+
+The authority signs these exact bytes with Ed25519. Leaf hashes are the real deposit leaf encoding passed through the protocol Merkle leaf hash. The signature is separate ABI calldata, not appended to the signing message.
+
+Both checkpoint witness byte strings use `tag || count:u32 || (item_length:u32 || item_bytes)*`, with at most 4096 entries and at most 1,048,576 bytes per decoded vector:
+
+| Vector tag | Item bytes | Strict entry ordering |
+| --- | --- | --- |
+| `LXP/Paxeer/withdrawal-witnesses/v1\0` | withdrawal_id[32], withdrawal_leaf_hash[32], canonical checkpoint proof | withdrawal_id |
+| `LXP/Paxeer/balance-witnesses/v1\0` | account[32], asset[32], balance:u128, recipient[20], canonical checkpoint proof | (account, asset, recipient) |
+
+The checkpoint proof is the existing `wire::encode_checkpoint_proof_for_protocol` representation: `0x01 0x02`, checkpoint hash[32], state root[32], epoch:u64, batch:u64, data-availability root[32], leaf index:u64, sibling count:u16, siblings[32] each, attestation count:u32, then the existing canonical guarantor attestations. Its decoder applies all existing protocol, depth, index and attestation structural checks. Withdrawal leaves and balance leaves use the existing verifier hash functions, including ABI address padding. Every witness root must equal the registered resulting state root.
+
+`CheckpointProof::encode_publication` and `ExitEvidence::encode_publication` produce these encodings from the workspace's real types and reject mismatched roots and unordered entries. The complete proof carries guarantor attestations; the existing claim verifiers check them against the certificate recorded on-chain.
+
+## Consumer flow
+
+1. Configure the normal `EndpointConfig` with the exact chain ID and TLS trust, or `LocalEmulator` for a loopback Anvil. Supply the existing vault and registry addresses, expected checkpoint identity, protocol version and confirmation depth. No custom RPC method or provider-specific indexer is used.
+2. Fetch `CheckpointRegistered` and the appropriate publication event using `eth_getLogs`. Fetch each transaction input using `eth_getTransactionByHash` and its receipt using `eth_getTransactionReceipt`. Require successful execution, matching emitting contract, checkpoint topics, transaction hash/index and block identity. Require the publication caller to equal the checkpoint registration caller.
+3. Use `eth_getBlockByNumber` for the head and containing blocks; require the requested confirmation depth, matching canonical block hashes and inclusion at the declared transaction index. `raw_call` also checks `eth_chainId` against endpoint configuration on each request. Refuse absent or ambiguous observations.
+4. Strictly decode the ABI, reconstruct it to reject aliasing, padding and trailing calldata, and recompute the complete publication digest. Decode canonical witnesses and bind checkpoint hash, resulting root, epoch, batch and data-availability root to the registration event.
+5. For deposits call `PublishedDepositProof::fetch_published` with the actual custody event facts, then pass its result and the separately tracked custody `FinalityReport` to `DepositProofVerifier::obtain`. That existing verifier checks the configured Ed25519 key, network, protocol, custody reference, quorum/finality and custody leaf inclusion.
+6. For withdrawals call `CheckpointProof::fetch_published` with the debit expectation, then pass the returned proof and verified `CommittedWithdrawalDebit` to `WithdrawalBoundary::construct_claim`. For exits call `ExitEvidence::fetch_published`, then `EmergencyExit::construct_claim`. These existing boundaries remain mandatory: they verify certificate standing, asset and debit bindings, nullifiers, roots and exit eligibility before settlement. Publication itself is not a payout authorization.
+
+The fetch methods return untrusted evidence and typed endpoint failures. They do not replace the existing quorum and admission APIs. Balance witnesses are available before `executeExit`; the exit event is never used as a pre-settlement proof source.

--- a/human/crates/layerx-paxeer-client/src/deposit.rs
+++ b/human/crates/layerx-paxeer-client/src/deposit.rs
@@ -1,3 +1,6 @@
+#[path = "evidence.rs"]
+pub(crate) mod evidence;
+
 use ed25519_dalek::{Signature, VerifyingKey};
 use layerx_agent_api::error::RequestId;
 use layerx_agent_api::idempotency::{BodyDigest, IdempotentMutation, Key};
@@ -2197,4 +2200,113 @@ fn deposit_nullifier(deposit_id: [u8; 32]) -> [u8; 32] {
 
 fn deposit_inclusion(error: MerkleError) -> DepositFailure {
     DepositFailure::ProofUnavailable(ProofFault::DepositInclusion(error))
+}
+
+impl PublishedDepositProof {
+    /// Fetches pinned registration bytes and constructs their index-aware custody path.
+    /// Call `DepositProofVerifier::obtain` to admit the signature and custody finality.
+    ///
+    /// # Errors
+    /// Refuses missing, ambiguous, displaced, malformed or digest/root-mismatched publication.
+    pub fn fetch_published(
+        endpoint: &EndpointConfig,
+        vault: EvmAddress,
+        registry: EvmAddress,
+        checkpoint: [u8; 32],
+        custody: CustodyDeposit,
+        confirmations: u64,
+    ) -> Result<Self, crate::EndpointFailure> {
+        use evidence as e;
+        let registered = e::registered(endpoint, registry, checkpoint, confirmations)?;
+        let published =
+            e::publication(endpoint, vault, e::DEPOSIT_TOPIC, checkpoint, confirmations)?;
+        let decode = || {
+            if published.sender != registered.sender
+                || published.topics.len() != 3
+                || published.data.len() != 64
+                || published.data[32..] != e::word(1)?
+                || !published.input.starts_with(&e::DEPOSIT_SELECTOR)
+            {
+                return Err(e::invalid());
+            }
+            let args = &published.input[4..];
+            let canonical = e::split_dynamic(args, 3, 0)?;
+            let signature = e::split_dynamic(args, 3, 1)?;
+            let offset = e::word_number(args.get(64..96).ok_or_else(e::invalid)?)?;
+            let mut r = e::Reader(args.get(offset..).ok_or_else(e::invalid)?);
+            let count = e::word_number(r.take(32)?)?;
+            if count == 0 || count > e::MAX_ITEMS {
+                return Err(e::invalid());
+            }
+            let mut leaves = Vec::with_capacity(count);
+            for _ in 0..count {
+                leaves.push(r.array::<32>()?);
+            }
+            r.finish()?;
+            let mut ordering = e::word(count)?.to_vec();
+            for leaf in &leaves {
+                ordering.extend_from_slice(leaf);
+            }
+            let tails = [e::dynamic(canonical)?, e::dynamic(signature)?, ordering];
+            if e::abi(&[], &tails)? != args
+                || e::digest(&e::abi(&[e::word(1)?], &tails)?) != published.data[..32]
+            {
+                return Err(e::invalid());
+            }
+            let mut r = e::Reader(
+                canonical
+                    .strip_prefix(DEPOSIT_ROOT_DOMAIN)
+                    .ok_or_else(e::invalid)?,
+            );
+            let registration = DepositRootRegistration {
+                checkpoint_id: r.array()?,
+                checkpoint_state_root: r.array()?,
+                deposit_root: r.array()?,
+                custody_reference: r.array()?,
+                network_id: u32::from_be_bytes(r.array()?),
+                protocol_version: u16::from_be_bytes(r.array()?),
+                signature: signature.try_into().map_err(|_| e::invalid())?,
+            };
+            r.finish()?;
+            if registration.checkpoint_id != checkpoint
+                || registration.checkpoint_state_root != registered.state_root
+                || registration.deposit_root != published.topics[2]
+                || deposit_root_registration_message(&registration).map_err(|_| e::invalid())?
+                    != canonical
+                || layerx_proof::merkle::root_from_leaf_hashes(&leaves).map_err(|_| e::invalid())?
+                    != registration.deposit_root
+                || leaves
+                    .iter()
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len()
+                    != leaves.len()
+            {
+                return Err(e::invalid());
+            }
+            let leaf = leaf_hash(
+                &deposit_leaf_bytes(
+                    custody.deposit_id,
+                    registration.custody_reference,
+                    custody.asset,
+                    custody.amount,
+                    checkpoint,
+                    registration.network_id,
+                    registration.protocol_version,
+                )
+                .map_err(|_| e::invalid())?,
+            )
+            .map_err(|_| e::invalid())?;
+            let index = leaves
+                .iter()
+                .position(|value| *value == leaf)
+                .ok_or_else(e::invalid)?;
+            let (inclusion_proof, _) = layerx_proof::merkle::build_leaf_hash_proof(&leaves, index)
+                .map_err(|_| e::invalid())?;
+            Ok(Self {
+                registration,
+                inclusion_proof,
+            })
+        };
+        decode().map_err(|fault| e::failure(endpoint, fault))
+    }
 }

--- a/human/crates/layerx-paxeer-client/src/evidence.rs
+++ b/human/crates/layerx-paxeer-client/src/evidence.rs
@@ -1,0 +1,442 @@
+use crate::{raw_call, CheckpointProof, EndpointConfig, EndpointFailure, EndpointFault, Json};
+use layerx_types::intent::EvmAddress;
+use sha2::{Digest as _, Sha256};
+
+pub(crate) const LIMIT: usize = 1_048_576;
+pub(crate) const MAX_ITEMS: usize = 4096;
+pub(crate) const WITHDRAWALS: &[u8] = b"LXP/Paxeer/withdrawal-witnesses/v1\0";
+pub(crate) const BALANCES: &[u8] = b"LXP/Paxeer/balance-witnesses/v1\0";
+
+pub(crate) fn invalid() -> EndpointFault {
+    EndpointFault::InconsistentObservation
+}
+pub(crate) fn failure(endpoint: &EndpointConfig, fault: EndpointFault) -> EndpointFailure {
+    EndpointFailure {
+        url: endpoint.url.clone(),
+        fault,
+    }
+}
+pub(crate) fn required<'a>(value: &'a Json, name: &str) -> Result<&'a Json, EndpointFault> {
+    value.member(name).ok_or_else(invalid)
+}
+pub(crate) fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::from("0x");
+    for byte in bytes {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+pub(crate) fn bytes(value: &Json) -> Result<Vec<u8>, EndpointFault> {
+    let text = value
+        .as_text()
+        .and_then(|s| s.strip_prefix("0x"))
+        .ok_or_else(invalid)?;
+    if text.len() % 2 != 0 || text.len() > LIMIT * 2 {
+        return Err(invalid());
+    }
+    text.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let text = std::str::from_utf8(pair).map_err(|_| invalid())?;
+            u8::from_str_radix(text, 16).map_err(|_| invalid())
+        })
+        .collect()
+}
+pub(crate) fn fixed<const N: usize>(value: &Json) -> Result<[u8; N], EndpointFault> {
+    bytes(value)?.try_into().map_err(|_| invalid())
+}
+fn quantity(value: &Json) -> Result<u64, EndpointFault> {
+    let text = value
+        .as_text()
+        .and_then(|s| s.strip_prefix("0x"))
+        .ok_or_else(invalid)?;
+    if text.is_empty() || (text.len() > 1 && text.starts_with('0')) {
+        return Err(invalid());
+    }
+    u64::from_str_radix(text, 16).map_err(|_| invalid())
+}
+pub(crate) fn word(value: usize) -> Result<[u8; 32], EndpointFault> {
+    let mut out = [0; 32];
+    out[24..].copy_from_slice(&u64::try_from(value).map_err(|_| invalid())?.to_be_bytes());
+    Ok(out)
+}
+pub(crate) fn word_number(value: &[u8]) -> Result<usize, EndpointFault> {
+    if value.len() != 32 || value[..24] != [0; 24] {
+        return Err(invalid());
+    }
+    usize::try_from(u64::from_be_bytes(
+        value[24..].try_into().map_err(|_| invalid())?,
+    ))
+    .map_err(|_| invalid())
+}
+pub(crate) fn dynamic(value: &[u8]) -> Result<Vec<u8>, EndpointFault> {
+    let mut out = word(value.len())?.to_vec();
+    out.extend_from_slice(value);
+    out.resize(out.len().div_ceil(32) * 32, 0);
+    Ok(out)
+}
+pub(crate) fn abi(head: &[[u8; 32]], tails: &[Vec<u8>]) -> Result<Vec<u8>, EndpointFault> {
+    let mut out = Vec::new();
+    let mut offset = (head.len() + tails.len()) * 32;
+    for value in head {
+        out.extend_from_slice(value);
+    }
+    for tail in tails {
+        out.extend_from_slice(&word(offset)?);
+        offset = offset.checked_add(tail.len()).ok_or_else(invalid)?;
+    }
+    for tail in tails {
+        out.extend_from_slice(tail);
+    }
+    if out.len() > LIMIT {
+        return Err(invalid());
+    }
+    Ok(out)
+}
+pub(crate) fn split_dynamic(
+    input: &[u8],
+    head_words: usize,
+    index: usize,
+) -> Result<&[u8], EndpointFault> {
+    let offset = word_number(
+        input
+            .get(index * 32..(index + 1) * 32)
+            .ok_or_else(invalid)?,
+    )?;
+    if offset < head_words * 32 || offset % 32 != 0 {
+        return Err(invalid());
+    }
+    let length_end = offset.checked_add(32).ok_or_else(invalid)?;
+    let size = word_number(input.get(offset..length_end).ok_or_else(invalid)?)?;
+    let start = offset.checked_add(32).ok_or_else(invalid)?;
+    let end = start.checked_add(size).ok_or_else(invalid)?;
+    input.get(start..end).ok_or_else(invalid)
+}
+
+pub(crate) struct Publication {
+    pub input: Vec<u8>,
+    pub topics: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+    pub sender: [u8; 20],
+}
+
+pub(crate) fn publication(
+    endpoint: &EndpointConfig,
+    contract: EvmAddress,
+    topic: [u8; 32],
+    checkpoint: [u8; 32],
+    confirmations: u64,
+) -> Result<Publication, EndpointFailure> {
+    let run = || -> Result<Publication, EndpointFault> {
+        if confirmations == 0 {
+            return Err(invalid());
+        }
+        let rpc = |method, params: &[Json]| raw_call(endpoint, method, params).map_err(|e| e.fault);
+        let logs = rpc(
+            "eth_getLogs",
+            &[Json::Object(vec![
+                ("address".into(), Json::Text(hex(&contract.bytes()))),
+                ("fromBlock".into(), Json::Text("0x0".into())),
+                ("toBlock".into(), Json::Text("latest".into())),
+                (
+                    "topics".into(),
+                    Json::Array(vec![Json::Text(hex(&topic)), Json::Text(hex(&checkpoint))]),
+                ),
+            ])],
+        )?;
+        let Json::Array(logs) = logs else {
+            return Err(invalid());
+        };
+        if logs.len() != 1 {
+            return Err(invalid());
+        }
+        let log = &logs[0];
+        if required(log, "removed")? != &Json::Bool(false)
+            || fixed::<20>(required(log, "address")?)? != contract.bytes()
+        {
+            return Err(invalid());
+        }
+        let Json::Array(topics) = required(log, "topics")? else {
+            return Err(invalid());
+        };
+        let topics = topics
+            .iter()
+            .map(fixed::<32>)
+            .collect::<Result<Vec<_>, _>>()?;
+        if topics.get(..2) != Some(&[topic, checkpoint]) {
+            return Err(invalid());
+        }
+        let hash = fixed::<32>(required(log, "transactionHash")?)?;
+        let block_hash = fixed::<32>(required(log, "blockHash")?)?;
+        let block_number = quantity(required(log, "blockNumber")?)?;
+        let tx_index = quantity(required(log, "transactionIndex")?)?;
+        let log_index = quantity(required(log, "logIndex")?)?;
+        let params = [Json::Text(hex(&hash))];
+        let tx = rpc("eth_getTransactionByHash", &params)?;
+        let receipt = rpc("eth_getTransactionReceipt", &params)?;
+        if fixed::<32>(required(&tx, "hash")?)? != hash
+            || fixed::<32>(required(&receipt, "transactionHash")?)? != hash
+            || quantity(required(&receipt, "status")?)? != 1
+        {
+            return Err(invalid());
+        }
+        for value in [&tx, &receipt] {
+            if fixed::<20>(required(value, "to")?)? != contract.bytes()
+                || fixed::<32>(required(value, "blockHash")?)? != block_hash
+                || quantity(required(value, "blockNumber")?)? != block_number
+                || quantity(required(value, "transactionIndex")?)? != tx_index
+            {
+                return Err(invalid());
+            }
+        }
+        let Json::Array(receipt_logs) = required(&receipt, "logs")? else {
+            return Err(invalid());
+        };
+        let matching = receipt_logs
+            .iter()
+            .filter(|item| {
+                item.member("logIndex").and_then(|v| quantity(v).ok()) == Some(log_index)
+            })
+            .collect::<Vec<_>>();
+        if matching.len() != 1 {
+            return Err(invalid());
+        }
+        for field in [
+            "address",
+            "topics",
+            "data",
+            "blockHash",
+            "blockNumber",
+            "transactionHash",
+            "transactionIndex",
+            "logIndex",
+            "removed",
+        ] {
+            if required(matching[0], field)? != required(log, field)? {
+                return Err(invalid());
+            }
+        }
+        confirm_block(endpoint, log, confirmations)?;
+        Ok(Publication {
+            input: bytes(required(&tx, "input")?)?,
+            topics,
+            data: bytes(required(log, "data")?)?,
+            sender: fixed(required(&tx, "from")?)?,
+        })
+    };
+    run().map_err(|fault| failure(endpoint, fault))
+}
+
+fn confirm_block(
+    endpoint: &EndpointConfig,
+    log: &Json,
+    confirmations: u64,
+) -> Result<(), EndpointFault> {
+    let rpc = |method, params: &[Json]| raw_call(endpoint, method, params).map_err(|e| e.fault);
+    let hash = fixed::<32>(required(log, "transactionHash")?)?;
+    let block_hash = fixed::<32>(required(log, "blockHash")?)?;
+    let block_number = quantity(required(log, "blockNumber")?)?;
+    let tx_index = quantity(required(log, "transactionIndex")?)?;
+    let head = rpc(
+        "eth_getBlockByNumber",
+        &[Json::Text("latest".into()), Json::Bool(false)],
+    )?;
+    let head_number = quantity(required(&head, "number")?)?;
+    if head_number
+        .checked_sub(block_number)
+        .and_then(|n| n.checked_add(1))
+        .is_none_or(|n| n < confirmations)
+    {
+        return Err(invalid());
+    }
+    let block = rpc(
+        "eth_getBlockByNumber",
+        &[Json::Text(format!("0x{block_number:x}")), Json::Bool(false)],
+    )?;
+    if quantity(required(&block, "number")?)? != block_number
+        || fixed::<32>(required(&block, "hash")?)? != block_hash
+    {
+        return Err(invalid());
+    }
+    let Json::Array(transactions) = required(&block, "transactions")? else {
+        return Err(invalid());
+    };
+    if fixed::<32>(
+        transactions
+            .get(usize::try_from(tx_index).map_err(|_| invalid())?)
+            .ok_or_else(invalid)?,
+    )? != hash
+    {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
+pub(crate) fn digest(value: &[u8]) -> [u8; 32] {
+    Sha256::digest(value).into()
+}
+
+pub(crate) struct Registered {
+    pub state_root: [u8; 32],
+    pub epoch: u64,
+    pub batch: u64,
+    pub da: [u8; 32],
+    pub sender: [u8; 20],
+}
+pub(crate) fn registered(
+    endpoint: &EndpointConfig,
+    registry: EvmAddress,
+    checkpoint: [u8; 32],
+    confirmations: u64,
+) -> Result<Registered, EndpointFailure> {
+    let value = publication(
+        endpoint,
+        registry,
+        REGISTERED_TOPIC,
+        checkpoint,
+        confirmations,
+    )?;
+    let run = || {
+        if value.topics.len() != 4 || value.data.len() != 192 {
+            return Err(invalid());
+        }
+        Ok(Registered {
+            state_root: value.data[96..128].try_into().map_err(|_| invalid())?,
+            epoch: u64::try_from(word_number(&value.topics[2])?).map_err(|_| invalid())?,
+            batch: u64::try_from(word_number(&value.topics[3])?).map_err(|_| invalid())?,
+            da: value.data[128..160].try_into().map_err(|_| invalid())?,
+            sender: value.sender,
+        })
+    };
+    run().map_err(|e| failure(endpoint, e))
+}
+pub(crate) fn witnesses(
+    endpoint: &EndpointConfig,
+    registry: EvmAddress,
+    checkpoint: [u8; 32],
+    confirmations: u64,
+) -> Result<(Vec<u8>, Vec<u8>, Registered), EndpointFailure> {
+    let registered = registered(endpoint, registry, checkpoint, confirmations)?;
+    let published = publication(
+        endpoint,
+        registry,
+        WITNESSES_TOPIC,
+        checkpoint,
+        confirmations,
+    )?;
+    let run = || {
+        if published.sender != registered.sender
+            || published.topics.len() != 2
+            || published.data.len() != 64
+            || published.data[..32] != word(1)?
+            || !published.input.starts_with(&WITNESSES_SELECTOR)
+        {
+            return Err(invalid());
+        }
+        let args = &published.input[4..];
+        if args.get(..32) != Some(&checkpoint) {
+            return Err(invalid());
+        }
+        let withdrawals = split_dynamic(args, 3, 1)?;
+        let balances = split_dynamic(args, 3, 2)?;
+        let tails = [dynamic(withdrawals)?, dynamic(balances)?];
+        if abi(&[checkpoint], &tails)? != args
+            || digest(&abi(&[checkpoint, word(1)?], &tails)?) != published.data[32..]
+        {
+            return Err(invalid());
+        }
+        Ok((withdrawals.to_vec(), balances.to_vec(), registered))
+    };
+    run().map_err(|e| failure(endpoint, e))
+}
+pub(crate) fn bind(
+    proof: &CheckpointProof,
+    checkpoint: [u8; 32],
+    registered: &Registered,
+) -> Result<(), EndpointFault> {
+    if proof.checkpoint_hash != checkpoint
+        || proof.state_root != registered.state_root
+        || proof.epoch != registered.epoch
+        || proof.batch_number != registered.batch
+        || proof.data_availability_root != registered.da
+    {
+        return Err(invalid());
+    }
+    Ok(())
+}
+pub(crate) fn vector(tag: &[u8], items: &[Vec<u8>]) -> Result<Vec<u8>, EndpointFault> {
+    if items.len() > MAX_ITEMS {
+        return Err(invalid());
+    }
+    let mut out = tag.to_vec();
+    out.extend_from_slice(
+        &u32::try_from(items.len())
+            .map_err(|_| invalid())?
+            .to_be_bytes(),
+    );
+    for item in items {
+        out.extend_from_slice(
+            &u32::try_from(item.len())
+                .map_err(|_| invalid())?
+                .to_be_bytes(),
+        );
+        out.extend_from_slice(item);
+        if out.len() > LIMIT {
+            return Err(invalid());
+        }
+    }
+    Ok(out)
+}
+pub(crate) fn items<'a>(tag: &[u8], bytes: &'a [u8]) -> Result<Vec<&'a [u8]>, EndpointFault> {
+    if bytes.len() > LIMIT {
+        return Err(invalid());
+    }
+    let mut r = Reader(bytes.strip_prefix(tag).ok_or_else(invalid)?);
+    let count = r.number()?;
+    if count > MAX_ITEMS {
+        return Err(invalid());
+    }
+    let mut out = Vec::new();
+    for _ in 0..count {
+        let len = r.number()?;
+        out.push(r.take(len)?);
+    }
+    r.finish()?;
+    Ok(out)
+}
+pub(crate) struct Reader<'a>(pub &'a [u8]);
+impl<'a> Reader<'a> {
+    pub fn take(&mut self, len: usize) -> Result<&'a [u8], EndpointFault> {
+        let out = self.0.get(..len).ok_or_else(invalid)?;
+        self.0 = &self.0[len..];
+        Ok(out)
+    }
+    pub fn array<const N: usize>(&mut self) -> Result<[u8; N], EndpointFault> {
+        self.take(N)?.try_into().map_err(|_| invalid())
+    }
+    pub fn number(&mut self) -> Result<usize, EndpointFault> {
+        usize::try_from(u32::from_be_bytes(self.array()?)).map_err(|_| invalid())
+    }
+    pub fn finish(self) -> Result<(), EndpointFault> {
+        if self.0.is_empty() {
+            Ok(())
+        } else {
+            Err(invalid())
+        }
+    }
+}
+pub(crate) const WITNESSES_SELECTOR: [u8; 4] = [0x69, 0x92, 0x97, 0x38];
+pub(crate) const DEPOSIT_SELECTOR: [u8; 4] = [0x8f, 0xf1, 0xfa, 0xc9];
+pub(crate) const WITNESSES_TOPIC: [u8; 32] = [
+    0x8e, 0x3f, 0xa1, 0x7f, 0xc3, 0x5, 0x84, 0x80, 0x5c, 0xf0, 0x62, 0x3e, 0xf3, 0xf, 0xbf, 0x1,
+    0xef, 0x3, 0x7, 0x71, 0x6a, 0x79, 0x9, 0xcf, 0xd3, 0x7c, 0x6f, 0xef, 0xb4, 0x76, 0xb9, 0x80,
+];
+pub(crate) const DEPOSIT_TOPIC: [u8; 32] = [
+    0xdc, 0x7b, 0x7d, 0xbc, 0xfc, 0x1d, 0xc6, 0x57, 0xc, 0x57, 0xd3, 0xd6, 0x41, 0x3b, 0x4a, 0x7f,
+    0xd3, 0xc1, 0xaa, 0x6, 0x8b, 0x1a, 0x8a, 0x45, 0x91, 0xd, 0x76, 0xe6, 0x5a, 0x35, 0xb0, 0xbc,
+];
+pub(crate) const REGISTERED_TOPIC: [u8; 32] = [
+    0x9, 0x4d, 0x6, 0x13, 0x2b, 0xe9, 0xf, 0x15, 0x44, 0xeb, 0xa6, 0x3f, 0xf4, 0xd5, 0xf, 0xf3,
+    0x21, 0x69, 0x50, 0xfc, 0xa4, 0x91, 0x2b, 0x3d, 0x46, 0x9d, 0x48, 0x2f, 0xbf, 0x88, 0x26, 0x1c,
+];

--- a/human/crates/layerx-paxeer-client/src/exit.rs
+++ b/human/crates/layerx-paxeer-client/src/exit.rs
@@ -881,3 +881,136 @@ fn word_quantity(word: &[u8; 32], what: &str) -> Result<u64, ExitError> {
         .skip(24)
         .fold(0_u64, |quantity, byte| (quantity << 8) | u64::from(*byte)))
 }
+
+impl ExitEvidence {
+    /// Encodes balance facts with the existing canonical checkpoint proof encoding.
+    /// Entries must be strictly ordered by account, asset and recipient.
+    ///
+    /// # Errors
+    /// Refuses mismatched fields, paths, roots, ordering or canonical proof bytes.
+    pub fn encode_publication(
+        entries: &[(Self, crate::CheckpointProof)],
+        protocol_version: u16,
+    ) -> Result<Vec<u8>, crate::EndpointFault> {
+        use crate::deposit::evidence as e;
+        let mut items = Vec::new();
+        let mut previous = None;
+        for (balance, proof) in entries {
+            validate_fields(balance).map_err(|_| e::invalid())?;
+            let key = (balance.account, balance.asset_id, balance.recipient.bytes());
+            if previous.is_some_and(|value| value >= key) {
+                return Err(e::invalid());
+            }
+            previous = Some(key);
+            if balance.leaf_index != proof.leaf_index
+                || balance.siblings != proof.siblings
+                || balance.attestations
+                    != proof
+                        .attestations
+                        .iter()
+                        .map(publication_attestation)
+                        .collect::<Vec<_>>()
+            {
+                return Err(e::invalid());
+            }
+            verify_balance_proof(balance, proof.state_root).map_err(|_| e::invalid())?;
+            let mut item = balance.account.to_vec();
+            item.extend_from_slice(&balance.asset_id);
+            item.extend_from_slice(&balance.finalised_balance.to_be_bytes());
+            item.extend_from_slice(&balance.recipient.bytes());
+            item.extend_from_slice(
+                &crate::wire::encode_checkpoint_proof_for_protocol(
+                    proof,
+                    e::LIMIT,
+                    protocol_version,
+                )
+                .map_err(|_| e::invalid())?,
+            );
+            items.push(item);
+        }
+        e::vector(e::BALANCES, &items)
+    }
+
+    /// Fetches pre-settlement balance evidence; `EmergencyExit::construct_claim`
+    /// still decides eligibility, certificate standing and payout authorization.
+    ///
+    /// # Errors
+    /// Refuses malformed or displaced publication, mismatched roots and absent account facts.
+    pub fn fetch_published(
+        endpoint: &EndpointConfig,
+        registry: EvmAddress,
+        checkpoint: [u8; 32],
+        expected: ([u8; 32], [u8; 32], EvmAddress),
+        protocol_version: u16,
+        confirmations: u64,
+    ) -> Result<Self, crate::EndpointFailure> {
+        use crate::deposit::evidence as e;
+        let (_, balances, registered) =
+            e::witnesses(endpoint, registry, checkpoint, confirmations)?;
+        let decode = || {
+            let mut previous = None;
+            let mut found = None;
+            for item in e::items(e::BALANCES, &balances)? {
+                let mut r = e::Reader(item);
+                let found_account = r.array()?;
+                let found_asset = r.array()?;
+                let balance = u128::from_be_bytes(r.array()?);
+                let found_recipient = EvmAddress::new(r.array()?);
+                let key = (found_account, found_asset, found_recipient.bytes());
+                if previous.is_some_and(|value| value >= key) {
+                    return Err(e::invalid());
+                }
+                previous = Some(key);
+                let proof = crate::wire::decode_checkpoint_proof_for_protocol(
+                    r.0,
+                    e::LIMIT,
+                    protocol_version,
+                )
+                .map_err(|_| e::invalid())?;
+                e::bind(&proof, checkpoint, &registered)?;
+                let evidence = Self {
+                    account: found_account,
+                    asset_id: found_asset,
+                    finalised_balance: balance,
+                    recipient: found_recipient,
+                    leaf_index: proof.leaf_index,
+                    siblings: proof.siblings,
+                    attestations: proof
+                        .attestations
+                        .iter()
+                        .map(publication_attestation)
+                        .collect(),
+                };
+                validate_fields(&evidence).map_err(|_| e::invalid())?;
+                verify_balance_proof(&evidence, registered.state_root).map_err(|_| e::invalid())?;
+                if key == (expected.0, expected.1, expected.2.bytes()) {
+                    found = Some(evidence);
+                }
+            }
+            found.ok_or_else(e::invalid)
+        };
+        decode().map_err(|fault| e::failure(endpoint, fault))
+    }
+}
+fn publication_attestation(value: &crate::WithdrawalAttestation) -> GuarantorAttestation {
+    GuarantorAttestation {
+        protocol_version: value.protocol_version,
+        network_id: value.network_id,
+        paxeer_chain_id: value.paxeer_chain_id,
+        settlement_contract: value.settlement_contract,
+        epoch: value.epoch,
+        checkpoint_id: value.checkpoint_id,
+        checkpoint_hash: value.checkpoint_hash,
+        guarantor_id: value.guarantor_id,
+        batch_number: value.batch_number,
+        data_availability_root: value.data_availability_root,
+        replayed: value.replayed,
+        data_available: value.data_available,
+        availability_class_mask: value.availability_class_mask,
+        attested_at: value.attested_at,
+        signer: value.signer,
+        signature_r: value.signature_r,
+        signature_s: value.signature_s,
+        signature_v: value.signature_v,
+    }
+}

--- a/human/crates/layerx-paxeer-client/src/withdraw.rs
+++ b/human/crates/layerx-paxeer-client/src/withdraw.rs
@@ -2194,3 +2194,91 @@ fn word_u128(word: &[u8; 32], what: &str) -> Result<u128, WithdrawalError> {
     bytes.copy_from_slice(&word[16..]);
     Ok(u128::from_be_bytes(bytes))
 }
+
+impl CheckpointProof {
+    /// Encodes a bounded vector of withdrawal identities, leaf hashes and canonical proofs.
+    /// Entries must be strictly ordered by withdrawal identity.
+    ///
+    /// # Errors
+    /// Refuses noncanonical proofs, ordering, bounds or roots.
+    pub fn encode_publication(
+        entries: &[(DebitExpectation, Self)],
+        protocol_version: u16,
+    ) -> Result<Vec<u8>, crate::EndpointFault> {
+        use crate::deposit::evidence as e;
+        let mut items = Vec::new();
+        let mut previous = None;
+        for (debit, proof) in entries {
+            debit.validated().map_err(|_| e::invalid())?;
+            if previous.is_some_and(|id| id >= debit.withdrawal_id) {
+                return Err(e::invalid());
+            }
+            previous = Some(debit.withdrawal_id);
+            let leaf = withdrawal_leaf(debit);
+            if proof_root(leaf, proof.leaf_index, &proof.siblings) != proof.state_root {
+                return Err(e::invalid());
+            }
+            let mut item = debit.withdrawal_id.to_vec();
+            item.extend_from_slice(&leaf);
+            item.extend_from_slice(
+                &crate::wire::encode_checkpoint_proof_for_protocol(
+                    proof,
+                    e::LIMIT,
+                    protocol_version,
+                )
+                .map_err(|_| e::invalid())?,
+            );
+            items.push(item);
+        }
+        e::vector(e::WITHDRAWALS, &items)
+    }
+
+    /// Retrieves canonical withdrawal membership for an already verified debit.
+    /// The returned proof must still pass `WithdrawalBoundary::construct_claim`.
+    ///
+    /// # Errors
+    /// Refuses unavailable publication, noncanonical encoding and identity/root mismatches.
+    pub fn fetch_published(
+        endpoint: &EndpointConfig,
+        registry: EvmAddress,
+        checkpoint: [u8; 32],
+        debit: &DebitExpectation,
+        protocol_version: u16,
+        confirmations: u64,
+    ) -> Result<Self, crate::EndpointFailure> {
+        use crate::deposit::evidence as e;
+        let (withdrawals, _, registered) =
+            e::witnesses(endpoint, registry, checkpoint, confirmations)?;
+        let decode = || {
+            let mut previous = None;
+            let mut found = None;
+            for item in e::items(e::WITHDRAWALS, &withdrawals)? {
+                let mut r = e::Reader(item);
+                let id = r.array::<32>()?;
+                let leaf = r.array::<32>()?;
+                if previous.is_some_and(|value| value >= id) {
+                    return Err(e::invalid());
+                }
+                previous = Some(id);
+                let proof = crate::wire::decode_checkpoint_proof_for_protocol(
+                    r.0,
+                    e::LIMIT,
+                    protocol_version,
+                )
+                .map_err(|_| e::invalid())?;
+                e::bind(&proof, checkpoint, &registered)?;
+                if proof_root(leaf, proof.leaf_index, &proof.siblings) != proof.state_root {
+                    return Err(e::invalid());
+                }
+                if id == debit.withdrawal_id {
+                    if leaf != withdrawal_leaf(debit) {
+                        return Err(e::invalid());
+                    }
+                    found = Some(proof);
+                }
+            }
+            found.ok_or_else(e::invalid)
+        };
+        decode().map_err(|fault| e::failure(endpoint, fault))
+    }
+}

--- a/human/crates/layerx-paxeer-client/tests/withdraw.rs
+++ b/human/crates/layerx-paxeer-client/tests/withdraw.rs
@@ -1322,3 +1322,454 @@ fn real_pending_challenge_reports_timing_and_upheld_challenge_cancels_without_pa
         VAULT_BALANCE
     );
 }
+
+fn publication_calldata(selector: [u8; 4], heads: &[[u8; 32]], tails: &[Vec<u8>]) -> Vec<u8> {
+    let mut words = heads.to_vec();
+    let mut offset = (heads.len() + tails.len()) * 32;
+    for tail in tails {
+        words.push(usize_word(offset));
+        offset += tail.len();
+    }
+    let mut data = call_data(selector, &words);
+    for tail in tails {
+        data.extend_from_slice(tail);
+    }
+    data
+}
+fn publication_bytes(bytes: &[u8]) -> Vec<u8> {
+    let mut out = usize_word(bytes.len()).to_vec();
+    out.extend_from_slice(bytes);
+    out.resize(out.len().div_ceil(32) * 32, 0);
+    out
+}
+fn exit_attestation(v: &WithdrawalAttestation) -> layerx_paxeer_client::GuarantorAttestation {
+    layerx_paxeer_client::GuarantorAttestation {
+        protocol_version: v.protocol_version,
+        network_id: v.network_id,
+        paxeer_chain_id: v.paxeer_chain_id,
+        settlement_contract: v.settlement_contract,
+        epoch: v.epoch,
+        checkpoint_id: v.checkpoint_id,
+        checkpoint_hash: v.checkpoint_hash,
+        guarantor_id: v.guarantor_id,
+        batch_number: v.batch_number,
+        data_availability_root: v.data_availability_root,
+        replayed: v.replayed,
+        data_available: v.data_available,
+        availability_class_mask: v.availability_class_mask,
+        attested_at: v.attested_at,
+        signer: v.signer,
+        signature_r: v.signature_r,
+        signature_s: v.signature_s,
+        signature_v: v.signature_v,
+    }
+}
+
+struct PublicationFixture {
+    anvil: Anvil,
+    vault: EvmAddress,
+    registry: EvmAddress,
+    challenge: EvmAddress,
+    claims: EvmAddress,
+    debit: DebitExpectation,
+    withdrawal: [u8; 32],
+    proof: CheckpointProof,
+    evidence: layerx_paxeer_client::ExitEvidence,
+    withdrawals: Vec<u8>,
+    balances: Vec<u8>,
+}
+fn publication_fixture() -> PublicationFixture {
+    use layerx_paxeer_client::ExitEvidence;
+    let anvil = Anvil::launch();
+    let (_, vault, bond, registry, challenge, claims) = deploy_suite_for_protocol(&anvil, 3);
+    let debit = debit_expectation(parse_address(RECIPIENT));
+    let withdrawal = withdrawal_leaf(debit);
+    let balance =
+        layerx_paxeer_client::balance_leaf(&debit.account, &ASSET, AMOUNT, debit.recipient);
+    let state_root = layerx_paxeer_client::merkle_node(&withdrawal, &balance);
+    let mut header = checkpoint_header(state_root, anvil.latest_timestamp() * 1000);
+    header.protocol_version = 3;
+    let checkpoint = checkpoint_hash(&header);
+    let attestation = signed_attestation(&header, checkpoint, bond);
+    anvil.send_checked(
+        FUNDED,
+        registry,
+        &register_checkpoint_calldata(&header, &attestation),
+        0,
+    );
+    let proof = CheckpointProof {
+        checkpoint_hash: checkpoint,
+        state_root,
+        epoch: 1,
+        batch_number: 1,
+        data_availability_root: header.data_availability_root,
+        leaf_index: 0,
+        siblings: vec![balance],
+        attestations: vec![attestation],
+    };
+    let balance_proof = CheckpointProof {
+        leaf_index: 1,
+        siblings: vec![withdrawal],
+        ..proof.clone()
+    };
+    let evidence = ExitEvidence {
+        account: debit.account,
+        asset_id: ASSET,
+        finalised_balance: AMOUNT,
+        recipient: debit.recipient,
+        leaf_index: 1,
+        siblings: vec![withdrawal],
+        attestations: vec![exit_attestation(&attestation)],
+    };
+    let withdrawals = CheckpointProof::encode_publication(&[(debit, proof.clone())], 3)
+        .unwrap_or_else(|e| panic!("withdrawals: {e:?}"));
+    let balances = ExitEvidence::encode_publication(&[(evidence.clone(), balance_proof)], 3)
+        .unwrap_or_else(|e| panic!("balances: {e:?}"));
+    PublicationFixture {
+        anvil,
+        vault,
+        registry,
+        challenge,
+        claims,
+        debit,
+        withdrawal,
+        proof,
+        evidence,
+        withdrawals,
+        balances,
+    }
+}
+
+fn verify_published_exit(
+    anvil: &Anvil,
+    registry: EvmAddress,
+    challenge: EvmAddress,
+    vault: EvmAddress,
+    fetched: layerx_paxeer_client::ExitEvidence,
+) {
+    use layerx_paxeer_client::{EmergencyExit, ExitConfig};
+    let nullifiers = anvil.deploy(
+        "WithdrawalNullifierRegistry",
+        &[
+            address_word(parse_address(FUNDED)),
+            address_word(parse_address(CHALLENGER)),
+            [0x71; 32],
+            quantity_const(1),
+        ],
+    );
+    let exit = anvil.deploy(
+        "EmergencyExit",
+        &[
+            address_word(registry),
+            address_word(challenge),
+            address_word(nullifiers),
+            address_word(vault),
+            address_word(parse_address(FUNDED)),
+            address_word(parse_address(CHALLENGER)),
+            quantity_word(&3600_u64.to_be_bytes()),
+            [0x72; 32],
+            quantity_const(1),
+        ],
+    );
+    let exit = EmergencyExit::new(ExitConfig {
+        endpoints: vec![anvil.endpoint.clone()],
+        minimum_endpoint_agreement: 1,
+        exit_contract: exit,
+        required_confirmations: 1,
+        poll_cadence: Duration::from_millis(20),
+        delayed_after_polls: 100,
+    })
+    .unwrap_or_else(|e| panic!("exit: {e:?}"));
+    anvil.advance(3601);
+    assert!(exit.construct_claim(&fetched).is_ok());
+    let mut wrong = fetched;
+    wrong.finalised_balance += 1;
+    assert!(exit.construct_claim(&wrong).is_err());
+}
+
+#[test]
+fn real_published_checkpoint_withdrawal_and_balance_witnesses() {
+    use layerx_paxeer_client::ExitEvidence;
+    let PublicationFixture {
+        anvil,
+        vault,
+        registry,
+        challenge,
+        claims,
+        debit,
+        withdrawal,
+        proof,
+        evidence,
+        withdrawals,
+        balances,
+    } = publication_fixture();
+    let checkpoint = proof.checkpoint_hash;
+    assert!(
+        CheckpointProof::fetch_published(&anvil.endpoint, registry, checkpoint, &debit, 3, 1)
+            .is_err()
+    );
+    let snapshot = anvil.call("evm_snapshot", &[]);
+    anvil.send_checked(
+        FUNDED,
+        registry,
+        &publication_calldata(
+            [0x69, 0x92, 0x97, 0x38],
+            &[checkpoint],
+            &[
+                publication_bytes(&withdrawals),
+                publication_bytes(&balances),
+            ],
+        ),
+        0,
+    );
+    assert!(
+        CheckpointProof::fetch_published(&anvil.endpoint, registry, checkpoint, &debit, 3, 2)
+            .is_err()
+    );
+    anvil.mine();
+    let fetched =
+        CheckpointProof::fetch_published(&anvil.endpoint, registry, checkpoint, &debit, 3, 2)
+            .unwrap_or_else(|e| panic!("published withdrawal: {e:?}"));
+    assert_eq!(fetched, proof);
+    let boundary = WithdrawalBoundary::new_for_protocol(
+        WithdrawalConfig {
+            endpoints: vec![anvil.endpoint.clone()],
+            minimum_endpoint_agreement: 1,
+            claims_contract: claims,
+            required_confirmations: 1,
+            poll_cadence: Duration::from_millis(20),
+            delayed_after_polls: 100,
+        },
+        3,
+    )
+    .unwrap_or_else(|e| panic!("boundary: {e:?}"));
+    let claim = boundary
+        .construct_claim(committed_debit_for_protocol(debit, 3), fetched)
+        .unwrap_or_else(|e| panic!("claim: {e:?}"));
+    assert_eq!(claim.leaf(), withdrawal);
+    let fetched = ExitEvidence::fetch_published(
+        &anvil.endpoint,
+        registry,
+        checkpoint,
+        (debit.account, ASSET, debit.recipient),
+        3,
+        2,
+    )
+    .unwrap_or_else(|e| panic!("published balance: {e:?}"));
+    assert_eq!(fetched, evidence);
+    verify_published_exit(&anvil, registry, challenge, vault, fetched);
+    assert_eq!(anvil.call("evm_revert", &[snapshot]), Json::Bool(true));
+    assert!(
+        CheckpointProof::fetch_published(&anvil.endpoint, registry, checkpoint, &debit, 3, 1)
+            .is_err()
+    );
+    let mut corrupt = withdrawals;
+    let last = corrupt.len() - 1;
+    corrupt[last] ^= 1;
+    anvil.send_checked(
+        FUNDED,
+        registry,
+        &publication_calldata(
+            [0x69, 0x92, 0x97, 0x38],
+            &[checkpoint],
+            &[publication_bytes(&corrupt), publication_bytes(&balances)],
+        ),
+        0,
+    );
+    let fetched =
+        CheckpointProof::fetch_published(&anvil.endpoint, registry, checkpoint, &debit, 3, 1);
+    if let Ok(fetched) = fetched {
+        assert!(boundary
+            .construct_claim(committed_debit_for_protocol(debit, 3), fetched)
+            .is_err());
+    }
+}
+
+fn published_custody(
+    anvil: &Anvil,
+    vault: EvmAddress,
+) -> (layerx_paxeer_client::CustodyDeposit, TransactionHash) {
+    use layerx_paxeer_client::CustodyDeposit;
+    use layerx_types::{amount::Amount, ids::AssetId};
+    let logs = anvil.call(
+        "eth_getLogs",
+        &[Json::Object(vec![
+            text_member("address", &address_hex(vault)),
+            text_member("fromBlock", "0x0"),
+            (
+                "topics".into(),
+                Json::Array(vec![Json::Text(
+                    "0x7edb71c9100c656847896d0b5b194f69f7da287eb57964a81e7f807a6a944028".into(),
+                )]),
+            ),
+        ])],
+    );
+    let Json::Array(logs) = logs else {
+        panic!("custody logs");
+    };
+    assert_eq!(logs.len(), 1);
+    let log = &logs[0];
+    let Json::Array(topics) = log.member("topics").unwrap_or_else(|| panic!("topics")) else {
+        panic!("topics");
+    };
+    let id: [u8; 32] = hex_bytes(topics[1].as_text().unwrap_or_else(|| panic!("id")))
+        .try_into()
+        .unwrap_or_else(|_| panic!("id length"));
+    let transaction = TransactionHash::from_hex(
+        log.member("transactionHash")
+            .and_then(Json::as_text)
+            .unwrap_or_else(|| panic!("tx hash")),
+    )
+    .unwrap_or_else(|e| panic!("tx: {e:?}"));
+    let custody = CustodyDeposit {
+        deposit_id: id,
+        asset: AssetId::new(ASSET),
+        payer: parse_address(FUNDED),
+        beneficiary: [0x28; 32],
+        amount: Amount::from_u128(VAULT_BALANCE),
+        nonce: 1,
+    };
+    (custody, transaction)
+}
+
+fn publish_signed_deposit(
+    anvil: &Anvil,
+    vault: EvmAddress,
+    checkpoint: [u8; 32],
+    state_root: [u8; 32],
+    custody: layerx_paxeer_client::CustodyDeposit,
+) -> (layerx_paxeer_client::DepositRootRegistration, SigningKey) {
+    use layerx_paxeer_client::{
+        deposit_leaf_bytes, deposit_root_registration_message, DepositRootRegistration,
+    };
+    let custody_reference = [0x74; 32];
+    let leaf = layerx_proof::merkle::leaf_hash(
+        &deposit_leaf_bytes(
+            custody.deposit_id,
+            custody_reference,
+            custody.asset,
+            custody.amount,
+            checkpoint,
+            NETWORK_ID,
+            3,
+        )
+        .unwrap_or_else(|e| panic!("leaf bytes: {e:?}")),
+    )
+    .unwrap_or_else(|e| panic!("leaf: {e:?}"));
+    let authority = SigningKey::from_bytes(&[0x75; 32]);
+    let mut registration = DepositRootRegistration {
+        checkpoint_id: checkpoint,
+        checkpoint_state_root: state_root,
+        deposit_root: leaf,
+        custody_reference,
+        network_id: NETWORK_ID,
+        protocol_version: 3,
+        signature: [0; 64],
+    };
+    let canonical = deposit_root_registration_message(&registration)
+        .unwrap_or_else(|e| panic!("registration: {e:?}"));
+    registration.signature = authority.sign(&canonical).to_bytes();
+    let mut ordering = quantity_const(1).to_vec();
+    ordering.extend_from_slice(&leaf);
+    anvil.send_checked(
+        FUNDED,
+        vault,
+        &publication_calldata(
+            [0x8f, 0xf1, 0xfa, 0xc9],
+            &[],
+            &[
+                publication_bytes(&canonical),
+                publication_bytes(&registration.signature),
+                ordering,
+            ],
+        ),
+        0,
+    );
+    (registration, authority)
+}
+
+#[test]
+fn real_published_deposit_registration_verifies_existing_signature_and_custody_rules() {
+    use layerx_paxeer_client::{
+        DepositProofConfig, DepositProofVerifier, FinalityTracker, PublishedDepositProof,
+        TrackerConfig,
+    };
+    use layerx_types::amount::Amount;
+    let anvil = Anvil::launch();
+    let (_, vault, bond, registry, _, _) = deploy_suite_for_protocol(&anvil, 3);
+    let header = {
+        let mut h = checkpoint_header([0x73; 32], anvil.latest_timestamp() * 1000);
+        h.protocol_version = 3;
+        h
+    };
+    let checkpoint = checkpoint_hash(&header);
+    let attestation = signed_attestation(&header, checkpoint, bond);
+    anvil.send_checked(
+        FUNDED,
+        registry,
+        &register_checkpoint_calldata(&header, &attestation),
+        0,
+    );
+    let (custody, transaction) = published_custody(&anvil, vault);
+    let (registration, authority) = publish_signed_deposit(
+        &anvil,
+        vault,
+        checkpoint,
+        header.resulting_state_root,
+        custody,
+    );
+    let custody_reference = registration.custody_reference;
+    let leaf = registration.deposit_root;
+    let fetched = PublishedDepositProof::fetch_published(
+        &anvil.endpoint,
+        vault,
+        registry,
+        checkpoint,
+        custody,
+        1,
+    )
+    .unwrap_or_else(|e| panic!("fetch deposit: {e:?}"));
+    assert_eq!(fetched.registration, registration);
+    let verifier = DepositProofVerifier::new(DepositProofConfig {
+        endpoints: vec![anvil.endpoint.clone()],
+        minimum_endpoint_agreement: 1,
+        required_confirmations: 1,
+        paxeer_chain_id: 31337,
+        paxeer_checkpoint_authority: authority.verifying_key().to_bytes(),
+        custody_reference,
+        layerx_network_id: NETWORK_ID,
+        layerx_protocol_version: 3,
+    })
+    .unwrap_or_else(|e| panic!("verifier: {e:?}"));
+    let mut tracker = FinalityTracker::new(
+        TrackerConfig {
+            endpoints: vec![anvil.endpoint.clone()],
+            minimum_endpoint_agreement: 1,
+            required_confirmations: 1,
+            poll_cadence: Duration::from_millis(20),
+            delayed_after_polls: 100,
+        },
+        transaction,
+    )
+    .unwrap_or_else(|e| panic!("tracker: {e:?}"));
+    let report = tracker.poll();
+    assert!(matches!(report.stage(), FinalityStage::Final { .. }));
+    let proof = verifier
+        .obtain(&report, vault, fetched.clone())
+        .unwrap_or_else(|e| panic!("verified deposit: {e:?}"));
+    assert_eq!(proof.deposit_root(), leaf);
+    let mut tampered = fetched;
+    tampered.registration.signature[0] ^= 1;
+    assert!(verifier.obtain(&report, vault, tampered).is_err());
+    let mut wrong = custody;
+    wrong.amount = Amount::from_u128(VAULT_BALANCE + 1);
+    assert!(PublishedDepositProof::fetch_published(
+        &anvil.endpoint,
+        vault,
+        registry,
+        checkpoint,
+        wrong,
+        1
+    )
+    .is_err());
+}

--- a/platform/hosted/paxeer/deploy-contracts.sh
+++ b/platform/hosted/paxeer/deploy-contracts.sh
@@ -410,6 +410,10 @@ phase_finalize() {
     run_script "finalize((address,address,address,address,address,address,address,address,address,address,address,address,address,address),(string,address,address,address,address,uint64,uint64,uint256,uint128,uint128,uint64,uint64,uint32,uint64,uint16,uint16,uint64,uint64,uint128,uint64,uint64,uint64,uint64,uint256,uint256),(bytes32,address,address,uint64,uint64,uint256)[],uint256)" \
         "$(addresses_tuple)" "$INPUT_TUPLE" "$GUARANTOR_TUPLES" "$(jq -r '.timelock.genesis_start_nonce' "$RECORD")"
     [ "$(call "$(jq -r '.blueprint' "$RECORD")" "deploymentsSealed()(bool)")" = "true" ] || fail "blueprint is not sealed"
+    for component in checkpoint_registry vault; do
+        [ "$(call "$(jq -r ".addresses.$component" "$RECORD")" 'EVIDENCE_VERSION()(uint16)')" = 1 ] \
+            || fail "$component evidence publication version mismatch"
+    done
     jq '.phases += ["finalize"]' "$RECORD" > "$WORK/record.json" && mv "$WORK/record.json" "$RECORD"
     echo "deploy-contracts: deployment finalized and sealed" >&2
 }

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4813,6 +4813,12 @@ file = "human/Cargo.lock platform/Cargo.lock"
 symbol = "ureq native-tls connector dependency"
 observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
 assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
+[observation.6.6.10]
+task = "6.6"
+file = "human/crates/layerx-paxeer-client/tests/disposable_custody.py; tests/bridge/deploy_local_custody.py"
+symbol = "real_disposable_custody_over_verified_tls; PERSISTENT_CHAIN_ID"
+observed = "cargo test --locked --manifest-path human/Cargo.toml -p layerx-paxeer-client exits 101 because disposable_custody.py imports PERSISTENT_CHAIN_ID from deploy_local_custody.py, which does not export that symbol. The failure occurs before the disposable Paxeer chain or native builder is invoked. The existing test and bridge helper are unchanged by the settlement evidence publication implementation. Exact output is retained in qual-logs/ct1/cargo-test.log."
+assumption = "Reconcile the persistent Comet-chain identity interface between the existing test and bridge helper while preserving all persistent-chain, genesis and blueprint refusal checks, then rerun the complete client suite."
 severity = "blocker"
 
 [observation.6.4.174]

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4813,6 +4813,8 @@ file = "human/Cargo.lock platform/Cargo.lock"
 symbol = "ureq native-tls connector dependency"
 observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
 assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
+severity = "blocker"
+
 [observation.6.6.10]
 task = "6.6"
 file = "human/crates/layerx-paxeer-client/tests/disposable_custody.py; tests/bridge/deploy_local_custody.py"

--- a/test/CheckpointRegistry.t.sol
+++ b/test/CheckpointRegistry.t.sol
@@ -7,6 +7,13 @@ import {GuarantorBond} from "../contracts/GuarantorBond.sol";
 import {Constants} from "../contracts/libraries/Constants.sol";
 
 interface CheckpointVm {
+    struct Log {
+        bytes32[] topics;
+        bytes data;
+        address emitter;
+    }
+    function recordLogs() external;
+    function getRecordedLogs() external returns (Log[] memory);
     function addr(uint256 privateKey) external returns (address);
     function deal(address account, uint256 balance) external;
     function prank(address sender) external;
@@ -776,6 +783,45 @@ contract CheckpointRegistryTest {
         require(
             registry.canonicalHeader(first).length == registry.canonicalHeader(second).length, "count leaked into size"
         );
+    }
+
+    function testInvalidatedCheckpointCannotPublishWitnesses() public {
+        CanonicalCheckpoint.HeaderCommitments memory header = _header();
+        bytes32 checkpoint = registry.checkpointHash(header, "");
+        registry.registerCheckpoint(header, "", _attestations(header, checkpoint, 2));
+        bond.setSlashingAuthority(address(this));
+        registry.invalidateCheckpoint(checkpoint);
+        vm.expectRevert(CheckpointRegistry.InvalidHeader.selector);
+        registry.publishCheckpointWitnesses(checkpoint, hex"0102", hex"0304");
+    }
+
+    function testWitnessPublicationAuthorizationDigestEventAndDuplicate() public {
+        CanonicalCheckpoint.HeaderCommitments memory header = _header();
+        bytes32 checkpoint = registry.checkpointHash(header, "");
+        registry.registerCheckpoint(header, "", _attestations(header, checkpoint, 2));
+        require(registry.checkpointProposer(checkpoint) == address(this), "proposer not bound");
+        vm.prank(address(0x1234));
+        vm.expectRevert(CheckpointRegistry.CheckpointProposerOnly.selector);
+        registry.publishCheckpointWitnesses(checkpoint, hex"0102", hex"0304");
+        vm.expectRevert(CheckpointRegistry.CheckpointProposerOnly.selector);
+        registry.publishCheckpointWitnesses(bytes32(uint256(5)), hex"0102", hex"0304");
+        vm.expectRevert(CheckpointRegistry.InvalidWitnesses.selector);
+        registry.publishCheckpointWitnesses(checkpoint, "", hex"0304");
+        vm.recordLogs();
+        registry.publishCheckpointWitnesses(checkpoint, hex"0102", hex"0304");
+        CheckpointVm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 digest = sha256(abi.encode(checkpoint, uint16(1), hex"0102", hex"0304"));
+        require(registry.witnessesDigest(checkpoint) == digest, "digest binding");
+        require(digest != sha256(abi.encode(checkpoint, uint16(1), hex"0103", hex"0304")), "withdrawal binding");
+        require(digest != sha256(abi.encode(checkpoint, uint16(1), hex"0102", hex"0305")), "balance binding");
+        require(logs.length == 1 && logs[0].emitter == address(registry), "emitter");
+        require(logs[0].topics.length == 2 && logs[0].topics[1] == checkpoint, "indexed checkpoint");
+        require(
+            logs[0].topics[0] == keccak256("CheckpointWitnessesPublished(bytes32,uint16,bytes32)"), "event signature"
+        );
+        require(keccak256(logs[0].data) == keccak256(abi.encode(uint16(1), digest)), "event data");
+        vm.expectRevert(CheckpointRegistry.WitnessesAlreadyPublished.selector);
+        registry.publishCheckpointWitnesses(checkpoint, hex"0102", hex"0304");
     }
 
     function _header() private pure returns (CanonicalCheckpoint.HeaderCommitments memory header) {

--- a/test/ContractIntegration.t.sol
+++ b/test/ContractIntegration.t.sol
@@ -30,6 +30,13 @@ import {Governed} from "../contracts/security/Governed.sol";
 import {UUPSNotUpgradeable} from "../contracts/security/UUPSNotUpgradeable.sol";
 
 interface IntegrationVm {
+    struct Log {
+        bytes32[] topics;
+        bytes data;
+        address emitter;
+    }
+    function recordLogs() external;
+    function getRecordedLogs() external returns (Log[] memory);
     function addr(uint256 privateKey) external returns (address);
 
     function assume(bool condition) external;
@@ -734,6 +741,54 @@ contract ContractIntegrationTest {
         address recipient = address(0x51A5);
         isolated.sweepSlashed(recipient, 2 ether);
         require(token.balanceOf(recipient) == 2 ether && isolated.slashedBalance() == 0, "slash sweep not conserved");
+    }
+
+    function testDepositRootPublicationAuthorizationDigestEventAndDuplicate() public {
+        _prepareSettlement(1_000_000_000);
+        bytes32 stateRoot = keccak256("registration-state");
+        (bytes32 checkpoint,,) = _registerCheckpoint(stateRoot);
+        bytes32 root = keccak256("deposit-root");
+        bytes memory registration = abi.encodePacked(
+            "LX:PAXEER:DEPOSIT:ROOT:v1",
+            checkpoint,
+            stateRoot,
+            root,
+            keccak256("custody-reference"),
+            checkpointRegistry.networkId(),
+            checkpointRegistry.protocolVersion()
+        );
+        bytes memory signature = new bytes(64);
+        bytes32[] memory ordering = new bytes32[](1);
+        ordering[0] = root;
+        vm.prank(address(0x1234));
+        vm.expectPartialRevert(LayerXVault.DepositRootProposerOnly.selector);
+        vault.registerDepositRoot(registration, signature, ordering);
+        vm.expectPartialRevert(LayerXVault.InvalidDepositRoot.selector);
+        vault.registerDepositRoot(registration, new bytes(63), ordering);
+        vm.expectPartialRevert(LayerXVault.InvalidDepositRoot.selector);
+        vault.registerDepositRoot(registration, signature, new bytes32[](0));
+        vm.recordLogs();
+        vault.registerDepositRoot(registration, signature, ordering);
+        IntegrationVm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 digest = sha256(abi.encode(uint16(1), registration, signature, ordering));
+        require(vault.depositRegistrationDigest(checkpoint) == digest, "registration digest");
+        require(logs.length == 1 && logs[0].emitter == address(vault), "registration emitter");
+        require(
+            logs[0].topics.length == 3 && logs[0].topics[1] == checkpoint && logs[0].topics[2] == root,
+            "registration topics"
+        );
+        require(
+            logs[0].topics[0] == keccak256("DepositRootRegistered(bytes32,bytes32,bytes32,uint16)"),
+            "registration signature"
+        );
+        require(keccak256(logs[0].data) == keccak256(abi.encode(digest, uint16(1))), "registration data");
+        signature[0] = 0x01;
+        require(digest != sha256(abi.encode(uint16(1), registration, signature, ordering)), "signature binding");
+        signature[0] = 0x00;
+        ordering[0] = keccak256("another-leaf");
+        require(digest != sha256(abi.encode(uint16(1), registration, signature, ordering)), "ordering binding");
+        vm.expectPartialRevert(LayerXVault.DepositRootAlreadyRegistered.selector);
+        vault.registerDepositRoot(registration, signature, ordering);
     }
 
     function _prepareSettlement(uint256 custody) private {


### PR DESCRIPTION
CheckpointRegistry records the accepted checkpoint submitter and lets that submitter publish the canonical withdrawal-state and balance witness bytes once per checkpoint (`publishCheckpointWitnesses`, `CheckpointWitnessesPublished`). LayerXVault pins the canonical Ed25519 deposit-root registration message, signature and leaf ordering once per checkpoint (`registerDepositRoot`, `DepositRootRegistered`). `layerx-paxeer-client` gains producers that retrieve the publications with standard JSON-RPC only (`eth_getLogs`, `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getBlockByNumber`) and feed the unchanged admission verifiers; `deposit.rs`, `withdraw.rs` and `exit.rs` verification rules are preserved byte for byte. `docs/wiki/SettlementEvidence.md` documents the ABI, canonical encodings and consumer sequence.

Gates run on the lane's build host (logs under the lane worktree `qual-logs/ct1/`):

| Command | Exit |
| --- | --- |
| `forge fmt --check` | 0 |
| `forge build` | 0 |
| `forge test` | 0 (148 passed) |
| `cargo fmt --check --manifest-path human/Cargo.toml -p layerx-paxeer-client` | 0 |
| `cargo clippy --locked --manifest-path human/Cargo.toml -p layerx-paxeer-client --all-targets -- -D warnings` | 0 |
| `cargo test --locked --manifest-path human/Cargo.toml -p layerx-paxeer-client --test withdraw real_published -- --test-threads=1` | 0 (2 Anvil round trips) |
| `cargo test --locked --manifest-path human/Cargo.toml -p layerx-paxeer-client --no-fail-fast` | 101: 47 passed, 1 pre-existing failure (`disposable_custody.py` imports `PERSISTENT_CHAIN_ID`, which `tests/bridge/deploy_local_custody.py` does not export; recorded as observation 6.6.10) |
| `make beta-ledger-check` | 0 |

Not run: cluster and image gates. Honest partial: the aggregate crate test gate is blocked by the pre-existing import defect noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
