### PR TITLE
Version the module registry with asset metadata and serve verified balance context

### DIFF
--- a/platform/Cargo.lock
+++ b/platform/Cargo.lock
@@ -764,7 +764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2174,7 +2174,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2488,10 +2488,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2658,6 +2658,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -2828,6 +2829,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/platform/hosted/authority/README.md
+++ b/platform/hosted/authority/README.md
@@ -1,9 +1,9 @@
 # Receipt authority and the human agent contract
 
 The binary dispatches all eight `/v1/agent/*` routes with a dedicated scoped
-credential and protected policy. Registry and authorized-batch have successful
+credential and protected policy. Registry, authorized-batch and balance-context have successful
 responses. Core-clock succeeds with two distinct retained verified headers.
-Balance-context, identity, capability-scope, budget-state and key-policy refuse
+Identity, capability-scope, budget-state and key-policy refuse
 when the sources described below cannot establish the requested facts. These
 refusals do not constitute complete successful-route coverage.
 
@@ -262,15 +262,23 @@ missing state/checkpoint proof.
 
 ## Remaining evidence refusals
 
-The canonical gateway file currently has exactly
-`{"modules":[{"module":9,"ordinals":[1,7]}]}` shape. Authority returns exactly
-these registrations, packing each activity as `(module << 16) | ordinal`, and
-`revision` is SHA-256 of the original file bytes. It does not infer registrations
-from receipts or inject Programs ordinals. The gateway currently injects
-Programs ordinals and limits registrations to eight, while the agent supports
-nine module IDs. Those differences require resolution by the gateway owner.
-There is no currency field in the gateway schema and it denies unknown fields.
-Consequently balance-context returns 503 `registry_currency_metadata_unavailable`.
+The canonical registry now requires `schema_version: 2`, `modules` and `assets`.
+Each asset contains `asset` (nonzero lowercase H32), `currency` (1..32 bytes),
+`decimals` (0..38) and `symbol` (1..32 bytes). Currency and symbol reject control
+characters. Assets must be unique, with 1..256 entries; unknown fields refuse.
+Both readers reject the old unversioned file and version 1. The authority keeps
+its existing module bounds and exact registrations; gateway retains its existing
+eight-module bound and Programs ordinal insertion. No gateway writer exists in
+`src/main.rs`; provisioning writes the file outside these owned paths.
+
+Balance-context selects currency metadata by the policy asset, requires a held
+verified header, and reports that header's timestamp as Unix milliseconds in a
+decimal string. Age is computed from the system wall clock, rejecting future
+headers and age exceeding the provisioned maximum before returning success.
+The sequencer ID, key and batch range are the same startup pins used by the
+verifier. Missing metadata or stale/missing evidence returns 503. The response
+also includes decimals, symbol, the exact registry file digest and the existing
+account evidence inventory. This endpoint returns context, not a state proof.
 
 Budget receipt fields do not encode budget revocation state. Replica documents
 provide batch inclusion, not checkpoint certificates. Budget-state returns 503
@@ -293,15 +301,18 @@ corresponding verified state and checkpoint evidence interface. The real client
 collapses these 503 statuses to Refused, as described above.
 
 The real-client TLS regression starts the real authority binary and invokes
-`RemoteHumanAuthority` in an isolated subprocess. It currently fails before the
-first request: agentd enables only ureq native TLS, while its client chooses the
-default Rustls provider, which is not compiled. No test-only dependency feature
-is added to hide this production mismatch. The agent owner must select the
-compiled provider and configure CA trust before the client assertions can run.
+`RemoteHumanAuthority` with the server's explicit private CA DER. It preserves
+refusal coverage and adds a successful balance-context read against the unchanged
+real-node receipt fixture. That historical-fixture test explicitly provisions a
+ten-year freshness window; the original short-window test still requires 503.
+The root-only real-node tests retain their prerequisites.
 
