### PR TITLE
Link the wave-12 native tests and report DA-unavailable failures

### DIFF
--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -5196,4 +5196,11 @@ file = "Makefile tests/test_guarantor_duties.c tests/test_da_retrieval.c tests/t
 symbol = "test-wave-12 test-guarantor test-da-retrieval test-da-unavailable"
 observed = "make test-wave-12 exits 2: test_guarantor_duties and test_da_retrieval fail to link Programs runtime symbols including layerx_programs_consume_program_spend_authorization and layerx_programs_interface_validate; test-da-unavailable exits 1 without an assertion diagnostic. Raw output is qual-logs/nat1/wave12.log. make -j16, make test-guarantor-bond, make test and make beta-ledger-check each exit 0. The finalisation refusal output is cleared before argument and guarantor-set validation; the existing guarantor bond assertion predicates are unchanged."
 assumption = "The broader aggregate is not qualified. Its Programs runtime link wiring and DA unavailability failure require separate task-scoped diagnosis; no assertion or return code was weakened to bypass them."
+
+[observation.6.1.39]
+task = "6.1"
+file = "tests/test_guarantor_bond.c Makefile"
+symbol = "main test-guarantor-bond test-wave-12"
+observed = "make test-wave-12 exits 2 because build/tests/test_guarantor_bond exits 1; reproduced after the Programs runtime build completes. Logs: qual-logs/nat2/wave12.log and qual-logs/nat2/wave12-final.log with sibling exit files. make test-guarantor test-da-retrieval test-da-unavailable exits 0, including both real Programs runtime links and every withheld DA class. make -j16 and make test exit 0. Logs: qual-logs/nat2/focused.log, build.log and test.log with sibling exit files."
+assumption = "The bond fixture or its native implementation requires separate diagnosis and repair in its owning scope. The historical link and canonical DA fixture fixes are present in the checkout. DA refusal predicates and exit codes remain unchanged; assertion reporting identifies individual failures. Image and cluster gates were not run."
 severity = "blocker"

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -5196,6 +5196,7 @@ file = "Makefile tests/test_guarantor_duties.c tests/test_da_retrieval.c tests/t
 symbol = "test-wave-12 test-guarantor test-da-retrieval test-da-unavailable"
 observed = "make test-wave-12 exits 2: test_guarantor_duties and test_da_retrieval fail to link Programs runtime symbols including layerx_programs_consume_program_spend_authorization and layerx_programs_interface_validate; test-da-unavailable exits 1 without an assertion diagnostic. Raw output is qual-logs/nat1/wave12.log. make -j16, make test-guarantor-bond, make test and make beta-ledger-check each exit 0. The finalisation refusal output is cleared before argument and guarantor-set validation; the existing guarantor bond assertion predicates are unchanged."
 assumption = "The broader aggregate is not qualified. Its Programs runtime link wiring and DA unavailability failure require separate task-scoped diagnosis; no assertion or return code was weakened to bypass them."
+severity = "blocker"
 
 [observation.6.1.39]
 task = "6.1"

--- a/tests/test_da_unavailable.c
+++ b/tests/test_da_unavailable.c
@@ -13,6 +13,15 @@
 #include <string.h>
 #include <unistd.h>
 
