### PR TITLE
Use named fields for Human peer authority bindings in agentd

### DIFF
--- a/agent/crates/layerx-agentd/src/human_peer_config.rs
+++ b/agent/crates/layerx-agentd/src/human_peer_config.rs
@@ -1,0 +1,179 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+use layerx_types::ids::Did;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct ConfigError {
+    entry_index: usize,
+    reason: Rejection,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum Rejection {
+    Fields,
+    Value,
+    Uid,
+    Tenant,
+    Principal,
+    DuplicateUid,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "LAYERX_AGENT_HUMAN_PEERS entry {}: {:?}",
+            self.entry_index, self.reason
+        )
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub(super) fn parse(value: &str) -> Result<BTreeMap<u32, (String, String)>, ConfigError> {
+    let mut peers = BTreeMap::new();
+    for (entry_index, entry) in value.split(',').enumerate() {
+        let error = |reason| ConfigError {
+            entry_index,
+            reason,
+        };
+        let mut fields = entry.split(';');
+        let uid = fields.next().and_then(|field| field.strip_prefix("uid="));
+        let tenant = fields
+            .next()
+            .and_then(|field| field.strip_prefix("tenant="));
+        let principal = fields
+            .next()
+            .and_then(|field| field.strip_prefix("principal="));
+        let (Some(uid), Some(tenant), Some(principal)) = (uid, tenant, principal) else {
+            return Err(error(Rejection::Fields));
+        };
+        if fields.next().is_some() {
+            return Err(error(Rejection::Fields));
+        }
+        if [uid, tenant, principal].iter().any(|value| {
+            value.is_empty()
+                || value
+                    .chars()
+                    .any(|ch| ch.is_whitespace() || ch.is_control())
+        }) {
+            return Err(error(Rejection::Value));
+        }
+        if !uid.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Err(error(Rejection::Uid));
+        }
+        let uid = uid.parse::<u32>().map_err(|_| error(Rejection::Uid))?;
+        if tenant.len() > 128
+            || !tenant
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return Err(error(Rejection::Tenant));
+        }
+        let (method, id) = principal
+            .strip_prefix("did:")
+            .and_then(|value| value.split_once(':'))
+            .ok_or_else(|| error(Rejection::Principal))?;
+        if method.is_empty()
+            || !method
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+            || id.is_empty()
+            || Did::new(principal.as_bytes()).is_err()
+        {
+            return Err(error(Rejection::Principal));
+        }
+        if peers
+            .insert(uid, (principal.to_owned(), tenant.to_owned()))
+            .is_some()
+        {
+            return Err(error(Rejection::DuplicateUid));
+        }
+    }
+    Ok(peers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse, Rejection};
+
+    #[test]
+    fn preserves_did_and_tenant_binding() -> Result<(), Box<dyn std::error::Error>> {
+        let peers = parse("uid=4020;tenant=beta;principal=did:layerx:beta:alice,uid=4294967295;tenant=Beta_2-prod;principal=did:key:z123")?;
+        assert_eq!(
+            peers.get(&4020),
+            Some(&("did:layerx:beta:alice".to_owned(), "beta".to_owned()))
+        );
+        assert_eq!(peers.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn refuses_positional_fields_and_separators() {
+        for value in [
+            "4020:did:layerx:beta:alice:beta",
+            "4020:beta:did:layerx:alice",
+            "",
+            "uid=1;tenant=beta;principal=did:key:a;extra=x",
+            "uid=1;tenant=be;ta;principal=did:key:a",
+            "uid=1;tenant=beta;principal=did:key:a,broken",
+            "uid=1;tenant=beta;principal=did:key:a,",
+            "uid=1;tenant=beta;tenant=beta",
+            "tenant=beta;uid=1;principal=did:key:a",
+        ] {
+            assert!(parse(value).is_err(), "accepted {value:?}");
+        }
+        for forbidden in [' ', '\t', '\n', '\r', '\0', '\u{7f}', '\u{a0}'] {
+            for value in [
+                format!("uid=1{forbidden};tenant=beta;principal=did:key:a"),
+                format!("uid=1;tenant=be{forbidden}ta;principal=did:key:a"),
+                format!("uid=1;tenant=beta;principal=did:key:a{forbidden}b"),
+            ] {
+                assert!(parse(&value).is_err(), "accepted {value:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn refuses_invalid_authority_and_duplicate_uids() {
+        for (uid, tenant, principal) in [
+            ("-1", "beta", "did:key:a"),
+            ("+1", "beta", "did:key:a"),
+            ("4294967296", "beta", "did:key:a"),
+            ("", "beta", "did:key:a"),
+            ("1", "", "did:key:a"),
+            ("1", "beta.prod", "did:key:a"),
+            ("1", "beta", "alice"),
+            ("1", "beta", "did:key"),
+            ("1", "beta", "did::a"),
+            ("1", "beta", "did:key:"),
+            ("1", "beta", "did:KEY:a"),
+        ] {
+            assert!(parse(&format!("uid={uid};tenant={tenant};principal={principal}")).is_err());
+        }
+        assert!(parse(&format!(
+            "uid=1;tenant={};principal=did:key:a",
+            "a".repeat(129)
+        ))
+        .is_err());
+        assert!(parse(&format!(
+            "uid=1;tenant=beta;principal=did:key:{}",
+            "a".repeat(256)
+        ))
+        .is_err());
+        let error =
+            parse("uid=1;tenant=beta;principal=did:key:a,uid=1;tenant=other;principal=did:key:b")
+                .err();
+        assert_eq!(
+            error
+                .as_ref()
+                .map(|error| (&error.reason, error.entry_index)),
+            Some((&Rejection::DuplicateUid, 1))
+        );
+        assert_eq!(
+            error.map(|error| error.to_string()),
+            Some("LAYERX_AGENT_HUMAN_PEERS entry 1: DuplicateUid".to_owned())
+        );
+    }
+}

--- a/agent/crates/layerx-agentd/src/main.rs
+++ b/agent/crates/layerx-agentd/src/main.rs
@@ -32,6 +32,7 @@ use layerx_programs::{
 };
 
 mod human_owner_mode;
+mod human_peer_config;
 
 const HEADER_LIMIT: usize = 16 * 1024;
 
@@ -89,24 +90,8 @@ fn parse_hex<const N: usize>(name: &str) -> Result<[u8; N], String> {
 }
 
 fn human_peers() -> Result<BTreeMap<u32, (String, String)>, String> {
-    let mut peers = BTreeMap::new();
-    for entry in required("LAYERX_AGENT_HUMAN_PEERS")?.split(',') {
-        let fields = entry.splitn(3, ':').collect::<Vec<_>>();
-        if fields.len() != 3 || fields[1].is_empty() || fields[2].is_empty() {
-            return Err("human peer map is invalid".to_owned());
-        }
-        let uid = fields[0].parse().map_err(|_| "human peer uid is invalid")?;
-        if peers
-            .insert(uid, (fields[1].to_owned(), fields[2].to_owned()))
-            .is_some()
-        {
-            return Err("human peer uid is duplicated".to_owned());
-        }
-    }
-    if peers.is_empty() {
-        return Err("human peer map is empty".to_owned());
-    }
-    Ok(peers)
+    human_peer_config::parse(&required("LAYERX_AGENT_HUMAN_PEERS")?)
+        .map_err(|error| error.to_string())
 }
 
 fn verified_limit() -> Result<LimitConfig, String> {

--- a/agent/crates/layerx-agentd/tests/runtime_mode.rs
+++ b/agent/crates/layerx-agentd/tests/runtime_mode.rs
@@ -102,3 +102,29 @@ fn full_requires_journal_and_probe_even_when_transport_inputs_are_present(
     std::fs::remove_dir_all(root)?;
     Ok(())
 }
+
+#[test]
+fn human_owner_refuses_ambiguous_peer_configuration_before_connecting() -> Result<(), Box<dyn Error>>
+{
+    for peers in [
+        "4020:did:layerx:beta:alice:beta",
+        "uid=4020;tenant=beta;principal=did:layerx:beta:alice;extra=value",
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_layerx-agentd"))
+            .env_clear()
+            .env("LAYERX_AGENT_MODE", "human-owner")
+            .env("LAYERX_AGENT_PROGRAM_LISTEN", "127.0.0.1:0")
+            .env("LAYERX_AGENT_PROGRAM_BEARER_TOKEN", "h".repeat(32))
+            .env("LAYERX_AGENT_HUMAN_AUTHORITY_BEARER", "a".repeat(32))
+            .env("LAYERX_AGENT_HUMAN_PEERS", peers)
+            .output()?;
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8(output.stderr)?;
+        assert!(
+            stderr.contains("LAYERX_AGENT_HUMAN_PEERS entry 0: Fields"),
+            "{stderr}"
+        );
+        assert!(!stderr.contains(peers));
+    }
+    Ok(())
+}

--- a/docs/wiki/RunningAnAgent.md
+++ b/docs/wiki/RunningAnAgent.md
@@ -593,7 +593,7 @@ The binary reads a disjoint `LAYERX_AGENT_*` set
 | `LAYERX_AGENT_HUMAN_SOCKET` | Absolute Human Unix socket |
 | `LAYERX_AGENT_HUMAN_SESSION_KEY_ROOT` | Absolute session-key root |
 | `LAYERX_AGENT_HUMAN_SESSION_OPERATOR_SECRET_FILE` | Protected operator secret |
-| `LAYERX_AGENT_HUMAN_PEERS` | `uid:principal:tenant` map |
+| `LAYERX_AGENT_HUMAN_PEERS` | Comma-separated `uid=<u32>;tenant=<tenant>;principal=<did>` entries, e.g. `uid=4020;tenant=beta;principal=did:layerx:beta:alice`. Tenant: 1–128 ASCII letters, digits, `-` or `_`. Values cannot contain `;`, commas, whitespace or control characters. Principals require `did:<method>:<id>` within the protocol DID byte bound. Positional entries and duplicate UIDs are refused with a zero-based entry index. |
 | `LAYERX_AGENT_HUMAN_LIMIT_ID` | 16-byte `LimitId` |
 | `LAYERX_AGENT_HUMAN_LIMIT_SCOPE` | `tenant` / `agent` / `session` / `capability` / `counterparty` |
 | `LAYERX_AGENT_HUMAN_LIMIT_SCOPE_ID` | 32-byte hex scope identity |

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -5158,3 +5158,26 @@ symbol = "Sections::from_chunks decode_records class_presence_precedes_decoding_
 observed = "The availability fixture uses layerx_wire::encode::Encoder for count-prefixed activity/oracle sequences and tagged length-prefixed receipts, matching src/replica/lxp_replay_section.c and src/network/lxp_da_bundle.c. Class presence is checked before record decoding so a withheld oracle section reports MissingClass rather than treating absent bytes as malformed framing. Complete responses retain record decoding, chunk ordering and root verification. Both original daemon assertions remain unchanged. Regression coverage pins empty and withheld responses, missing classes with reordered chunks, complete reordered refusal, successful canonical retrieval, omitted and incorrect sequence counts, and reversed receipt/event tags. Touched-file rustfmt check, locked all-target clippy with -D warnings, daemon availability tests (3), client availability tests (4), and the focused decoder test (1) exit 0. Evidence: qual-logs/dan2/fmt-touched.log, clippy.log, focused.log, client-availability.log and decoder.log with sibling exit files."
 assumption = "Focused qualification passes. Full qualification remains blocked by the inherited formatting differences and absent native binaries recorded separately. The canonical decoder and original assertions were not relaxed."
 severity = "note"
+[observation.6.4.179]
+task = "6.4"
+file = "platform/hosted/beta-cluster.sh agent/crates/layerx-agentd/src/human_peer_config.rs docs/wiki/RunningAnAgent.md"
+symbol = "LAYERX_AGENT_HUMAN_PEERS"
+observed = "The checkout has no platform/hosted/beta-cluster.sh and no hosted manifest carrying LAYERX_AGENT_HUMAN_PEERS. bash -n platform/hosted/beta-cluster.sh exits 127 because the file is absent (qual-logs/ag3/bash.log). The consumer requires uid=<u32>;tenant=<tenant>;principal=<did>, with comma-separated entries and indexed typed configuration refusals."
+assumption = "The deployment producer must emit the named-field encoding and pass its shell syntax gate in the checkout containing that producer. No cluster or image gate ran because this host lacks those tools."
+severity = "blocker"
+
+[observation.6.4.180]
+task = "6.4"
+file = "agent/crates/layerx-agentd/src/export.rs agent/crates/layerx-agentd/src/policy/eval.rs agent/crates/layerx-agentd/tests/budget_unknown.rs agent/crates/layerx-agentd/tests/operator.rs"
+symbol = "package_formatting"
+observed = "cargo fmt --check --manifest-path agent/Cargo.toml -p layerx-agentd exits 1 with existing formatting differences in these four files (qual-logs/ag3/fmt.log). These unrelated files remain unchanged."
+assumption = "The full package formatting gate requires the owners of these unrelated changes to format them."
+severity = "blocker"
+
+[observation.6.4.181]
+task = "6.4"
+file = "agent/crates/layerx-agentd/tests/support/real_authority.rs agent/crates/layerx-agentd/tests/budget_create.rs"
+symbol = "fixture LAYERX_TEST_NATIVE_BIN_DIR"
+observed = "cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd exits 101 at budget_create because build/bin/layerxd is absent; subsequent fixture users report a poisoned lock (qual-logs/ag3/test.log). The supplied /root/lx-lanes/native-bin directory is also absent. The binary unit and runtime_mode targets pass separately, including DID peer parsing and real-binary positional-format refusal (qual-logs/ag3/test-focused.log). All-target Clippy with warnings denied passes (qual-logs/ag3/clippy-final.log)."
+assumption = "Full package execution requires qualified native layerxd and layerx-genesis-build binaries supplied through LAYERX_TEST_NATIVE_BIN_DIR. Focused success does not qualify the full package."
+severity = "blocker"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -5181,3 +5181,11 @@ symbol = "fixture LAYERX_TEST_NATIVE_BIN_DIR"
 observed = "cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd exits 101 at budget_create because build/bin/layerxd is absent; subsequent fixture users report a poisoned lock (qual-logs/ag3/test.log). The supplied /root/lx-lanes/native-bin directory is also absent. The binary unit and runtime_mode targets pass separately, including DID peer parsing and real-binary positional-format refusal (qual-logs/ag3/test-focused.log). All-target Clippy with warnings denied passes (qual-logs/ag3/clippy-final.log)."
 assumption = "Full package execution requires qualified native layerxd and layerx-genesis-build binaries supplied through LAYERX_TEST_NATIVE_BIN_DIR. Focused success does not qualify the full package."
 severity = "blocker"
+
+[observation.6.4.182]
+task = "6.4"
+file = "agent/crates/layerx-agentd/tests/support/real_authority.rs agent/crates/layerx-agentd/tests/budget_create.rs"
+symbol = "fixture"
+observed = "After rebasing the named-field Human peer parser onto main, cargo fmt --check --manifest-path agent/Cargo.toml -p layerx-agentd and cargo clippy --locked --manifest-path agent/Cargo.toml -p layerx-agentd --all-targets -- -D warnings exit 0. cargo test --locked --manifest-path agent/Cargo.toml -p layerx-agentd exits 101 at budget_create: the real-node harness requires uid 0 but executes as uid 1000; subsequent fixture users report a poisoned lock. The three availability tests pass. Evidence: qual-logs/fmt.log, qual-logs/clippy.log, qual-logs/test.log and qual-logs/gates.tsv. make beta-ledger-check exits 0 (qual-logs/ledger.log)."
+assumption = "Full package qualification requires a root execution environment and qualified native binaries; /root/lx-lanes/native-bin is absent on this host. No harness assertions were changed. Cluster and image gates were not run."
+severity = "blocker"


### PR DESCRIPTION
Replaces the positional colon-separated LAYERX_AGENT_HUMAN_PEERS format, which mis-split DID principals containing colons, with named uid/tenant/principal fields. The old shape is refused with an indexed typed configuration error; there is no dual-format acceptance. Adds parsing tests and documents the variable in the wiki.

Gates: cargo clippy -D warnings, focused agentd tests (8 passing), touched-file formatting, make beta-ledger-check. Full package tests need native binaries and are recorded in the ledger. Cluster producers of the variable live on the Human transport branch and adopt the new format there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)