-A separate real-server wire test verifies registry and cached authorized-batch
-success from an unmodified real-node receipt fixture, all remaining route
-refusals, token separation, wrong tenant, and missing/changed policy. It does not
-replace the failing real-client regression or claim all-eight-route happy-path
-coverage. The live two-header clock test remains unqualified. See the feature
-qualification ledger and worktree `qual-logs/hm2/` for exact executed outcomes.
+The requested derived-header certificate conflicts with the existing finality
+contract. `ReplicaDocument` supplies one sequencer signature over the batch-header
+digest. `layerx_wire::receipt::CheckpointCertificate` contains guarantor
+signatures and a threshold; encoding a sequencer signature into those fields
+would not establish checkpoint finality. `layerx-proof` establishes batch
+inclusion separately from checkpoint finality. Budget and key-policy clients
+require verification rank 4 or 5; identity owner installation and capability
+installation also require checkpoint-finalised evidence. These checks are intact.
+No state-proof or checkpoint encoding is claimed for the remaining refusals.

--- a/platform/hosted/authority/src/human.rs
+++ b/platform/hosted/authority/src/human.rs
@@ -93,7 +93,18 @@ struct KeyPolicy {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Registry {
+    schema_version: u16,
+    assets: Vec<CurrencyMetadata>,
     modules: Vec<Module>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CurrencyMetadata {
+    asset: String,
+    currency: String,
+    decimals: u8,
+    symbol: String,
 }
 
 #[derive(Deserialize)]
@@ -537,15 +548,7 @@ fn dispatch(config: &Config, request: &Request) -> Result<Response, Response> {
     let evidence = human.evidence(config)?;
     match name {
         "core-clock" => clock(&evidence, human.horizon),
-        "balance-context" => {
-            let summary = account_summary(p, &evidence)?;
-            let mut response = unavailable("registry_currency_metadata_unavailable");
-            let mut body = serde_json::from_slice::<Value>(&response.body)
-                .map_err(|_| unavailable("encoding_failed"))?;
-            body["evidence"] = summary;
-            response.body = body.to_string().into_bytes();
-            Ok(response)
-        }
+        "balance-context" => balance_context(p, &human.registry_path, &evidence, config),
         "budget-state" => budget(p, &params["budget_id"], &evidence),
         _ => policy_route(name, &params, p, &evidence),
     }
@@ -573,13 +576,34 @@ fn budget(p: &PrincipalPolicy, id: &str, evidence: &[Verified]) -> Result<Respon
     Ok(response)
 }
 
-fn registry(path: &Path) -> Result<Response, Response> {
+fn read_registry(path: &Path) -> Result<(Registry, Vec<u8>), Response> {
     let bytes =
         protected::read(path, MAX_FILE).map_err(|()| unavailable("module_registry_unavailable"))?;
     let registry: Registry =
         serde_json::from_slice(&bytes).map_err(|_| unavailable("module_registry_invalid"))?;
     let mut seen = BTreeSet::new();
-    if registry.modules.is_empty()
+    if registry.schema_version != 2
+        || registry.assets.is_empty()
+        || registry.assets.len() > 256
+        || registry.assets.iter().any(|a| {
+            !valid_digest(&a.asset)
+                || a.asset != a.asset.to_ascii_lowercase()
+                || a.currency.is_empty()
+                || a.currency.len() > 32
+                || a.currency.chars().any(char::is_control)
+                || a.symbol.is_empty()
+                || a.symbol.len() > 32
+                || a.symbol.chars().any(char::is_control)
+                || a.decimals > 38
+        })
+        || registry
+            .assets
+            .iter()
+            .map(|a| &a.asset)
+            .collect::<BTreeSet<_>>()
+            .len()
+            != registry.assets.len()
+        || registry.modules.is_empty()
         || registry.modules.len() > 32
         || registry.modules.iter().any(|m| {
             !(1..=9).contains(&m.module)
@@ -592,11 +616,59 @@ fn registry(path: &Path) -> Result<Response, Response> {
     {
         return Err(unavailable("module_registry_invalid"));
     }
+    Ok((registry, bytes))
+}
+
+fn registry(path: &Path) -> Result<Response, Response> {
+    let (registry, bytes) = read_registry(path)?;
     let modules: Vec<_> = registry.modules.iter().map(|m| value!({"module_id": m.module,
         "activity_types": m.ordinals.iter().map(|o| (u32::from(m.module) << 16) | u32::from(*o)).collect::<Vec<_>>() })).collect();
     Ok(json(
         200,
         &value!({"modules": modules, "revision": hex::encode(&digest(&bytes))}),
+    ))
+}
+
+fn balance_context(
+    p: &PrincipalPolicy,
+    registry_path: &Path,
+    evidence: &[Verified],
+    config: &Config,
+) -> Result<Response, Response> {
+    let (registry, bytes) = read_registry(registry_path)?;
+    let asset = registry
+        .assets
+        .iter()
+        .find(|a| a.asset == p.asset_id)
+        .ok_or_else(|| unavailable("registry_currency_metadata_unavailable"))?;
+    let head = evidence
+        .iter()
+        .max_by_key(|e| e.last_sequence)
+        .ok_or_else(|| unavailable("head_unavailable"))?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|_| unavailable("clock_unavailable"))?
+        .as_millis();
+    let age_ms = now_ms
+        .checked_sub(u128::from(head.timestamp_ms))
+        .ok_or_else(|| unavailable("head_timestamp_in_future"))?;
+    if age_ms > u128::from(p.maximum_age_seconds) * 1000 {
+        return Err(unavailable("balance_evidence_stale"));
+    }
+    Ok(json(
+        200,
+        &value!({
+            "account_id": p.account_id, "asset_id": p.asset_id,
+            "currency": asset.currency, "decimals": asset.decimals, "symbol": asset.symbol,
+            "registry_revision": hex::encode(&digest(&bytes)),
+            "observed_at": head.timestamp_ms.to_string(),
+            "age_seconds": u64::try_from(age_ms / 1000).map_err(|_| unavailable("clock_unavailable"))?,
+            "maximum_age_seconds": p.maximum_age_seconds,
+            "sequencer_id": hex::encode(&config.sequencer_id),
+            "sequencer_public_key": hex::encode(&config.sequencer_public_key),
+            "first_batch_number": config.first_batch, "last_batch_number": config.last_batch,
+            "evidence": account_summary(p, evidence)?
+        }),
     ))
 }
 

--- a/platform/hosted/authority/src/main.rs
+++ b/platform/hosted/authority/src/main.rs
@@ -86,6 +86,9 @@ struct Config {
     network_id: String,
     wire_version: String,
     authorization: SequencerAuthorization,
+    sequencer_id: [u8; 32],
+    first_batch: u64,
+    last_batch: u64,
     sequencer_public_key: [u8; 32],
 }
 
@@ -283,6 +286,9 @@ fn config() -> Result<Config, String> {
         protocol_network_id,
         network_id,
         wire_version,
+        sequencer_id,
+        first_batch,
+        last_batch,
         authorization: SequencerAuthorization::new(
             sequencer_id,
             sequencer_public_key,

--- a/platform/hosted/authority/tests/human_tls.rs
+++ b/platform/hosted/authority/tests/human_tls.rs
@@ -140,7 +140,7 @@ fn seed(root: &Path) {
     );
     write(
         &root.join("modules.json"),
-        br#"{"modules":[{"module":9,"ordinals":[1,7]}]}"#,
+        br#"{"schema_version":2,"assets":[{"asset":"0202020202020202020202020202020202020202020202020202020202020202","currency":"USD","decimals":6,"symbol":"$"}],"modules":[{"module":9,"ordinals":[1,7]}]}"#,
     );
     write(
         &root.join("human.token"),
@@ -404,6 +404,7 @@ fn drive_client() {
         "human-test-token-0000000000000000000000".to_owned(),
         Duration::from_secs(5),
         1_048_576,
+        &must(fs::read(root.join("server.der"))),
     ));
     let peer = HumanPeer {
         uid: 1,
@@ -482,4 +483,58 @@ fn drive_client() {
     must(client.registry(&peer));
     write(&root.join("policy.json"), br#"{"principals":[]}"#);
     assert!(client.registry(&peer).is_err());
+}
+
+#[test]
+fn real_client_balance_context_uses_registry_and_verified_header() {
+    let root = prepare_root();
+    seed(&root);
+    let mut policy: Value = must(serde_json::from_slice(&must(fs::read(
+        root.join("policy.json"),
+    ))));
+    policy["principals"][0]["maximum_age_seconds"] = json!(315_360_000_u64);
+    write(
+        &root.join("policy.json"),
+        &must(serde_json::to_vec(&policy)),
+    );
+    let (server, address) = launch(root);
+    let mut client = must(RemoteHumanAuthority::connect(
+        &format!("https://{address}"),
+        "human-test-token-0000000000000000000000".to_owned(),
+        Duration::from_secs(5),
+        1_048_576,
+        &must(fs::read(server.root.join("server.der"))),
+    ));
+    let peer = HumanPeer {
+        uid: 1,
+        tenant: "tenant space".to_owned(),
+        principal: "principal".to_owned(),
+    };
+    let (account, asset, currency, observed_at, age, maximum_age, authorization) =
+        must(client.balance_context(&peer));
+    assert_eq!(account, [1; 32]);
+    assert_eq!(asset, [2; 32]);
+    assert_eq!(currency, "USD");
+    assert!(age <= maximum_age);
+    let fixture: Value = must(serde_json::from_str(include_str!(
+        "fixtures/real-program-deploy-receipt.json"
+    )));
+    let header = must(layerx_wire::receipt::decode_batch_header(&must(
+        hex::decode(
+            fixture["header_hex"]
+                .as_str()
+                .unwrap_or_else(|| panic!("header")),
+        ),
+    )));
+    assert_eq!(observed_at, header.timestamp_ms().to_string());
+    assert_eq!(
+        hex::encode(&authorization.public_key()),
+        fixture["sequencer_public_key_hex"]
+    );
+    write(
+        &server.root.join("modules.json"),
+        br#"{"modules":[{"module":9,"ordinals":[1,7]}]}"#,
+    );
+    assert!(client.registry(&peer).is_err());
+    assert!(client.balance_context(&peer).is_err());
 }

--- a/platform/hosted/authority/tests/support/human_unit.rs
+++ b/platform/hosted/authority/tests/support/human_unit.rs
@@ -28,7 +28,7 @@ fn registry_uses_exact_file_bytes_and_refuses_unprotected_invalid_missing_source
     fs::create_dir(&root).unwrap_or_else(|e| panic!("directory: {e}"));
     let path = root.join("registry.json");
     assert_eq!(result_status(registry(&path)), 503);
-    let bytes = br#"{"modules":[{"module":9,"ordinals":[1,7]}]}"#;
+    let bytes = br#"{"schema_version":2,"assets":[{"asset":"0202020202020202020202020202020202020202020202020202020202020202","currency":"USD","decimals":6,"symbol":"$"}],"modules":[{"module":9,"ordinals":[1,7]}]}"#;
     fs::write(&path, bytes).unwrap_or_else(|e| panic!("registry: {e}"));
     fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
         .unwrap_or_else(|e| panic!("mode: {e}"));
@@ -153,4 +153,46 @@ fn query_decoding_rejects_duplicates_and_preserves_utf8() {
     let result =
         query(Some("did=did%3Alayerx%3A%C3%A9%20x")).unwrap_or_else(|_| panic!("valid query"));
     assert_eq!(result["did"], "did:layerx:é x");
+}
+
+#[test]
+fn registry_rejects_legacy_and_invalid_asset_metadata() {
+    let root = std::env::temp_dir().join(format!("human-assets-{}", std::process::id()));
+    fs::create_dir(&root).unwrap_or_else(|e| panic!("directory: {e:?}"));
+    let path = root.join("registry.json");
+    let valid = value!({"schema_version":2,"assets":[{"asset":hex::encode(&[2;32]),"currency":"USD","decimals":6,"symbol":"$"}],"modules":[{"module":9,"ordinals":[1,7]}]});
+    let mut invalid = Vec::new();
+    let mut legacy = valid.clone();
+    legacy
+        .as_object_mut()
+        .unwrap_or_else(|| panic!("object"))
+        .remove("schema_version");
+    invalid.push(legacy);
+    for (field, value) in [
+        ("asset", value!(hex::encode(&[0; 32]))),
+        ("currency", value!("")),
+        ("symbol", value!("\n")),
+        ("decimals", value!(39)),
+    ] {
+        let mut document = valid.clone();
+        document["assets"][0][field] = value;
+        invalid.push(document);
+    }
+    let mut duplicate = valid.clone();
+    duplicate["assets"]
+        .as_array_mut()
+        .unwrap_or_else(|| panic!("assets"))
+        .push(valid["assets"][0].clone());
+    invalid.push(duplicate);
+    for document in invalid {
+        fs::write(
+            &path,
+            serde_json::to_vec(&document).unwrap_or_else(|e| panic!("JSON: {e:?}")),
+        )
+        .unwrap_or_else(|e| panic!("write: {e:?}"));
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .unwrap_or_else(|e| panic!("permissions: {e:?}"));
+        assert_eq!(result_status(registry(&path)), 503);
+    }
+    fs::remove_dir_all(root).unwrap_or_else(|e| panic!("cleanup: {e:?}"));
 }

--- a/platform/hosted/gateway/README.md
+++ b/platform/hosted/gateway/README.md
@@ -1,0 +1,29 @@
+# Canonical module registry
+
+`LAYERX_GATEWAY_MODULE_REGISTRY_FILE` names a JSON file shared with the human
+receipt authority. The required shape is:
+
+```json
+{
+  "schema_version": 2,
+  "assets": [{
+    "asset": "0202020202020202020202020202020202020202020202020202020202020202",
+    "currency": "USD",
+    "decimals": 6,
+    "symbol": "$"
+  }],
+  "modules": [{"module": 9, "ordinals": [1, 2, 7]}]
+}
+```
+
+The asset shown is illustrative; provision the actual network asset ID and its
+metadata. Both consumers reject the unversioned shape and version 1. Every asset
+ID is nonzero lowercase 64-digit hex and unique. There must be 1..256 assets;
+currency and symbol contain 1..32 UTF-8 bytes without control characters;
+decimals is an unsigned integer from 0 through 38. Unknown fields refuse.
+
+Gateway retains its existing module validation, eight-module bound and Programs
+ordinal insertion. Authority returns the exact module registrations in the file
+and its SHA-256 revision. The gateway only reads this file; the cluster renderer
+must write the new shape. Authority requires a protected regular file, so its
+mount must meet the authority README's ownership and path rules.

--- a/platform/hosted/gateway/src/main.rs
+++ b/platform/hosted/gateway/src/main.rs
@@ -149,7 +149,18 @@ struct ReadinessResponse {
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ModuleFile {
+    schema_version: u16,
+    assets: Vec<AssetMetadata>,
     modules: Vec<ModuleDeclaration>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetMetadata {
+    asset: String,
+    currency: String,
+    decimals: u8,
+    symbol: String,
 }
 
 #[derive(Deserialize)]
@@ -2760,6 +2771,33 @@ fn configured_modules() -> Result<ModuleRegistry, String> {
         .map_err(|error| error.to_string())?,
     )
     .map_err(|_| "gateway module registry is invalid".to_owned())?;
+    modules_from_file(module_file)
+}
+
+fn modules_from_file(module_file: ModuleFile) -> Result<ModuleRegistry, String> {
+    let mut assets = std::collections::BTreeSet::new();
+    if module_file.schema_version != 2
+        || module_file.assets.is_empty()
+        || module_file.assets.len() > 256
+        || module_file.assets.iter().any(|a| {
+            a.asset.len() != 64
+                || !a
+                    .asset
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+                || a.asset.bytes().all(|b| b == b'0')
+                || !assets.insert(&a.asset)
+                || a.currency.is_empty()
+                || a.currency.len() > 32
+                || a.currency.chars().any(char::is_control)
+                || a.symbol.is_empty()
+                || a.symbol.len() > 32
+                || a.symbol.chars().any(char::is_control)
+                || a.decimals > 38
+        })
+    {
+        return Err("gateway asset registry is invalid".to_owned());
+    }
     if module_file.modules.is_empty() || module_file.modules.len() > 8 {
         return Err("gateway module registry is outside its bound".to_owned());
     }
@@ -3692,5 +3730,39 @@ mod authority_shape_tests {
         let mut unknown = document;
         unknown["unexpected"] = serde_json::json!(true);
         assert!(serde_json::from_value::<AuthorityResponse>(unknown).is_err());
+    }
+}
+
+#[cfg(test)]
+mod module_schema_tests {
+    use super::*;
+
+    #[test]
+    fn registry_requires_versioned_asset_metadata() {
+        let valid = serde_json::json!({"schema_version":2,"assets":[{"asset":"02".repeat(32),"currency":"USD","decimals":6,"symbol":"$"}],"modules":[{"module":9,"ordinals":[1,2,7]}]});
+        let parse = |value: serde_json::Value| -> Result<ModuleRegistry, String> {
+            modules_from_file(serde_json::from_value(value).map_err(|e| e.to_string())?)
+        };
+        assert!(parse(valid.clone()).is_ok());
+        assert!(parse(serde_json::json!({"modules":[{"module":9,"ordinals":[1,2,7]}]})).is_err());
+        for (field, value) in [
+            ("asset", serde_json::json!("00".repeat(32))),
+            ("currency", serde_json::json!("")),
+            ("symbol", serde_json::json!("\n")),
+            ("decimals", serde_json::json!(39)),
+        ] {
+            let mut document = valid.clone();
+            document["assets"][0][field] = value;
+            assert!(parse(document).is_err());
+        }
+        let mut duplicate = valid.clone();
+        duplicate["assets"]
+            .as_array_mut()
+            .unwrap_or_else(|| panic!("assets"))
+            .push(valid["assets"][0].clone());
+        assert!(parse(duplicate).is_err());
+        let mut old_version = valid;
+        old_version["schema_version"] = serde_json::json!(1);
+        assert!(parse(old_version).is_err());
     }
 }

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -4694,6 +4694,7 @@ symbol = "Server State RemoteIdentityProvider"
 observed = "cargo test --locked --manifest-path human/Cargo.toml -p layerx-human-identity-provider exits 0 with 11 tests passing, zero ignored; qual-logs/hm3/test-final.log. Tests compile the unchanged identity_dispatch.rs source with the actual service types and exercise its RemoteIdentityProvider over real Unix sockets. Separate real-server and real-binary tests cover malformed frames, UID refusal, atomic snapshot replay, protected file and directory refusal, committed-state corruption, missing-snapshot refusal, owner-only device enrollment, crash restart and SIGTERM. Owned Rust files pass rustfmt --check --edition 2021 --config skip_children=true; qual-logs/hm3/fmt-owned-check.log. The no-deps all-target Clippy diagnostic exits 101 solely on five existing diagnostics in the imported identity_dispatch.rs source at lines 147, 191 and 192; qual-logs/hm3/clippy-owned-final.log. No lint allowances, assertions or client source were changed."
 assumption = "Runtime tests validate the provider and original client wire exchange, not automatic enrollment integration or a deployed cluster. Required workspace formatting and dependency Clippy gates remain blocked as recorded in observation.3.7.21. Environment uses CARGO_BUILD_JOBS=16, MAKEFLAGS=-j16, the pinned Rust 1.91.1 toolchain and human/target."
 severity = "note"
+
 [observation.6.4.159]
 task = "6.4"
 file = "human/crates/layerx-human-service/src/server/production_auth.rs"
@@ -4813,3 +4814,35 @@ symbol = "ureq native-tls connector dependency"
 observed = "ureq 3.4.0 gates its NativeTlsConnector on native-tls rather than native-tls-no-default. Agentd enables native-tls and adds its required transitive webpki-root-certs package to agent/Cargo.lock. The human and platform lockfiles do not contain that package and are outside the owned paths. Explicit RootCerts::Specific still excludes bundled roots from runtime trust."
 assumption = "Dependent workspace owners must regenerate their lockfiles for the enabled connector before locked builds; no unrelated package upgrade is required by the agentd change."
 severity = "blocker"
+
+[observation.6.4.174]
+task = "6.4"
+file = "agent/crates/layerx-agentd/src/human_runtime.rs agent/crates/layerx-proof/src/checkpoint.rs agent/crates/layerx-wire/src/receipt.rs"
+symbol = "RemoteHumanAuthority::budget_state RemoteHumanAuthority::key_rotation_policy CheckpointCertificate"
+observed = "The requested derived budget revocation sequence is zero without account-touching evidence, but the client explicitly rejects zero. Budget and key-policy readers require verification ranks 4 or 5. Retained ReplicaDocument batch evidence has one sequencer signature over a batch-header digest and proves batch inclusion; it has no bonded guarantor attestations or settlement registration. The existing wire CheckpointCertificate encodes guarantor signatures and threshold, and the proof verifier distinguishes that finality from batch inclusion. Encoding the sequencer signature as a guarantor signature or returning rank 4 without its verifier would misstate the evidence. Identity owner and capability installation also require checkpoint-finalised evidence."
+assumption = "An explicitly versioned derived-state contract across the client and authority, or actual independently verified checkpoint evidence, is required. Current finality checks and the four evidence refusals remain intact. No synthetic certificate or state proof is supplied."
+severity = "blocker"
+
+[observation.6.4.175]
+task = "6.4"
+file = "platform/hosted/tests/beta-cluster.sh platform/hosted/gateway/tests/local/lifecycle.rs"
+symbol = "module registry provisioning"
+observed = "Authority and gateway module registry readers require schema_version 2 and an assets array alongside modules. Each asset has asset, currency, decimals and symbol. Gateway main.rs contains a reader but no registry writer; provisioning writers are outside the permitted paths. The gateway eight-module bound and Programs ordinal insertion remain unchanged."
+assumption = "Registry writers must supply the actual network asset metadata in the new shape documented in platform/hosted/gateway/README.md. Old unversioned files and version 1 are refused by both readers."
+severity = "blocker"
+
+[observation.6.4.176]
+task = "6.4"
+file = "platform/hosted/authority/tests/real_node.rs platform/hosted/authority/tests/human_tls.rs"
+symbol = "real-node identity prerequisite and explicit-CA TLS client"
+observed = "cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority -p layerx-platform-gateway exits 101 after 21 authority unit, TLS and maintenance tests pass. All three real-server TLS tests pass, including RemoteHumanAuthority with explicit CA DER and the successful registry-bound balance-context read. Both real-node tests fail their unchanged UID assertion: actual 1000, required 0. Gateway tests are not reached by this command. Evidence: qual-logs/hm2/hm2c-test.log and hm2c-test.exit. Native executable checks fail at both worktree and advertised binary paths in qual-logs/hm2/hm2c-prerequisites.log."
+assumption = "Real-node qualification and successful two-header clock evidence require the existing privileged native harness and actual native binaries. Cluster and image gates remain unrun because their tools and infrastructure are absent. No all-eight-route successful-client coverage is claimed."
+severity = "blocker"
+
+[observation.6.4.177]
+task = "6.4"
+file = "platform/hosted/gateway/tests/tap_nonce.rs platform/hosted/gateway/src/main.rs"
+symbol = "module_schema_tests and Redis qualification prerequisite"
+observed = "The separate gateway cargo test command first exits 101 because redis-server is absent, after all 21 unit tests pass. Installing untracked Redis tooling and its liblzf/libjemalloc dependencies under qual-logs/hm2/redis/extracted allows cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway to exit 0 with all 23 tests passing. The rerun prepends extracted/usr/bin to PATH and sets LD_LIBRARY_PATH to extracted/usr/lib/x86_64-linux-gnu. Final cargo fmt --check and cargo clippy --locked --all-targets -- -D warnings for both authority and gateway exit 0. Evidence: qual-logs/hm2/hm2c-gateway-test-final.log, hm2c-redis-install.log, hm2c-fmt-final.log and hm2c-clippy-final.log."
+assumption = "The Redis tests start isolated loopback TLS servers on ephemeral ports and retain their original assertions. These passing local gates do not establish privileged native-node, cluster, image, or all-eight-route success."
+severity = "note"


### PR DESCRIPTION
Continues the human agent authority routes on the receipt authority. The canonical module registry becomes schema version 2 with a required `assets` array (asset id, currency, decimals, symbol) validated identically by the authority and the gateway; old shapes refuse. `balance-context` resolves currency and decimals from the bound asset and takes its timestamp and freshness from a verified retained header and the configured sequencer authorization range. The `RemoteHumanAuthority` TLS tests pass an explicit private CA DER, with a new successful balance-context case over the real-node receipt fixture. The platform lockfile resolves the merged native-tls connector dependency.

Gates run on the lane's build host (logs under the lane worktree `qual-logs/hm2/`):

| Command | Exit |
| --- | --- |
| `cargo fmt --check --manifest-path platform/Cargo.toml -p layerx-platform-authority -p layerx-platform-gateway` | 0 |
| `cargo clippy --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority -p layerx-platform-gateway --all-targets -- -D warnings` | 0 |
| `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-gateway` | 0 (23 tests, including both real Redis integration tests) |
| `cargo test --locked --manifest-path platform/Cargo.toml -p layerx-platform-authority -p layerx-platform-gateway` | 101: 21 authority tests pass, the two unchanged root-only native tests fail on that host for lack of root and native binaries |

Honest partial: four routes (budget state, key rotation policy, identity owner, capability installation) still refuse because the retained sequencer-signed batch headers do not establish guarantor checkpoint finality (ranks 4..5) and no verified checkpoint evidence source exists yet; the refusals stay intact rather than fabricating finality. The beta cluster renderer and the gateway's local test registry writers must emit the schema-version-2 registry before this can deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