+#define FAIL_IF(condition, code) do { \
+    if (condition) { \
+        (void)fprintf(stderr, "%s:%d: DA class %s: failed: %s (exit %d)\n", \
+                      __FILE__, __LINE__, argc > 1 ? argv[1] : "<missing>", \
+                      #condition, (code)); \
+        return (code); \
+    } \
+} while (0)
+
 static int key_pair(uint8_t value, uint8_t private_key[32],
                     uint8_t public_key[33])
 {
@@ -67,16 +76,16 @@ int main(int argc, char **argv)
     size_t i;
     size_t j;
 
-    if (argc != 2) return 2;
+    FAIL_IF(argc != 2, 2);
     withheld_class = class_from_name(argv[1]);
-    if (withheld_class == 0) return 2;
+    FAIL_IF(withheld_class == 0, 2);
     for (i = 0U; i < 5U; ++i)
         for (j = 0U; j < sizeof(section[i]); ++j)
             section[i][j] = (uint8_t)(1U + i * 16U + j);
-    if (mkdtemp(directory) == NULL ||
-        lxp_arena_init(&arena, arena_storage, sizeof(arena_storage)) != LXP_OK ||
-        lxp_da_store_init(&store, directory) != LXP_OK)
-        return 1;
+    FAIL_IF(mkdtemp(directory) == NULL, 1);
+    FAIL_IF(lxp_arena_init(&arena, arena_storage, sizeof(arena_storage)) !=
+            LXP_OK, 1);
+    FAIL_IF(lxp_da_store_init(&store, directory) != LXP_OK, 1);
     (void)memset(&body, 0, sizeof(body));
     body.header.batch_number = 51U;
     body.activities = (lxp_byte_span){section[0], sizeof(section[0])};
@@ -84,15 +93,15 @@ int main(int argc, char **argv)
     body.oracle_inputs = (lxp_byte_span){section[2], sizeof(section[2])};
     body.state_diff = (lxp_byte_span){section[3], sizeof(section[3])};
     body.recovery_metadata = (lxp_byte_span){section[4], sizeof(section[4])};
-    if (lxp_da_bundle_build(&body, LXP_DA_CANONICAL_CHUNK_BYTES, &arena, &complete) != LXP_OK ||
-        lxp_da_bundle_root(&complete, &arena, complete_root) != LXP_OK ||
-        lxp_da_withhold_sim(&complete, withheld_class, &arena, &withheld,
-                            &available_mask) != LXP_OK ||
-        available_mask != (uint8_t)(LXP_GUARANTOR_AVAILABILITY_ALL &
-            (uint8_t)~(uint8_t)(1U << ((uint8_t)withheld_class - 1U))))
-        return 1;
-    if (lxp_da_store_bundle(&store, &withheld, &arena) != LXP_ERR_DA_MISSING)
-        return 1;
+    FAIL_IF(lxp_da_bundle_build(&body, LXP_DA_CANONICAL_CHUNK_BYTES,
+                                &arena, &complete) != LXP_OK, 1);
+    FAIL_IF(lxp_da_bundle_root(&complete, &arena, complete_root) != LXP_OK, 1);
+    FAIL_IF(lxp_da_withhold_sim(&complete, withheld_class, &arena, &withheld,
+                                 &available_mask) != LXP_OK, 1);
+    FAIL_IF(available_mask != (uint8_t)(LXP_GUARANTOR_AVAILABILITY_ALL &
+            (uint8_t)~(uint8_t)(1U << ((uint8_t)withheld_class - 1U))), 1);
+    FAIL_IF(lxp_da_store_bundle(&store, &withheld, &arena) !=
+            LXP_ERR_DA_MISSING, 1);
     (void)memset(&checkpoint, 0, sizeof(checkpoint));
     checkpoint.header.protocol_version = 1U;
     checkpoint.header.network_id = 44U;
@@ -110,11 +119,11 @@ int main(int argc, char **argv)
     guarantor.network_id = 44U;
     guarantor.paxeer_chain_id = 31337U;
     guarantor.paxeer_settlement_contract[0] = 0xa1U;
-    if (key_pair(11U, guarantor.paxeer_private_key,
-                 guarantor.paxeer_public_key) != 0 ||
-        lxp_da_possession_attest(&store, &guarantor, &checkpoint, 2000U,
-                                 &arena, &attestation) != LXP_ERR_DA_MISSING)
-        return 1;
+    FAIL_IF(key_pair(11U, guarantor.paxeer_private_key,
+                     guarantor.paxeer_public_key) != 0, 1);
+    FAIL_IF(lxp_da_possession_attest(&store, &guarantor, &checkpoint, 2000U,
+                                      &arena, &attestation) !=
+            LXP_ERR_DA_MISSING, 1);
 
     (void)memset(&state, 0, sizeof(state));
     (void)memset(anchor, 0x5a, sizeof(anchor));
@@ -127,33 +136,33 @@ int main(int argc, char **argv)
     state.pending_withdrawal_settlement_enabled = true;
     state.pending_deposit_settlement_enabled = true;
     state.pending_dispute_settlement_enabled = true;
-    if (lxp_checkpoint_block_on_da(&state, 51U, false) !=
-            LXP_ERR_DA_MISSING ||
-        !state.unfinalized_checkpoint_blocked ||
-        state.blocked_checkpoint_batch_number != 51U ||
-        state.pending_withdrawal_settlement_enabled ||
-        state.pending_deposit_settlement_enabled ||
-        state.pending_dispute_settlement_enabled ||
-        memcmp(state.settlement_anchor, anchor, 32U) != 0 ||
-        !state.withdrawal_settlement_enabled)
-        return 1;
-    if (lxp_da_unavailable_mode(&state, 50U, false, false) !=
-            LXP_ERR_DA_MISSING ||
-        !state.checkpoint_finalized || !state.emergency_data_mode ||
-        !state.emergency_exit_enabled || !state.finalisation_halted ||
-        state.finalized_batch_number != 50U ||
-        memcmp(state.settlement_anchor, anchor, 32U) != 0)
-        return 1;
-    if (lxp_da_unavailable_mode(&state, 50U, true, false) != LXP_OK ||
-        state.emergency_data_mode || state.finalisation_halted ||
-        state.emergency_exit_enabled)
-        return 1;
-    if (lxp_da_unavailable_mode(&state, 50U, false, false) !=
-            LXP_ERR_DA_MISSING ||
-        lxp_da_unavailable_mode(&state, 50U, false, true) != LXP_OK ||
-        state.emergency_data_mode || state.finalisation_halted ||
-        state.unfinalized_checkpoint_blocked)
-        return 1;
-    if (rmdir(directory) != 0) return 1;
+    FAIL_IF(lxp_checkpoint_block_on_da(&state, 51U, false) !=
+            LXP_ERR_DA_MISSING, 1);
+    FAIL_IF(!state.unfinalized_checkpoint_blocked, 1);
+    FAIL_IF(state.blocked_checkpoint_batch_number != 51U, 1);
+    FAIL_IF(state.pending_withdrawal_settlement_enabled, 1);
+    FAIL_IF(state.pending_deposit_settlement_enabled, 1);
+    FAIL_IF(state.pending_dispute_settlement_enabled, 1);
+    FAIL_IF(memcmp(state.settlement_anchor, anchor, 32U) != 0, 1);
+    FAIL_IF(!state.withdrawal_settlement_enabled, 1);
+    FAIL_IF(lxp_da_unavailable_mode(&state, 50U, false, false) !=
+            LXP_ERR_DA_MISSING, 1);
+    FAIL_IF(!state.checkpoint_finalized, 1);
+    FAIL_IF(!state.emergency_data_mode, 1);
+    FAIL_IF(!state.emergency_exit_enabled, 1);
+    FAIL_IF(!state.finalisation_halted, 1);
+    FAIL_IF(state.finalized_batch_number != 50U, 1);
+    FAIL_IF(memcmp(state.settlement_anchor, anchor, 32U) != 0, 1);
+    FAIL_IF(lxp_da_unavailable_mode(&state, 50U, true, false) != LXP_OK, 1);
+    FAIL_IF(state.emergency_data_mode, 1);
+    FAIL_IF(state.finalisation_halted, 1);
+    FAIL_IF(state.emergency_exit_enabled, 1);
+    FAIL_IF(lxp_da_unavailable_mode(&state, 50U, false, false) !=
+            LXP_ERR_DA_MISSING, 1);
+    FAIL_IF(lxp_da_unavailable_mode(&state, 50U, false, true) != LXP_OK, 1);
+    FAIL_IF(state.emergency_data_mode, 1);
+    FAIL_IF(state.finalisation_halted, 1);
+    FAIL_IF(state.unfinalized_checkpoint_blocked, 1);
+    FAIL_IF(rmdir(directory) != 0, 1);
     return 0;
 }

