### PR TITLE
Restore agentd formatting so the fmt gate passes

### DIFF
--- a/agent/crates/layerx-agentd/src/export.rs
+++ b/agent/crates/layerx-agentd/src/export.rs
@@ -31,8 +31,8 @@ pub fn build(
     {
         return Err(ExportBuildError::Empty);
     }
-    let local_verification = verify(&artifact, expected_settlement_domain)
-        .map_err(ExportBuildError::Verification)?;
+    let local_verification =
+        verify(&artifact, expected_settlement_domain).map_err(ExportBuildError::Verification)?;
     Ok(BuiltExport {
         artifact,
         local_verification,

--- a/agent/crates/layerx-agentd/src/policy/eval.rs
+++ b/agent/crates/layerx-agentd/src/policy/eval.rs
@@ -196,13 +196,11 @@ impl RuleMatcher for DeterministicMatcher {
             && constraints
                 .maximum_cumulative_amount
                 .is_none_or(|maximum| cumulative_amount <= maximum)
-            && constraints
-                .maximum_cumulative_count
-                .is_none_or(|maximum| {
-                    input
-                        .authenticated_cumulative_count()
-                        .is_some_and(|count| count <= maximum)
-                })
+            && constraints.maximum_cumulative_count.is_none_or(|maximum| {
+                input
+                    .authenticated_cumulative_count()
+                    .is_some_and(|count| count <= maximum)
+            })
             && (constraints.purposes.is_empty() || constraints.purposes.contains(&request.purpose))
             && (constraints.capability_ids.is_empty()
                 || constraints.capability_ids.contains(&input.capability.id))

--- a/agent/crates/layerx-agentd/tests/budget_unknown.rs
+++ b/agent/crates/layerx-agentd/tests/budget_unknown.rs
@@ -45,7 +45,7 @@ fn process_loss_between_submission_and_receipt_preserves_unknown_hold() {
         &protocol(0),
         &support::evidence_verifier(),
     )
-        .unwrap_or_else(|error| panic!("rebuild: {error:?}"));
+    .unwrap_or_else(|error| panic!("rebuild: {error:?}"));
     assert_eq!(accounting.held_unresolved, 400);
     assert_eq!(accounting.unresolved_count, 1);
     assert_eq!(accounting.protocol_consumed, None);

--- a/agent/crates/layerx-agentd/tests/operator.rs
+++ b/agent/crates/layerx-agentd/tests/operator.rs
@@ -116,8 +116,7 @@ fn inspections_and_unavailable_budget_reconciliation_are_audited_before_refusal(
         evidence: support::raw_receipt_at([0x44; 32], 0, 7, 90),
     }];
     assert!(matches!(
-        surface
-            .reconcile_budget_divergence(
+        surface.reconcile_budget_divergence(
             &context(2),
             [2; 32],
             &mut local,


### PR DESCRIPTION
Formatting-only reflow of four agentd files that failed cargo fmt --check on main. No semantic changes.

Gates: cargo fmt --check, cargo clippy --all-targets -D warnings, cargo test --no-run for layerx-agentd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)