### PR TITLE
Route bridge reserve credits through the ledger balance owner

### DIFF
--- a/include/layerx/lxp_transfer.h
+++ b/include/layerx/lxp_transfer.h
@@ -112,6 +112,9 @@ lxp_result lxp_ledger_bootstrap_balance(lx_account *account,
                                         const uint8_t asset_id[32],
                                         lxp_u128 balance,
                                         uint64_t next_sequence);
+lxp_result lxp_ledger_apply_bridge_credit(lx_account *reserve,
+                                           const uint8_t asset_id[32],
+                                           lxp_u128 amount);
 lxp_result lxp_ledger_restore_account_snapshot(lx_account *account,
                                                lxp_u128 balance,
                                                const uint8_t asset_id[32],

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -5205,3 +5205,18 @@ symbol = "main test-guarantor-bond test-wave-12"
 observed = "make test-wave-12 exits 2 because build/tests/test_guarantor_bond exits 1; reproduced after the Programs runtime build completes. Logs: qual-logs/nat2/wave12.log and qual-logs/nat2/wave12-final.log with sibling exit files. make test-guarantor test-da-retrieval test-da-unavailable exits 0, including both real Programs runtime links and every withheld DA class. make -j16 and make test exit 0. Logs: qual-logs/nat2/focused.log, build.log and test.log with sibling exit files."
 assumption = "The bond fixture or its native implementation requires separate diagnosis and repair in its owning scope. The historical link and canonical DA fixture fixes are present in the checkout. DA refusal predicates and exit codes remain unchanged; assertion reporting identifies individual failures. Image and cluster gates were not run."
 severity = "blocker"
+[observation.6.11.127]
+task = "6.11"
+file = "tests/modules/test_asset_deposit.c src/modules/asset/lx_asset_custody.c Makefile"
+symbol = "test-asset-deposit"
+observed = "make test-asset-balance test-asset-deposit test-asset-withdraw exits 2 because build/tests/test_asset_deposit exits 1 without an assertion diagnostic. Relinking the same test against the original src/protocol/lxp_module_ctx.c from 97444fe2a9849672715ca1dc559dcd19ccac7a8e also exits 1. The balance and withdrawal targets pass separately. Evidence: qual-logs/nat3/asset-regressions.log, deposit-baseline-build.log, deposit-baseline.log, asset-balance-withdraw.log and gates.tsv."
+assumption = "The existing deposit-test failure requires separate asset-custody diagnosis. The ledger ownership change and the original module-context implementation produce the same failure; existing assertions remain unchanged."
+severity = "blocker"
+
+[observation.6.11.128]
+task = "6.11"
+file = "src/ledger/lxp_apply.c src/protocol/lxp_module_ctx.c include/layerx/lxp_transfer.h tests/bridge/sole_writer.sh tests/bridge/test_credit.c tests/bridge/qualify_credit.py tests/modules/test_asset_transfer.c"
+symbol = "lxp_ledger_apply_bridge_credit lxp_ctx_bridge_credit"
+observed = "The bridge reserve top-up now invokes ledger apply after the existing authorization, supply preflight and rollback snapshot. make -j16, make test-asset-transfer, make test and make beta-ledger-check exit 0. The unchanged sole-writer check passes. BRIDGE_PYTHON=qual-logs/nat3/venv/bin/python3 bash tests/bridge/sole_writer.sh exits 0: a real custody deposit on isolated chain 31337 produces byte-identical canonical account state diffs (397 bytes) and unsigned receipt encodings (1006 bytes) through original and updated module contexts, with real signature verification, rollback stages, replay refusal and nine custody evidence tests passing. Evidence: qual-logs/nat3/build.log, asset-transfer.log, test.log, beta-ledger.log, bridge-differential-venv.log and gates.tsv."
+assumption = "The initial bridge comparison exited 1 because system Python lacked Crypto; the isolated virtual environment satisfies tests/bridge/requirements.txt. Codify inspection could not run because cg is unavailable. Cluster and image gates were not run. Task statuses are unchanged."
+severity = "note"

--- a/src/ledger/lxp_apply.c
+++ b/src/ledger/lxp_apply.c
@@ -104,6 +104,23 @@ lxp_result lxp_ledger_bootstrap_balance(lx_account *account,
     return LXP_OK;
 }
 
+lxp_result lxp_ledger_apply_bridge_credit(lx_account *reserve,
+                                           const uint8_t asset_id[32],
+                                           lxp_u128 amount)
+{
+    lxp_u128 next_balance;
+    lxp_result status;
+    if (reserve == NULL || asset_id == NULL) return LXP_ERR_NON_CANONICAL;
+    if (reserve->kind != LX_ACCOUNT_SYSTEM_PAXEER_RESERVE || reserve->frozen ||
+        !reserve->has_asset || memcmp(reserve->asset_id, asset_id, 32U) != 0 ||
+        reserve->next_sequence == UINT64_MAX)
+        return LXP_ERR_UNAUTHORIZED_DEBIT;
+    status = lxp_u128_add(reserve->balance, amount, &next_balance);
+    if (status != LXP_OK) return status;
+    reserve->balance = next_balance;
+    return LXP_OK;
+}
+
 lxp_result lxp_ledger_restore_account_snapshot(lx_account *account,
                                                lxp_u128 balance,
                                                const uint8_t asset_id[32],

--- a/src/protocol/lxp_module_ctx.c
+++ b/src/protocol/lxp_module_ctx.c
@@ -1376,7 +1376,11 @@ lxp_result lxp_ctx_bridge_credit(lxp_module_ctx *ctx,
     ctx->transfer_snapshots[0].next_sequence = reserve->next_sequence;
     (void)memcpy(ctx->transfer_snapshots[0].asset_id, reserve->asset_id, 32U);
     ctx->transfer_snapshot_count = 1U;
-    reserve->balance = next_reserve;
+    status = lxp_ledger_apply_bridge_credit(reserve, profile.bytes + 97U, amount);
+    if (status != LXP_OK) {
+        lxp_module_ctx_rollback(ctx);
+        return status;
+    }
 #ifdef LXP_TESTING
     if (ctx->bridge_credit_fail_stage == 2U) {
         lxp_module_ctx_rollback(ctx);

--- a/tests/bridge/qualify_credit.py
+++ b/tests/bridge/qualify_credit.py
@@ -60,6 +60,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--build-dir', default='build')
     parser.add_argument('--maintenance', action='store_true')
+    parser.add_argument('--compare-baseline', type=Path)
     args = parser.parse_args()
     build = (ROOT / args.build_dir).resolve()
     evidence = ROOT / 'build' / 'custody-qualification'
@@ -113,6 +114,19 @@ def main():
                     work / 'actor', '0', timestamp, work / 'activity')
                 run(build / 'tests/bridge/test-credit', work / 'genesis-output/genesis.manifest',
                     work / 'activity', work / 'actor')
+                if args.compare_baseline:
+                    inputs = [work / 'genesis-output/genesis.manifest', work / 'activity', work / 'actor']
+                    run(args.compare_baseline.resolve(), *inputs, work / 'before.bin')
+                    run(build / 'tests/bridge/test-credit', *inputs, work / 'after.bin')
+                    before = (work / 'before.bin').read_bytes()
+                    after = (work / 'after.bin').read_bytes()
+                    if before != after:
+                        raise AssertionError('bridge-credit state diff or receipt bytes changed')
+                    diff_size = int.from_bytes(before[:8], 'big')
+                    receipt_size = int.from_bytes(before[8:16], 'big')
+                    if not diff_size or not receipt_size or len(before) != 16 + diff_size + receipt_size:
+                        raise AssertionError('invalid comparison framing')
+                    print(f'byte-identical bridge-credit state diff ({diff_size}) and receipt ({receipt_size})')
                 if args.maintenance:
                     run(build / 'tests/lxp_test_maintenance_publication',
                         work / 'genesis-output/genesis.manifest', work / 'activity')

--- a/tests/bridge/sole_writer.sh
+++ b/tests/bridge/sole_writer.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+export CARGO_BUILD_JOBS=16 MAKEFLAGS=-j16
+baseline=97444fe2a9849672715ca1dc559dcd19ccac7a8e
+work=qual-logs/nat3/sole-writer
+mkdir -p "$work"
+git show "$baseline:src/protocol/lxp_module_ctx.c" > "$work/lxp_module_ctx.c"
+cat > "$work/baseline.mk" <<'MAKE'
+qual-logs/nat3/sole-writer/module_ctx.o: qual-logs/nat3/sole-writer/lxp_module_ctx.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DLXP_TESTING -c $< -o $@
+qual-logs/nat3/sole-writer/test-credit-before: tests/bridge/test_credit.c qual-logs/nat3/sole-writer/module_ctx.o $(TEST_LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
+	$(CC) $(CPPFLAGS) $(CFLAGS) -DLXP_TESTING $< qual-logs/nat3/sole-writer/module_ctx.o $(TEST_LIBRARY) $(PROGRAMS_RUNTIME_LIB) $(TEST_LIBRARY) $(EXTRA_LDFLAGS) -lcrypto -pthread -ldl -lm -o $@
+MAKE
+make -f Makefile -f "$work/baseline.mk" "$work/test-credit-before" \
+    build/tests/bridge/sign-credit build/tests/bridge/test-credit build/bin/layerx-genesis-build
+"${BRIDGE_PYTHON:-python3}" tests/bridge/qualify_credit.py \
+    --compare-baseline "$work/test-credit-before"

--- a/tests/bridge/test_credit.c
+++ b/tests/bridge/test_credit.c
@@ -3,6 +3,7 @@
 #include "layerx/lxp_crypto.h"
 #include "layerx/lxp_hash.h"
 #include "layerx/lxp_kernel.h"
+#include "layerx/lxp_state_diff.h"
 #include "layerx/lx_asset.h"
 #include "layerx/programs.h"
 #include "files.h"
@@ -152,8 +153,8 @@ int main(int argc, char **argv)
     size_t value_length;
     uint8_t supply_key[47] = "custody-issued:";
     uint8_t replay_key[50] = "deposit-nullifier:";
-    if (argc != 4) {
-        (void)fprintf(stderr, "usage: test-credit genesis.manifest signed-credit.activity actor-key\n");
+    if (argc != 4 && argc != 5) {
+        (void)fprintf(stderr, "usage: test-credit genesis.manifest signed-credit.activity actor-key [comparison-output]\n");
         return 2;
     }
     CHECK(arena_bytes && manifest && state && journal && kernel && accounts && before && ctx && effects);
@@ -314,6 +315,24 @@ int main(int argc, char **argv)
     CHECK(lxp_state_root_proof(kernel, LXP_MODULE_BRIDGE, root, &proof) == LXP_OK);
     CHECK(prove_leaf(bridge_key, sizeof(bridge_key), bridge_root, 32U, &proof, root) == 0);
     CHECK(memcmp(root, funding_receipt.resulting_state_root, 32U) == 0);
+    if (argc == 5) {
+        lxp_byte_span diff_bytes;
+        lxp_byte_span receipt_bytes;
+        CHECK(lxp_state_diff_encode(before, accounts, &arena, &diff_bytes) == LXP_OK);
+        CHECK(lxp_receipt_encode(&funding_receipt, false, &arena, &receipt_bytes) == LXP_OK);
+        CHECK(diff_bytes.length > 0U && receipt_bytes.length > 0U);
+        FILE *output = fopen(argv[4], "wbx");
+        CHECK(output != NULL);
+        uint8_t lengths[16];
+        for (size_t index = 0U; index < 8U; ++index) {
+            lengths[index] = (uint8_t)((uint64_t)diff_bytes.length >> (56U - index * 8U));
+            lengths[8U + index] = (uint8_t)((uint64_t)receipt_bytes.length >> (56U - index * 8U));
+        }
+        CHECK(fwrite(lengths, 1U, sizeof(lengths), output) == sizeof(lengths));
+        CHECK(fwrite(diff_bytes.bytes, 1U, diff_bytes.length, output) == diff_bytes.length);
+        CHECK(fwrite(receipt_bytes.bytes, 1U, receipt_bytes.length, output) == receipt_bytes.length);
+        CHECK(fclose(output) == 0);
+    }
     CHECK(begin(ctx, kernel, &arena, effects, state->next_sequence) == 0);
     altered_activity = activity;
     ++altered_activity.account_sequence;

--- a/tests/modules/test_asset_transfer.c
+++ b/tests/modules/test_asset_transfer.c
@@ -98,8 +98,45 @@ static int init_ctx(lxp_module_ctx *ctx, lxp_kernel *kernel, lxp_arena *arena,
     return lxp_module_ctx_bind_effects(ctx, effects) == LXP_OK ? 0 : 1;
 }
 
+static int bridge_reserve_credit(void)
+{
+    const uint8_t asset[32] = {1U};
+    const lxp_u128 amount = {0U, 1U};
+    lx_account reserve = {0};
+    lx_account before;
+    reserve.kind = LX_ACCOUNT_SYSTEM_PAXEER_RESERVE;
+    if (lxp_ledger_bootstrap_balance(&reserve, asset,
+            (lxp_u128){0U, UINT64_MAX}, 7U) != LXP_OK)
+        return 1;
+    before = reserve;
+    if (lxp_ledger_apply_bridge_credit(&reserve, asset, amount) != LXP_OK ||
+        reserve.balance.hi != 1U || reserve.balance.lo != 0U ||
+        reserve.next_sequence != before.next_sequence)
+        return 1;
+    before.balance = reserve.balance;
+    if (memcmp(&reserve, &before, sizeof(reserve)) != 0) return 1;
+    for (unsigned int failure = 0U; failure < 6U; ++failure) {
+        reserve = before;
+        switch (failure) {
+        case 0U: reserve.kind = LX_ACCOUNT_AGENT_MAIN; break;
+        case 1U: reserve.frozen = true; break;
+        case 2U: reserve.has_asset = false; break;
+        case 3U: reserve.asset_id[0] ^= 1U; break;
+        case 4U: reserve.next_sequence = UINT64_MAX; break;
+        case 5U: reserve.balance = (lxp_u128){UINT64_MAX, UINT64_MAX}; break;
+        }
+        lx_account unchanged = reserve;
+        if (lxp_ledger_apply_bridge_credit(&reserve, asset, amount) == LXP_OK ||
+            memcmp(&reserve, &unchanged, sizeof(reserve)) != 0)
+            return 1;
+    }
+    return lxp_ledger_apply_bridge_credit(NULL, asset, amount) != LXP_OK &&
+           lxp_ledger_apply_bridge_credit(&reserve, NULL, amount) != LXP_OK ? 0 : 1;
+}
+
 int main(void)
 {
+    if (bridge_reserve_credit() != 0) return 1;
     static const uint8_t seed[32] = {
         0x9dU, 0x61U, 0xb1U, 0x9dU, 0xefU, 0xfdU, 0x5aU, 0x60U,
         0xbaU, 0x84U, 0x4aU, 0xf4U, 0x92U, 0xecU, 0x2cU, 0xc4U,


### PR DESCRIPTION
Bridge reserve credits now go through the ledger apply path, preserving the existing authorization, supply preflight and rollback behavior. The sole-writer check remains unchanged.

Rebased onto main at `25b21de3` with one fetch/rebase invocation. The rebase completed without conflicts or source repairs. All observation records from main and the original branch are preserved, with unique IDs. Published head: `c55407b5ee7edef5a3ad7df3f5ce638e92d9249a`.

Qualification after rebase (logs are untracked under `/root/lx-lanes/nat3/`):

| Command | Exit code | Log |
| --- | --- | --- |
| `make -j16` | 0 | `qual-logs/nat3b/build.log` |
| `make test-asset-transfer` | 0 | `qual-logs/nat3b/asset-transfer.log` |
| `bash tools/lxp_check_sole_writer.sh` | 0 | `qual-logs/nat3b/sole-writer.log` |
| `make test` | 0 | `qual-logs/nat3b/test.log` |
| `make beta-ledger-check` | 0 | `qual-logs/nat3b/beta-ledger.log` |

Environment: `CARGO_BUILD_JOBS=4 MAKEFLAGS=-j4`; the requested build command explicitly uses `-j16`.

The prior asset-deposit failure remains recorded in observation 6.11.127; that separate gate was not rerun for this rebase. No checks were weakened and no task statuses were changed.

🤖 Generated with Codex