--- a/tools/lxp_da_withhold.sh
+++ b/tools/lxp_da_withhold.sh
@@ -9,7 +9,13 @@ run_class() {
         activities|receipts|oracle|state-diff|recovery) ;;
         *) echo "unknown DA class: $1" >&2; exit 2 ;;
     esac
-    "$binary" "$1"
+    if "$binary" "$1"; then
+        printf 'DA class %s: passed (exit 0)\n' "$1"
+    else
+        status=$?
+        printf 'DA class %s: %s failed (exit %s)\n' "$1" "$binary" "$status" >&2
+        exit "$status"
+    fi
 }
 
 if [ "$mode" = all ]; then


### PR DESCRIPTION
Rebased native wave-12 tests onto main, retaining the finalisation fix, Programs runtime link dependencies, DA-withhold assertion reporting, and every qualification record from both branches. Restored the severity field misplaced by the automatic merge.

Qualified source is committed at `991a66cec7c1acba1c51aab49cfa9e10d085074e`. Environment: `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4 LAYERX_TEST_NATIVE_BIN_DIR=/root/lx-lanes/native-bin`.

| Command | Exit | Log |
| --- | --- | --- |
| `make -j8` | 0 | `qual-logs/nat2b/make.log` |
| `make test-wave-12` | 0 | `qual-logs/nat2b/test-wave-12.log` |
| `make beta-ledger-check` | 0 | `qual-logs/nat2b/beta-ledger-check.log` |

Logs are untracked under `/root/lx-lanes/nat2/`. The fetch/rebase sequence ran exactly once. All prior ledger records match their original contents; the ledger check passes with unique record identifiers.

🤖 Generated with Codex
