### PR TITLE
Prove public account and balance reads at the core and verify them in the SDK

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -921,6 +921,7 @@ dependencies = [
 name = "layerx-sdk"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
  "layerx-agent-api",
  "layerx-client",
  "layerx-crypto",

--- a/agent/crates/layerx-client/src/evidence.rs
+++ b/agent/crates/layerx-client/src/evidence.rs
@@ -12,10 +12,11 @@ use layerx_proof::inclusion::{
 use layerx_proof::merkle::{MerkleError, Proof, MAX_DEPTH};
 use layerx_proof::receipt::verify_sequencer_signature;
 use layerx_proof::state::{
-    verify_nested_account, verify_nested_account_maintenance, AccountProofError,
+    verify_nested_account, verify_nested_account_maintenance, AccountProofError, CanonicalAccount,
     NestedAccountProof, VerifiedAccountState, VerifiedMaintenanceAccountState,
 };
 use layerx_types::payload::ModuleRegistry;
+use layerx_types::verify::VerificationLevel;
 use layerx_wire::activity::{decode_signed, encode_signed};
 use layerx_wire::hash::activity_id;
 use layerx_wire::maintenance::decode_occupancy_maintenance;
@@ -740,6 +741,162 @@ fn account_proof_bundle(
         proof_material: response.proof,
         activity_id: target_activity_id,
         verified: Box::new(verified),
+        signed_header: decoded.signed_header,
+    })
+}
+
+/// Returns the public-read label naming the level a proof established, and
+/// `None` for any level below `STATE_PROVEN`, which no state proof reaches.
+#[must_use]
+pub const fn verification_label(level: VerificationLevel) -> Option<&'static str> {
+    match level.wire_rank() {
+        3 => Some("state_proven"),
+        4 => Some("checkpoint_finalised"),
+        5 => Some("settlement_anchored"),
+        _ => None,
+    }
+}
+
+/// Trusted coordinates for verifying exported account-state evidence outside a
+/// live point read: the pinned sequencer key and the domain the value binds to.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AccountEvidencePolicy {
+    pub expected_protocol_version: u16,
+    pub expected_network_id: u32,
+    pub handshake_sequencer_key: [u8; 32],
+    pub root_selector: RootSelector,
+}
+
+/// An account value whose nested state proof, signed batch header and
+/// sequencer authority verified locally from exported bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedAccountEvidence {
+    account: CanonicalAccount,
+    level: VerificationLevel,
+    observed_sequence: u64,
+    batch_number: u64,
+    state_root: [u8; 32],
+    signed_header: SignedHeader,
+}
+
+impl VerifiedAccountEvidence {
+    /// Borrows the canonical account committed by the proven state root.
+    #[must_use]
+    pub const fn account(&self) -> &CanonicalAccount {
+        &self.account
+    }
+
+    /// Returns the level this verification actually established.
+    #[must_use]
+    pub const fn level(&self) -> VerificationLevel {
+        self.level
+    }
+
+    /// Returns the global sequence the proven value was observed at.
+    #[must_use]
+    pub const fn observed_sequence(&self) -> u64 {
+        self.observed_sequence
+    }
+
+    /// Returns the batch number of the signed header carrying the state root.
+    #[must_use]
+    pub const fn batch_number(&self) -> u64 {
+        self.batch_number
+    }
+
+    /// Returns the proven resulting state root.
+    #[must_use]
+    pub const fn state_root(&self) -> [u8; 32] {
+        self.state_root
+    }
+
+    /// Borrows the signed header the proof chain terminated in.
+    #[must_use]
+    pub const fn signed_header(&self) -> &SignedHeader {
+        &self.signed_header
+    }
+}
+
+/// Verifies exported account-state bytes against their nested proof material
+/// without a live connection, so a value served over a public interface stays
+/// checkable by whoever received it.
+///
+/// # Errors
+///
+/// Refuses malformed evidence, a root-selector or account substitution, a
+/// header outside the pinned handshake key, and every nested proof, receipt,
+/// header and maintenance-settlement failure.
+pub fn verify_account_evidence(
+    canonical_value: &[u8],
+    proof_material: &[u8],
+    account: [u8; 32],
+    asset: Option<[u8; 32]>,
+    policy: AccountEvidencePolicy,
+) -> Result<VerifiedAccountEvidence, EvidenceError> {
+    let decoded = decode_nested_evidence(
+        proof_material,
+        policy.expected_protocol_version,
+        policy.expected_network_id,
+    )?;
+    if decoded.selector != policy.root_selector || decoded.proof.account_id != account {
+        return Err(EvidenceError::SelectorMismatch);
+    }
+    let authorization = decoded.signed_header.pinned_key_authorization(
+        policy.handshake_sequencer_key,
+        policy.expected_protocol_version,
+        policy.expected_network_id,
+    )?;
+    let (value, observed_sequence, batch_number) = match decoded.kind {
+        AccountEvidenceKind::Activity => {
+            let verified = verify_nested_account(
+                canonical_value,
+                account,
+                asset,
+                &decoded.proof,
+                &authorization,
+            )
+            .map_err(EvidenceError::Account)?;
+            (
+                verified.account().clone(),
+                verified.observed_sequence(),
+                verified.header().header().batch_number(),
+            )
+        }
+        AccountEvidenceKind::Maintenance { parameter_version } => {
+            let activity_count = decoded
+                .proof
+                .receipt_proof
+                .leaf_count()
+                .checked_sub(1)
+                .ok_or(EvidenceError::Malformed)?;
+            let verified = verify_nested_account_maintenance(
+                canonical_value,
+                account,
+                asset,
+                &decoded.proof,
+                &authorization,
+                activity_count,
+                parameter_version,
+            )
+            .map_err(EvidenceError::Account)?;
+            (
+                verified.account().clone(),
+                verified.header().header().last_sequence(),
+                verified.header().header().batch_number(),
+            )
+        }
+    };
+    Ok(VerifiedAccountEvidence {
+        account: value,
+        level: decoded
+            .checkpoint
+            .as_ref()
+            .map_or(VerificationLevel::STATE_PROVEN, |checkpoint| {
+                checkpoint.report().level()
+            }),
+        observed_sequence,
+        batch_number,
+        state_root: decoded.proof.resulting_state_root,
         signed_header: decoded.signed_header,
     })
 }

--- a/agent/crates/layerx-client/tests/maintenance_reads.rs
+++ b/agent/crates/layerx-client/tests/maintenance_reads.rs
@@ -6,7 +6,9 @@ use std::thread;
 use std::time::Duration;
 
 use ed25519_dalek::{Signer as _, SigningKey};
-use layerx_client::evidence::{EvidenceError, RootSelector};
+use layerx_client::evidence::{
+    verification_label, verify_account_evidence, AccountEvidencePolicy, EvidenceError, RootSelector,
+};
 use layerx_client::head::Head;
 use layerx_client::lni::framing::{read_frame, write_frame};
 use layerx_client::lni::schema::{decode_envelope, encode_envelope, Envelope, Version};
@@ -489,6 +491,82 @@ fn read_evidence(
     assert!(server.join().is_ok(), "response writer panicked");
     fs::remove_file(path).unwrap_or_else(|error| panic!("remove socket: {error}"));
     result
+}
+
+#[test]
+fn exported_account_evidence_verifies_offline_and_refuses_substitution() {
+    for maintenance in [false, true] {
+        let (proof, authorization, value) = fixture(maintenance);
+        let wire = evidence(if maintenance { 2 } else { 1 }, &proof);
+        let policy = AccountEvidencePolicy {
+            expected_protocol_version: PROTOCOL_VERSION,
+            expected_network_id: 42,
+            handshake_sequencer_key: authorization.public_key(),
+            root_selector: RootSelector::Latest,
+        };
+        let verified = verify_account_evidence(&value, &wire, proof.account_id, None, policy)
+            .unwrap_or_else(|error| panic!("offline account evidence: {error:?}"));
+        assert_eq!(verified.level(), VerificationLevel::STATE_PROVEN);
+        assert_eq!(verification_label(verified.level()), Some("state_proven"));
+        assert_eq!(verified.observed_sequence(), 10);
+        assert_eq!(verified.batch_number(), 7);
+        assert_eq!(verified.state_root(), proof.resulting_state_root);
+        assert_eq!(verified.account().account_id, proof.account_id);
+        assert_eq!(
+            verified.signed_header().public_key,
+            authorization.public_key()
+        );
+        assert_eq!(
+            verify_account_evidence(&value, &wire, [0x99; 32], None, policy),
+            Err(EvidenceError::SelectorMismatch),
+            "account substitution {maintenance}"
+        );
+        let asset = program_account_vectors().1;
+        assert_eq!(verified.account().asset_id(), asset);
+        assert!(
+            verify_account_evidence(&value, &wire, proof.account_id, Some(asset), policy).is_ok(),
+            "held asset {maintenance}"
+        );
+        assert_eq!(
+            verify_account_evidence(&value, &wire, proof.account_id, Some([0x55; 32]), policy),
+            Err(EvidenceError::Account(AccountProofError::AssetIdentity)),
+            "asset substitution {maintenance}"
+        );
+        let foreign_key = AccountEvidencePolicy {
+            handshake_sequencer_key: [0x7a; 32],
+            ..policy
+        };
+        assert_eq!(
+            verify_account_evidence(&value, &wire, proof.account_id, None, foreign_key),
+            Err(EvidenceError::SequencerMismatch),
+            "sequencer substitution {maintenance}"
+        );
+        let foreign_network = AccountEvidencePolicy {
+            expected_network_id: policy.expected_network_id + 1,
+            ..policy
+        };
+        assert!(
+            verify_account_evidence(&value, &wire, proof.account_id, None, foreign_network)
+                .is_err(),
+            "network substitution {maintenance}"
+        );
+        let checkpoint_root = AccountEvidencePolicy {
+            root_selector: RootSelector::Checkpoint([0x11; 32]),
+            ..policy
+        };
+        assert_eq!(
+            verify_account_evidence(&value, &wire, proof.account_id, None, checkpoint_root),
+            Err(EvidenceError::SelectorMismatch),
+            "root selector substitution {maintenance}"
+        );
+        let mut changed = value.clone();
+        let last = changed.len() - 1;
+        changed[last] ^= 1;
+        assert!(
+            verify_account_evidence(&changed, &wire, proof.account_id, None, policy).is_err(),
+            "value mutation {maintenance}"
+        );
+    }
 }
 
 #[test]

--- a/agent/crates/layerx-sdk/Cargo.toml
+++ b/agent/crates/layerx-sdk/Cargo.toml
@@ -20,5 +20,8 @@ url = "=2.5.8"
 tungstenite = { version = "=0.30.0", features = ["native-tls"] }
 zeroize = "=1.9.0"
 
+[dev-dependencies]
+ed25519-dalek = "=2.2.0"
+
 [lints]
 workspace = true

--- a/agent/crates/layerx-sdk/src/rpc_verification.rs
+++ b/agent/crates/layerx-sdk/src/rpc_verification.rs
@@ -1,5 +1,9 @@
 use std::time::{Duration, Instant};
 
+use layerx_client::evidence::{
+    verification_label, verify_account_evidence, AccountEvidencePolicy, RootSelector,
+    VerifiedAccountEvidence,
+};
 use layerx_proof::inclusion::{verify_receipt, SequencerAuthorization};
 use layerx_proof::merkle::Proof;
 use layerx_wire::receipt::{decode_batch_header, Receipt};
@@ -7,6 +11,9 @@ use serde_json::Value;
 use sha2::{Digest as _, Sha256};
 
 use crate::rpc::{Commitment, RpcClient, RpcError};
+
+const MAX_ACCOUNT_VALUE_BYTES: usize = 4_096;
+const MAX_ACCOUNT_PROOF_BYTES: usize = 1_048_576;
 
 pub struct ReceiptPolicy {
     pub protocol_version: u16,
@@ -78,7 +85,139 @@ impl VerifiedBatchEvidence {
     }
 }
 
+/// Trust pinned by a caller for a public account read: the domain the value
+/// must bind to and the node's authorised sequencer key.
+pub struct AccountPolicy {
+    pub protocol_version: u16,
+    pub network_id: u32,
+    pub sequencer_key: [u8; 32],
+}
+
+/// An `lx_getAccount` or `lx_getBalance` result whose served fields were
+/// reproduced from proof material this client verified itself.
+pub struct VerifiedRpcAccount {
+    evidence: VerifiedAccountEvidence,
+    canonical: Vec<u8>,
+    proof_material: Vec<u8>,
+}
+
+impl VerifiedRpcAccount {
+    /// Borrows the account, level, batch number and state root established by
+    /// local verification.
+    #[must_use]
+    pub const fn evidence(&self) -> &VerifiedAccountEvidence {
+        &self.evidence
+    }
+
+    /// Returns the exact canonical account bytes the proof committed to.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical
+    }
+
+    /// Returns the exact proof bytes this client verified.
+    #[must_use]
+    pub fn proof_material(&self) -> &[u8] {
+        &self.proof_material
+    }
+
+    /// Verifies one served account read against its own proof material and
+    /// refuses every served field the proof does not reproduce.
+    ///
+    /// # Errors
+    /// Returns `InvalidResponse` for a malformed result and `Verification`
+    /// when the evidence, the achieved level, the served label or any served
+    /// field disagrees with the verified account.
+    pub fn from_rpc_result(
+        result: &Value,
+        account: [u8; 32],
+        policy: &AccountPolicy,
+    ) -> Result<Self, RpcError> {
+        if hex_field(result, "account_id", 32)? != account {
+            return Err(RpcError::Verification);
+        }
+        let canonical = hex_field(result, "canonical_value", MAX_ACCOUNT_VALUE_BYTES)?;
+        let proof_material = hex_field(result, "proof_material", MAX_ACCOUNT_PROOF_BYTES)?;
+        let evidence = verify_account_evidence(
+            &canonical,
+            &proof_material,
+            account,
+            None,
+            AccountEvidencePolicy {
+                expected_protocol_version: policy.protocol_version,
+                expected_network_id: policy.network_id,
+                handshake_sequencer_key: policy.sequencer_key,
+                root_selector: RootSelector::Latest,
+            },
+        )
+        .map_err(|_| RpcError::Verification)?;
+        let proven = evidence.account();
+        if result.get("verification").and_then(Value::as_str)
+            != verification_label(evidence.level())
+            || result
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::as_bytes)
+                != Some(proven.name.as_slice())
+            || hex_field(result, "asset_id", 32)? != proven.asset_id()
+            || decimal_field(result, "balance")? != proven.balance()
+            || decimal_field(result, "next_sequence")? != u128::from(proven.next_sequence)
+            || result.get("frozen").and_then(Value::as_bool) != Some(proven.frozen)
+            || decimal_field(result, "batch_number")? != u128::from(evidence.batch_number())
+        {
+            return Err(RpcError::Verification);
+        }
+        Ok(Self {
+            evidence,
+            canonical,
+            proof_material,
+        })
+    }
+}
+
+fn decimal_field(value: &Value, name: &str) -> Result<u128, RpcError> {
+    let text = value
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or(RpcError::InvalidResponse)?;
+    let parsed: u128 = text.parse().map_err(|_| RpcError::InvalidResponse)?;
+    if parsed.to_string() != text {
+        return Err(RpcError::InvalidResponse);
+    }
+    Ok(parsed)
+}
+
 impl RpcClient {
+    /// Reads an account through `lx_getAccount` and verifies the served value
+    /// against its own proof material before returning it.
+    ///
+    /// # Errors
+    /// Preserves RPC refusals and returns `Verification` for any result the
+    /// proof material does not establish at `STATE_PROVEN` or above.
+    pub fn verified_account(
+        &self,
+        account: [u8; 32],
+        policy: &AccountPolicy,
+    ) -> Result<VerifiedRpcAccount, RpcError> {
+        let result = self.get_account(&super::rpc::encode_hex(&account))?;
+        VerifiedRpcAccount::from_rpc_result(&result, account, policy)
+    }
+
+    /// Reads a balance through `lx_getBalance` under the same verification as
+    /// `verified_account`.
+    ///
+    /// # Errors
+    /// Preserves RPC refusals and returns `Verification` for any result the
+    /// proof material does not establish at `STATE_PROVEN` or above.
+    pub fn verified_balance(
+        &self,
+        account: [u8; 32],
+        policy: &AccountPolicy,
+    ) -> Result<VerifiedRpcAccount, RpcError> {
+        let result = self.get_balance(&super::rpc::encode_hex(&account))?;
+        VerifiedRpcAccount::from_rpc_result(&result, account, policy)
+    }
+
     /// # Errors
     /// Returns pending on deadline, RPC errors, or an exact verification refusal.
     pub fn wait_for(

--- a/agent/crates/layerx-sdk/tests/account_reads.rs
+++ b/agent/crates/layerx-sdk/tests/account_reads.rs
@@ -1,0 +1,589 @@
+//! Verifies public account and balance reads client-side against the exact
+//! nested state evidence a node exports alongside them.
+
+use std::collections::BTreeMap;
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{channel, Sender};
+use std::thread::{self, JoinHandle};
+
+use ed25519_dalek::{Signer as _, SigningKey};
+use layerx_client::evidence::verification_label;
+use layerx_proof::merkle::{build_proof, Proof};
+use layerx_proof::state::{decode_account_value, NestedAccountProof};
+use layerx_sdk::rpc::{RpcClient, RpcError};
+use layerx_sdk::rpc_verification::{AccountPolicy, VerifiedRpcAccount};
+use layerx_wire::encode::Encoder;
+use layerx_wire::hash::{batch_header_digest, receipt_digest};
+use layerx_wire::limits::PROTOCOL_VERSION;
+use serde_json::{json, Value};
+use sha2::{Digest as _, Sha256};
+
+const PROGRAM_ACCOUNT_VECTORS: &str =
+    include_str!("../../../../tests/vectors/program_account_state_v2.vec");
+const NETWORK_ID: u32 = 42;
+const BATCH_NUMBER: u64 = 7;
+const RECEIPT_SEQUENCE: u64 = 10;
+const HEAD_SEQUENCE: u64 = 99;
+
+fn nibble(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn hex(value: &str) -> Vec<u8> {
+    assert_eq!(value.len() % 2, 0, "odd-length vector value");
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = nibble(pair[0]).unwrap_or_else(|| panic!("invalid vector hex"));
+            let low = nibble(pair[1]).unwrap_or_else(|| panic!("invalid vector hex"));
+            (high << 4) | low
+        })
+        .collect()
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut text, byte| {
+        text.push(char::from_digit(u32::from(byte >> 4), 16).unwrap_or_else(|| panic!("nibble")));
+        text.push(char::from_digit(u32::from(byte & 0x0f), 16).unwrap_or_else(|| panic!("nibble")));
+        text
+    })
+}
+
+fn account_vector() -> ([u8; 32], Vec<u8>) {
+    let entries: BTreeMap<&str, &str> = PROGRAM_ACCOUNT_VECTORS
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .collect();
+    let account_id = hex(entries
+        .get("account_id")
+        .unwrap_or_else(|| panic!("missing account id vector")))
+    .try_into()
+    .unwrap_or_else(|_| panic!("account id is not 32 bytes"));
+    let value = hex(entries
+        .get("account_value")
+        .unwrap_or_else(|| panic!("missing account value vector")));
+    (account_id, value)
+}
+
+fn state_leaf(key: &[u8], value: &[u8]) -> [u8; 32] {
+    let mut bytes = Vec::with_capacity(26 + key.len() + value.len());
+    bytes.extend_from_slice(b"LXP/v1/state-leaf\0");
+    bytes.extend_from_slice(
+        &u32::try_from(key.len())
+            .unwrap_or_else(|_| panic!("test key length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(
+        &u32::try_from(value.len())
+            .unwrap_or_else(|_| panic!("test value length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(key);
+    bytes.extend_from_slice(value);
+    Sha256::digest(bytes).into()
+}
+
+fn state_node(left: [u8; 32], right: [u8; 32]) -> [u8; 32] {
+    let mut bytes = Vec::with_capacity(82);
+    bytes.extend_from_slice(b"LXP/v1/state-node\0");
+    bytes.extend_from_slice(&left);
+    bytes.extend_from_slice(&right);
+    Sha256::digest(bytes).into()
+}
+
+fn receipt_bytes(resulting_state_root: [u8; 32], sequencer: &SigningKey) -> Vec<u8> {
+    let encode = |signature: Option<[u8; 64]>| {
+        let mut encoder = Encoder::new(4096);
+        assert_eq!(
+            encoder.structure_header_version(0x5201, PROTOCOL_VERSION),
+            Ok(())
+        );
+        assert_eq!(encoder.u16(PROTOCOL_VERSION), Ok(()));
+        assert_eq!(encoder.bytes(&[0x71; 32], 32), Ok(()));
+        assert_eq!(encoder.u64(RECEIPT_SEQUENCE), Ok(()));
+        assert_eq!(encoder.bytes(&[0x21; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&resulting_state_root, 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x22; 32], 32), Ok(()));
+        assert_eq!(encoder.i32(0), Ok(()));
+        assert_eq!(encoder.sequence_length(0, 512), Ok(()));
+        assert_eq!(encoder.u128(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x23; 32], 32), Ok(()));
+        assert_eq!(encoder.u16(1), Ok(()));
+        assert_eq!(encoder.u32(1), Ok(()));
+        assert_eq!(encoder.u32(1), Ok(()));
+        assert_eq!(encoder.u8(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x24; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(25), Ok(()));
+        assert_eq!(encoder.bytes(&[0x25; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(100), Ok(()));
+        assert_eq!(encoder.u128(75), Ok(()));
+        assert_eq!(encoder.u64(1), Ok(()));
+        assert_eq!(encoder.bytes(&[0x26; 32], 32), Ok(()));
+        assert_eq!(encoder.u128(10), Ok(()));
+        assert_eq!(encoder.u128(35), Ok(()));
+        assert_eq!(encoder.bytes(&[0x27; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x28; 32], 32), Ok(()));
+        assert_eq!(encoder.bytes(&[0x29; 32], 32), Ok(()));
+        assert_eq!(encoder.u64(1_000), Ok(()));
+        assert_eq!(encoder.u8(u8::from(signature.is_some())), Ok(()));
+        if let Some(signature) = signature {
+            assert_eq!(encoder.bytes(&signature, 64), Ok(()));
+        }
+        encoder.finish()
+    };
+    let unsigned = encode(None);
+    let digest = receipt_digest(&unsigned)
+        .unwrap_or_else(|error| panic!("receipt digest failed: {error:?}"));
+    encode(Some(sequencer.sign(&digest).to_bytes()))
+}
+
+fn header_bytes(
+    resulting_state_root: [u8; 32],
+    receipt_root: [u8; 32],
+    sequencer_id: [u8; 32],
+) -> Vec<u8> {
+    let mut encoder = Encoder::new(354);
+    assert_eq!(
+        encoder.structure_header_version(0x1701, PROTOCOL_VERSION),
+        Ok(())
+    );
+    assert_eq!(encoder.u8(15), Ok(()));
+    let digests: [(u8, [u8; 32]); 8] = [
+        (7, [0x31; 32]),
+        (8, resulting_state_root),
+        (9, [0x32; 32]),
+        (10, receipt_root),
+        (11, [0x33; 32]),
+        (12, [0x34; 32]),
+        (13, [0x35; 32]),
+        (15, sequencer_id),
+    ];
+    let counters: [(u8, u64); 5] = [(3, 2), (4, BATCH_NUMBER), (5, 9), (6, 10), (14, 1_000)];
+    for field in 1..=15_u8 {
+        assert_eq!(encoder.tag(field, 15), Ok(()));
+        match field {
+            1 => assert_eq!(encoder.u16(PROTOCOL_VERSION), Ok(())),
+            2 => assert_eq!(encoder.u32(NETWORK_ID), Ok(())),
+            _ => {
+                if let Some((_, counter)) = counters.iter().find(|(tag, _)| *tag == field) {
+                    assert_eq!(encoder.u64(*counter), Ok(()));
+                } else {
+                    let (_, digest) = digests
+                        .iter()
+                        .find(|(tag, _)| *tag == field)
+                        .unwrap_or_else(|| panic!("header field {field} is undefined"));
+                    assert_eq!(encoder.bytes(digest, 32), Ok(()));
+                }
+            }
+        }
+    }
+    let bytes = encoder.finish();
+    assert_eq!(bytes.len(), 354);
+    bytes
+}
+
+fn nested_fixture(
+    account_id: [u8; 32],
+    account_value: &[u8],
+    sequencer: &SigningKey,
+) -> NestedAccountProof {
+    let sequencer_id = sequencer.verifying_key().to_bytes();
+    let mut account_key = [0_u8; 33];
+    account_key[0] = 4;
+    account_key[1..].copy_from_slice(&account_id);
+    let account_leaf = state_leaf(&account_key, account_value);
+    let mut other_account_key = [0xff_u8; 33];
+    other_account_key[0] = 4;
+    assert!(account_key < other_account_key);
+    let other_account_leaf = state_leaf(&other_account_key, b"other-account");
+    let account_root = state_node(account_leaf, other_account_leaf);
+    let account_proof = Proof::new(0, 2, vec![other_account_leaf])
+        .unwrap_or_else(|error| panic!("account proof: {error:?}"));
+
+    let account_tree_leaf = state_leaf(b"account-tree", &account_root);
+    let sequence_leaf = state_leaf(b"sequence", &11_u64.to_be_bytes());
+    let universal_root = state_node(account_tree_leaf, sequence_leaf);
+    let account_tree_proof = Proof::new(0, 2, vec![sequence_leaf])
+        .unwrap_or_else(|error| panic!("account-tree proof: {error:?}"));
+
+    let universal_leaf = state_leaf(&0_u16.to_be_bytes(), &universal_root);
+    let module_leaf = state_leaf(&1_u16.to_be_bytes(), &[0x61; 32]);
+    let resulting_state_root = state_node(universal_leaf, module_leaf);
+    let universal_root_proof = Proof::new(0, 2, vec![module_leaf])
+        .unwrap_or_else(|error| panic!("universal proof: {error:?}"));
+
+    let receipt = receipt_bytes(resulting_state_root, sequencer);
+    let (receipt_proof, receipt_root) = build_proof(&[receipt.as_slice()], 0)
+        .unwrap_or_else(|error| panic!("receipt proof: {error:?}"));
+    let header = header_bytes(resulting_state_root, receipt_root, sequencer_id);
+    let header_digest =
+        batch_header_digest(&header).unwrap_or_else(|error| panic!("header digest: {error:?}"));
+    NestedAccountProof {
+        account_id,
+        account_root,
+        universal_root,
+        resulting_state_root,
+        account_proof,
+        account_tree_proof,
+        universal_root_proof,
+        receipt_bytes: receipt,
+        receipt_proof,
+        header_bytes: header,
+        header_signature: sequencer.sign(&header_digest).to_bytes(),
+    }
+}
+
+fn append_length(bytes: &mut Vec<u8>, value: &[u8]) {
+    bytes.extend_from_slice(
+        &u32::try_from(value.len())
+            .unwrap_or_else(|_| panic!("wire length"))
+            .to_be_bytes(),
+    );
+    bytes.extend_from_slice(value);
+}
+
+fn append_proof(bytes: &mut Vec<u8>, proof: &Proof) {
+    bytes.extend_from_slice(&proof.leaf_index().to_be_bytes());
+    bytes.extend_from_slice(&proof.leaf_count().to_be_bytes());
+    bytes.push(u8::try_from(proof.siblings().len()).unwrap_or_else(|_| panic!("proof depth")));
+    for sibling in proof.siblings() {
+        bytes.extend_from_slice(sibling);
+    }
+}
+
+/// Encodes exactly the account evidence a node exports with a latest-root read.
+fn exported_evidence(proof: &NestedAccountProof, sequencer_id: [u8; 32]) -> Vec<u8> {
+    let mut bytes = 1_u16.to_be_bytes().to_vec();
+    bytes.extend_from_slice(&[2, 1]);
+    for root in [
+        proof.account_id,
+        proof.account_root,
+        proof.universal_root,
+        proof.resulting_state_root,
+    ] {
+        bytes.extend_from_slice(&root);
+    }
+    for path in [
+        &proof.account_proof,
+        &proof.account_tree_proof,
+        &proof.universal_root_proof,
+    ] {
+        append_proof(&mut bytes, path);
+    }
+    append_length(&mut bytes, &proof.receipt_bytes);
+    append_proof(&mut bytes, &proof.receipt_proof);
+    bytes.extend_from_slice(&1_u16.to_be_bytes());
+    bytes.extend_from_slice(&sequencer_id);
+    bytes.extend_from_slice(&sequencer_id);
+    bytes.extend_from_slice(&BATCH_NUMBER.to_be_bytes());
+    bytes.extend_from_slice(&BATCH_NUMBER.to_be_bytes());
+    append_length(&mut bytes, &proof.header_bytes);
+    bytes.extend_from_slice(&proof.header_signature);
+    bytes.push(0);
+    bytes
+}
+
+struct Fixture {
+    account_id: [u8; 32],
+    canonical_value: Vec<u8>,
+    proof_material: Vec<u8>,
+    sequencer_key: [u8; 32],
+}
+
+fn fixture() -> Fixture {
+    let (account_id, canonical_value) = account_vector();
+    let sequencer = SigningKey::from_bytes(&[0x51; 32]);
+    let sequencer_key = sequencer.verifying_key().to_bytes();
+    let proof = nested_fixture(account_id, &canonical_value, &sequencer);
+    Fixture {
+        account_id,
+        canonical_value,
+        proof_material: exported_evidence(&proof, sequencer_key),
+        sequencer_key,
+    }
+}
+
+/// Builds the exact result object the core public account read serves.
+fn served(fixture: &Fixture) -> Value {
+    let account = decode_account_value(fixture.account_id, &fixture.canonical_value)
+        .unwrap_or_else(|error| panic!("canonical account: {error:?}"));
+    let name =
+        std::str::from_utf8(&account.name).unwrap_or_else(|error| panic!("account name: {error}"));
+    json!({
+        "account_id": encode_hex(&fixture.account_id),
+        "name": name,
+        "asset_id": encode_hex(&account.asset_id()),
+        "balance": account.balance().to_string(),
+        "next_sequence": account.next_sequence.to_string(),
+        "frozen": account.frozen,
+        "canonical_value": encode_hex(&fixture.canonical_value),
+        "proof_material": encode_hex(&fixture.proof_material),
+        "observed_head_sequence": HEAD_SEQUENCE.to_string(),
+        "batch_number": BATCH_NUMBER.to_string(),
+        "verification": "state_proven"
+    })
+}
+
+fn policy(sequencer_key: [u8; 32]) -> AccountPolicy {
+    AccountPolicy {
+        protocol_version: PROTOCOL_VERSION,
+        network_id: NETWORK_ID,
+        sequencer_key,
+    }
+}
+
+#[test]
+fn served_account_read_is_reproduced_from_its_own_proof_material() {
+    let fixture = fixture();
+    let result = served(&fixture);
+    let verified = VerifiedRpcAccount::from_rpc_result(
+        &result,
+        fixture.account_id,
+        &policy(fixture.sequencer_key),
+    )
+    .unwrap_or_else(|error| panic!("served read refused: {error:?}"));
+    let evidence = verified.evidence();
+    assert_eq!(evidence.account().account_id, fixture.account_id);
+    assert_eq!(
+        Some(evidence.account().balance().to_string().as_str()),
+        result["balance"].as_str()
+    );
+    assert_eq!(
+        Some(encode_hex(&evidence.account().asset_id()).as_str()),
+        result["asset_id"].as_str()
+    );
+    assert!(evidence.account().has_asset());
+    assert_eq!(evidence.batch_number(), BATCH_NUMBER);
+    assert_eq!(evidence.observed_sequence(), RECEIPT_SEQUENCE);
+    assert_eq!(verification_label(evidence.level()), Some("state_proven"));
+    assert_eq!(evidence.signed_header().public_key, fixture.sequencer_key);
+    assert_eq!(verified.canonical_bytes(), fixture.canonical_value);
+    assert_eq!(verified.proof_material(), fixture.proof_material);
+}
+
+#[test]
+fn served_fields_the_proof_does_not_reproduce_are_refused() {
+    let fixture = fixture();
+    let policy = policy(fixture.sequencer_key);
+    for (field, substitute) in [
+        ("balance", json!("1")),
+        ("next_sequence", json!("9")),
+        ("frozen", json!(true)),
+        ("name", json!("module:programs:value:2222222222222222")),
+        ("asset_id", json!("11".repeat(32))),
+        ("account_id", json!("22".repeat(32))),
+        ("batch_number", json!("8")),
+        ("verification", json!("unverified")),
+        ("verification", json!("checkpoint_finalised")),
+        ("verification", json!("state_proven ")),
+    ] {
+        let mut result = served(&fixture);
+        result[field] = substitute.clone();
+        let refusal = VerifiedRpcAccount::from_rpc_result(&result, fixture.account_id, &policy);
+        assert!(
+            matches!(refusal, Err(RpcError::Verification)),
+            "substituting {field} with {substitute} was accepted"
+        );
+    }
+}
+
+#[test]
+fn absent_or_malformed_evidence_is_refused() {
+    let fixture = fixture();
+    let policy = policy(fixture.sequencer_key);
+    let mut without_proof = served(&fixture);
+    without_proof["proof_material"] = json!("");
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&without_proof, fixture.account_id, &policy),
+        Err(RpcError::InvalidResponse)
+    ));
+
+    let mut without_label = served(&fixture);
+    assert!(without_label
+        .as_object_mut()
+        .unwrap_or_else(|| panic!("served result is an object"))
+        .remove("verification")
+        .is_some());
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&without_label, fixture.account_id, &policy),
+        Err(RpcError::Verification)
+    ));
+
+    let mut padded_decimal = served(&fixture);
+    padded_decimal["next_sequence"] = json!("007");
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&padded_decimal, fixture.account_id, &policy),
+        Err(RpcError::InvalidResponse)
+    ));
+
+    let mut forged_signature = fixture.proof_material.clone();
+    let last_signature_byte = forged_signature.len() - 2;
+    forged_signature[last_signature_byte] ^= 1;
+    let mut forged = served(&fixture);
+    forged["proof_material"] = json!(encode_hex(&forged_signature));
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&forged, fixture.account_id, &policy),
+        Err(RpcError::Verification)
+    ));
+
+    let mut substituted_value = fixture.canonical_value.clone();
+    let balance_byte = substituted_value.len() - 1;
+    substituted_value[balance_byte] ^= 1;
+    let mut substituted = served(&fixture);
+    substituted["canonical_value"] = json!(encode_hex(&substituted_value));
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&substituted, fixture.account_id, &policy),
+        Err(RpcError::Verification)
+    ));
+}
+
+#[test]
+fn evidence_outside_the_pinned_trust_is_refused() {
+    let fixture = fixture();
+    let result = served(&fixture);
+    let foreign = [
+        AccountPolicy {
+            network_id: NETWORK_ID + 1,
+            ..policy(fixture.sequencer_key)
+        },
+        AccountPolicy {
+            protocol_version: PROTOCOL_VERSION + 1,
+            ..policy(fixture.sequencer_key)
+        },
+        policy([0x7a; 32]),
+    ];
+    for policy in foreign {
+        assert!(matches!(
+            VerifiedRpcAccount::from_rpc_result(&result, fixture.account_id, &policy),
+            Err(RpcError::Verification)
+        ));
+    }
+    assert!(matches!(
+        VerifiedRpcAccount::from_rpc_result(&result, [0x99; 32], &policy(fixture.sequencer_key)),
+        Err(RpcError::Verification)
+    ));
+}
+
+fn read_request_body(stream: &mut TcpStream) -> Vec<u8> {
+    let mut buffer = Vec::new();
+    let mut byte = [0_u8; 1];
+    let mut expected = None;
+    loop {
+        let read = stream
+            .read(&mut byte)
+            .unwrap_or_else(|error| panic!("read request: {error}"));
+        assert_eq!(read, 1, "the request ended before its body");
+        buffer.push(byte[0]);
+        if expected.is_none() && buffer.ends_with(b"\r\n\r\n") {
+            let head = String::from_utf8_lossy(&buffer).to_ascii_lowercase();
+            let length: usize = head
+                .split("content-length:")
+                .nth(1)
+                .and_then(|rest| rest.split("\r\n").next())
+                .and_then(|value| value.trim().parse().ok())
+                .unwrap_or_else(|| panic!("request has no content length"));
+            expected = Some(buffer.len() + length);
+        }
+        if expected.is_some_and(|total| buffer.len() >= total) {
+            break;
+        }
+    }
+    let body = buffer
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .unwrap_or_else(|| panic!("request head is unterminated"))
+        + 4;
+    buffer[body..].to_vec()
+}
+
+fn serve(
+    listener: TcpListener,
+    results: Vec<Value>,
+    calls: Sender<(String, Value)>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        for result in results {
+            let (mut stream, _) = listener
+                .accept()
+                .unwrap_or_else(|error| panic!("accept: {error}"));
+            let request: Value = serde_json::from_slice(&read_request_body(&mut stream))
+                .unwrap_or_else(|error| panic!("request body: {error}"));
+            calls
+                .send((
+                    request["method"].as_str().unwrap_or_default().to_owned(),
+                    request["params"].clone(),
+                ))
+                .unwrap_or_else(|error| panic!("record call: {error}"));
+            let body = serde_json::to_vec(&json!({
+                "jsonrpc": "2.0",
+                "id": request["id"].as_str().unwrap_or_default(),
+                "result": result
+            }))
+            .unwrap_or_else(|error| panic!("encode response: {error}"));
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream
+                .write_all(head.as_bytes())
+                .and_then(|()| stream.write_all(&body))
+                .and_then(|()| stream.flush())
+                .unwrap_or_else(|error| panic!("write response: {error}"));
+        }
+    })
+}
+
+#[test]
+fn rpc_account_and_balance_reads_verify_before_returning() {
+    let fixture = fixture();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap_or_else(|error| panic!("bind: {error}"));
+    let port = listener
+        .local_addr()
+        .unwrap_or_else(|error| panic!("local address: {error}"))
+        .port();
+    let mut understated = served(&fixture);
+    understated["balance"] = json!("1");
+    let (calls, observed) = channel();
+    let server = serve(
+        listener,
+        vec![served(&fixture), served(&fixture), understated],
+        calls,
+    );
+
+    let client = RpcClient::connect(&format!("http://127.0.0.1:{port}/rpc"), None)
+        .unwrap_or_else(|error| panic!("connect: {error:?}"));
+    let policy = policy(fixture.sequencer_key);
+    let account = client
+        .verified_account(fixture.account_id, &policy)
+        .unwrap_or_else(|error| panic!("verified account: {error:?}"));
+    assert_eq!(account.canonical_bytes(), fixture.canonical_value);
+    let balance = client
+        .verified_balance(fixture.account_id, &policy)
+        .unwrap_or_else(|error| panic!("verified balance: {error:?}"));
+    assert_eq!(
+        balance.evidence().account().balance(),
+        account.evidence().account().balance()
+    );
+    assert!(matches!(
+        client.verified_account(fixture.account_id, &policy),
+        Err(RpcError::Verification)
+    ));
+
+    assert!(server.join().is_ok(), "the server thread panicked");
+    let selector = json!([encode_hex(&fixture.account_id)]);
+    let recorded: Vec<(String, Value)> = observed.iter().collect();
+    assert_eq!(
+        recorded,
+        vec![
+            ("lx_getAccount".to_owned(), selector.clone()),
+            ("lx_getBalance".to_owned(), selector.clone()),
+            ("lx_getAccount".to_owned(), selector),
+        ]
+    );
+}

--- a/platform/hosted/core/src/public_reads.rs
+++ b/platform/hosted/core/src/public_reads.rs
@@ -1,3 +1,4 @@
+use layerx_client::evidence::verification_label;
 use sha2::{Digest, Sha256};
 
 use super::{
@@ -18,8 +19,15 @@ pub(super) fn account(config: &Config, id: &str) -> Response {
         1,
         u64::MAX,
     );
-    let Ok(value) = client.account(account_id, VerificationLevel::UNVERIFIED, 1, authorization)
-    else {
+    let Ok(value) = client.account(
+        account_id,
+        VerificationLevel::STATE_PROVEN,
+        1,
+        authorization,
+    ) else {
+        return refusal(503, "account_evidence_unavailable", Some(5));
+    };
+    let Some(verification) = verification_label(value.achieved()) else {
         return refusal(503, "account_evidence_unavailable", Some(5));
     };
     let Ok(account) = decode_account_value(account_id, value.canonical_bytes()) else {
@@ -38,7 +46,8 @@ pub(super) fn account(config: &Config, id: &str) -> Response {
         "canonical_value": hex_encode(value.canonical_bytes()),
         "proof_material": hex_encode(value.proof_material()),
         "observed_head_sequence": value.freshness().observed_head_sequence.to_string(),
-        "batch_number": value.freshness().batch_number.to_string()
+        "batch_number": value.freshness().batch_number.to_string(),
+        "verification": verification
     }))
 }
 

--- a/platform/hosted/core/tests/boundary.rs
+++ b/platform/hosted/core/tests/boundary.rs
@@ -5,6 +5,9 @@
 mod lxgb_metadata;
 
 use ed25519_dalek::{Signer, SigningKey};
+use layerx_client::evidence::{
+    verification_label, verify_account_evidence, AccountEvidencePolicy, EvidenceError, RootSelector,
+};
 use layerx_client::lni::handshake::{perform, HandshakeConfig};
 use layerx_client::lni::preparation::{preparation_state, PreparationStateContext};
 use layerx_client::lni::schema::Version;
@@ -12,7 +15,9 @@ use layerx_client::lni::simulate::{
     simulation_boundary_id, simulation_evidence_digest, SimulationEvidence,
 };
 use layerx_client::lni::transport::{ConnectionGate, Limits, Uds};
-use layerx_platform_core::{build_send, hex_encode, treasury_did, SendRequest};
+use layerx_platform_core::{
+    build_send, fixed_hex, hex_decode, hex_encode, treasury_did, SendRequest,
+};
 use layerx_types::activity::{Authority, EnvelopeBuilder, Signature, TimestampBound};
 use layerx_types::amount::Amount;
 use layerx_types::ids::{Did, IdempotencyKey};
@@ -843,7 +848,12 @@ fn genesis_request(asset: &[u8; 32], sequencer_key: &[u8; 32]) -> Vec<u8> {
     }
     assert_eq!(request.len(), 395, "LXGB request length");
     let issuer = SigningKey::from_bytes(&random32());
-    lxgb_metadata::append(&mut request, asset, &issuer.verifying_key().to_bytes(), &random32());
+    lxgb_metadata::append(
+        &mut request,
+        asset,
+        &issuer.verifying_key().to_bytes(),
+        &random32(),
+    );
     request
 }
 
@@ -2234,7 +2244,9 @@ fn start_supervised_cluster() -> Cluster {
     lxgb_metadata::append(
         &mut metadata,
         &asset,
-        &SigningKey::from_bytes(&treasury_seed).verifying_key().to_bytes(),
+        &SigningKey::from_bytes(&treasury_seed)
+            .verifying_key()
+            .to_bytes(),
         &random32(),
     );
     write(&root.join("bootstrap-metadata.lxgb"), &metadata, 0o644);
@@ -2257,7 +2269,10 @@ fn start_supervised_cluster() -> Cluster {
             text(&root.join("bootstrap-sequencer.key")),
         ),
         ("--treasury-key", text(&root.join("bootstrap-treasury.key"))),
-        ("--genesis-metadata", text(&root.join("bootstrap-metadata.lxgb"))),
+        (
+            "--genesis-metadata",
+            text(&root.join("bootstrap-metadata.lxgb")),
+        ),
         (
             "--program-token-file",
             text(&root.join("bootstrap-program.token")),
@@ -2828,6 +2843,63 @@ fn account_proof_export_preserves_exact_native_verified_bytes() {
         json(&value)["result"]["proof_material"]
     );
     assert_eq!(exported["result"]["account_id"], account);
+
+    let body = json(&value);
+    let served = &body["result"];
+    assert_eq!(served["verification"], "state_proven");
+    let field = |name: &str| {
+        served[name]
+            .as_str()
+            .unwrap_or_else(|| panic!("{name} missing from {}", value.body))
+            .to_owned()
+    };
+    let verified = must(
+        verify_account_evidence(
+            &must(hex_decode(&field("canonical_value")), "canonical value"),
+            &must(hex_decode(&field("proof_material")), "proof material"),
+            must(fixed_hex("account_id", &account), "account id"),
+            None,
+            AccountEvidencePolicy {
+                expected_protocol_version: PROTOCOL_VERSION,
+                expected_network_id: NETWORK_ID,
+                handshake_sequencer_key: cluster.sequencer_key,
+                root_selector: RootSelector::Latest,
+            },
+        ),
+        "served account evidence",
+    );
+    assert_eq!(
+        verification_label(verified.level()),
+        Some(field("verification").as_str())
+    );
+    let proven = verified.account();
+    assert_eq!(field("name").as_bytes(), proven.name.as_slice());
+    assert_eq!(field("asset_id"), hex_encode(&proven.asset_id()));
+    assert_eq!(field("balance"), proven.balance().to_string());
+    assert_eq!(field("next_sequence"), proven.next_sequence.to_string());
+    assert_eq!(served["frozen"], proven.frozen);
+    assert_eq!(field("batch_number"), verified.batch_number().to_string());
+    assert_eq!(
+        verified.signed_header().public_key,
+        cluster.sequencer_key,
+        "the served proof must terminate in the cluster sequencer"
+    );
+    assert!(matches!(
+        verify_account_evidence(
+            &must(hex_decode(&field("canonical_value")), "canonical value"),
+            &must(hex_decode(&field("proof_material")), "proof material"),
+            must(fixed_hex("account_id", &account), "account id"),
+            None,
+            AccountEvidencePolicy {
+                expected_protocol_version: PROTOCOL_VERSION,
+                expected_network_id: NETWORK_ID,
+                handshake_sequencer_key: [0x5c; 32],
+                root_selector: RootSelector::Latest,
+            },
+        ),
+        Err(EvidenceError::SequencerMismatch)
+    ));
+
     for account in ["invalid".to_owned(), "00".repeat(32)] {
         assert_refusal(
             &boundary

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -8894,3 +8894,51 @@ symbol = "lxp_authority_envelope_declare lxp_governance_activity"
 observed = "A governance activity submitted to a node running a protocol version below the state commitment version reaches the authority resolution with no governance module registered: cmd/layerxd/lxp_daemon_process.c:4810 registers lxp_governance_module_iface only at LXP_PROTOCOL_VERSION_STATE_COMMITMENT while the per-activity type filter admits lxp_governance_activity at every version. The declared envelope therefore omits the governance module bit and lxp_authority_check_scope refuses with LXP_ERR_AUTH_SCOPE before execution, where the previous synthesis carried the activity into lxp_kernel_execute_activity and recorded an unknown-module refusal in a receipt."
 assumption = "Both outcomes refuse the activity, and the surrounding block already treats an authority failure as a hard error rather than a refusal receipt, so the resolution joins an existing class rather than creating one. Widening the activity type filter to follow the registered module set belongs to the filter's owner."
 severity = "note"
+
+[observation.6.2.4100]
+task = "6.2"
+file = "platform/hosted/core/src/public_reads.rs agent/crates/layerx-client/src/read.rs agent/crates/layerx-client/src/client.rs cmd/layerxd/lxp_daemon_lni.c"
+symbol = "account verify_state_value require_account_read_capabilities send_account_read"
+observed = "The core public account read asked layerx_client::Client::account for VerificationLevel::UNVERIFIED, so /v1/accounts/{id} and /v1/accounts/{id}/balance, the sources of lx_getAccount and lx_getBalance, served a value and its proof material while naming no level, and a node answering with no proof material at all was served as a 200 that no receiver could check. read.rs verify_state_value verifies every non-empty proof material identically whatever level was requested, and only its empty-evidence branch consults the requested level, so raising the request to STATE_PROVEN changes exactly one served outcome: an empty-evidence response is now the typed MissingEvidence refusal answered as 503 account_evidence_unavailable. The request keeps RootSelector::Latest because read_context selects a checkpoint root only from CHECKPOINT_FINALISED, and require_account_read_capabilities demands HistoricalProofs only when requires_historical_account_proofs holds, which is also only from CHECKPOINT_FINALISED, so no additional node capability is required. cmd/layerxd answers an ACCOUNT_READ_REQUEST with proof material on success or a typed refusal, so no successful read loses its evidence. The served object gained a verification member naming the level the proof actually established: state_proven, or checkpoint_finalised and settlement_anchored when the evidence carries a checkpoint report."
+assumption = "Refusing an unverifiable account read is the honest public contract and matches the proof-gated receipt and proof routes on the same boundary, so the row's default of proving at the core was taken rather than serving an unverified value with a lower label. Evidence: qual-logs/platform-tests.log, where account_proof_export_preserves_exact_native_verified_bytes now verifies the served proof material offline against the cluster sequencer key, and qual-logs/agent-tests.log."
+severity = "note"
+
+[observation.6.2.4101]
+task = "6.2"
+file = "platform/hosted/core/src/public_reads.rs platform/hosted/gateway/src/rpc.rs"
+symbol = "did_accounts lx_getBalances authenticated_node_snapshot"
+observed = "did_accounts still reads at VerificationLevel::UNVERIFIED and labels its answer authenticated_node_snapshot, so /v1/dids/{did}/accounts and the lx_getBalances method that resolves to it remain the one public account-shaped read whose values carry no state proof. The enumeration is a DID-scoped listing rather than a point read, so it has no single nested account proof to verify and cannot reuse the account read's evidence path unchanged, and the same route is the subject of the unresolved read contract recorded at observation 6.2.940 and observation 6.11.161."
+assumption = "The DID listing contract is owned elsewhere and its refusal shape is still contested, so the route was left exactly as written rather than given a label the evidence does not support."
+severity = "note"
+
+[observation.6.2.4102]
+task = "6.2"
+file = "agent/crates/layerx-client/tests/availability_daemon.rs tests/daemon/program-admission.sh"
+symbol = "real_daemon_availability_refusals bootstrap"
+observed = "cargo test -p layerx-sdk -p layerx-client exits 101 on one target: real_daemon_availability_refusals drives tests/daemon/program-admission.sh build --availability-batches with the native binaries built from this worktree, and the harness exits 1 during bootstrap with 'bootstrap: genesis request has an unexpected length' before any account read runs. Every other target passes, including the account read coverage this row added. No C source, harness script or genesis path is modified on this branch, so the harness refusal is reproducible from an unmodified checkout. Evidence: qual-logs/agent-tests.log and qual-logs/availability-harness.log."
+assumption = "The genesis request length disagreement lies in the native bootstrap path, outside this row's owned files, so it is recorded for its owning lane rather than repaired here."
+severity = "blocker"
+
+[observation.6.2.4103]
+task = "6.2"
+file = "agent/crates/layerx-client/tests/supply_receipt.rs"
+symbol = "canonical_native_supply_receipt_round_trips expect_used"
+observed = "cargo clippy -p layerx-sdk -p layerx-client --all-targets exits 101 before reaching any file this row touches: supply_receipt.rs calls expect() twice, at lines 32 and 33, and the agent workspace denies clippy::expect_used. The two lints are the only clippy failures in either crate; clippy over the crate libraries and over both tests this row owns exits 0. Evidence: qual-logs/agent-clippy.log and qual-logs/agent-clippy-owned.log."
+assumption = "The file belongs to another lane's payment work and rewriting its panics would edit code outside this row, so both calls were left exactly as written."
+severity = "blocker"
+
+[observation.6.2.4104]
+task = "6.2"
+file = "platform/hosted/core/tests/boundary.rs platform/hosted/node/bootstrap.sh platform/hosted/core/src/public_reads.rs"
+symbol = "supervisor_reset_rebuilds_genesis_and_replays_once public_read_selectors_use_real_node_and_refuse_missing_evidence did_accounts"
+observed = "cargo test -p layerx-platform-core reproduces the two boundary failures already recorded at observation 6.11.160 and observation 6.11.161, twelve of fourteen tests passing. supervisor_reset_rebuilds_genesis_and_replays_once still fails inside the copied bootstrap script, which cannot find contracts/config/checkpoint-settlement.json from the disposable test root and refuses the certificate threshold, and public_read_selectors_use_real_node_and_refuse_missing_evidence still fails on the DID listing assertion, receiving 200 with an empty account list and authenticated_node_snapshot where 503 did_account_listing_unavailable is required. Both failures precede any account read assertion and neither route is changed by this row; account_proof_export_preserves_exact_native_verified_bytes, proof_and_sequence_reads_refuse_invalid_or_absent_real_node_evidence and the remaining ten tests pass. Evidence: qual-logs/platform-tests.log."
+assumption = "Both failures are the ones already recorded against their owning tasks and both lie outside this row's files, so the harness, the bootstrap script and the DID handler were left exactly as written."
+severity = "blocker"
+
+[observation.6.2.4105]
+task = "6.2"
+file = "agent/crates/layerx-client/src/read.rs agent/crates/layerx-client/src/evidence.rs"
+symbol = "verify_state_value verify_account_evidence"
+observed = "read.rs verify_state_value and the evidence.rs verify_account_evidence this row added now perform the same nested account verification: decode the evidence, bind the root selector and account, pin the sequencer key, and run verify_nested_account or verify_nested_account_maintenance. They are not interchangeable, because verify_state_value additionally requires the signed header's response authorization to equal the live handshake authorization and a Latest selector to name the currently sealed batch, neither of which an offline receiver of exported bytes can evaluate. Routing the live read through the shared verifier would need those two live checks factored out of the shared body."
+assumption = "read.rs is outside this row's owned files and the duplication is exact rather than divergent, so the live read path was left unchanged and the consolidation is recorded for the owner of the point-read path."
+severity = "note"


### PR DESCRIPTION
## Issue

The core public account read asked the node for `VerificationLevel::UNVERIFIED`
(`platform/hosted/core/src/public_reads.rs:21` on `bae8bf98e`), so
`/v1/accounts/{id}` and `/v1/accounts/{id}/balance` — the routes behind
`lx_getAccount` and `lx_getBalance` — served a value together with its proof
material while naming no verification level, and a node response carrying no
proof material at all was served as a 200 that no receiver could check. The
receipt and proof routes on the same boundary were already proof-gated, and no
SDK path verified a served account read client-side.

## What changed and why

**Core (`platform/hosted/core/src/public_reads.rs`)** — the account read now
requests `STATE_PROVEN` and derives the served `verification` member from the
level the proof actually established. `read.rs::verify_state_value` verifies
every non-empty proof material identically whatever level was requested, and
only its empty-evidence branch consults the requested level, so exactly one
served outcome changes: an empty-evidence response becomes the typed
`MissingEvidence` refusal answered as `503 account_evidence_unavailable`. The
request keeps `RootSelector::Latest` and needs no extra node capability; both
the checkpoint selector and `HistoricalProofs` begin only at
`CHECKPOINT_FINALISED`.

**Client (`agent/crates/layerx-client/src/evidence.rs`)** — new
`verify_account_evidence` verifies exported account bytes against their nested
proof material with no live connection: it binds the root selector and the
account, pins the sequencer key through the signed batch header, and runs the
activity or maintenance nested account verification, returning the account, the
level, the observed sequence, the batch number, the state root and the signed
header. `verification_label` maps a level to its public read label and returns
`None` below `STATE_PROVEN`, so the core and the SDK share one mapping.

**SDK (`agent/crates/layerx-sdk/src/rpc_verification.rs`)** —
`VerifiedRpcAccount::from_rpc_result` plus `RpcClient::verified_account` and
`verified_balance`. A served result is accepted only when the account
identifier matches, the evidence verifies under the caller's pinned protocol
version, network and sequencer key, the served label equals the label for the
level actually achieved, and `name`, `asset_id`, `balance`, `next_sequence`,
`frozen` and `batch_number` all reproduce from the verified account. Decimal
fields must be canonical.

**Tests** build real evidence rather than fixtures of it.
`layerx-client/tests/maintenance_reads.rs` verifies exported activity and
maintenance evidence offline from the program account vector and refuses
account substitution, asset substitution, a foreign sequencer key, a foreign
network, a checkpoint selector and a mutated canonical value. The new
`layerx-sdk/tests/account_reads.rs` assembles the exact object the core serves
over a real nested proof with real ed25519 signatures, drives
`verified_account`/`verified_balance` against a loopback JSON-RPC server, and
refuses every served field the proof does not reproduce.
`platform/hosted/core/tests/boundary.rs` now asserts the `state_proven` label
on a real cluster read and verifies the served proof material offline against
the cluster sequencer key, refusing a foreign key.

## Gates

Re-run after rebasing onto `main` at `5fa084634`; the native `layerxd` and
`layerx-genesis-build` binaries were rebuilt from the rebased tree first, since
that merge changed the daemon and authority C sources.

| Command | Exit | Log | SHA |
|---|---|---|---|
| `rustfmt --edition 2021 <touched files>` | 0 | `qual-logs/fmt.log` | `c52c80a02` |
| `CARGO_TARGET_DIR=/root/lx-shared-target/agent cargo test -p layerx-sdk --test account_reads -p layerx-client --test maintenance_reads` | 0 | `qual-logs/agent-owned-tests.log` | `c4d98ef3f2ab320eacf7ba9d5489a05053c4dbea` |
| `CARGO_TARGET_DIR=/root/lx-shared-target/platform cargo test -p layerx-platform-core --test boundary --no-fail-fast` | 101 | `qual-logs/platform-boundary.log` | `c4d98ef3f2ab320eacf7ba9d5489a05053c4dbea` |
| `make beta-ledger-check` | 0 | `qual-logs/ledger-check.log` | `c4d98ef3f2ab320eacf7ba9d5489a05053c4dbea` |
| `git diff --check` | 0 | — | `c4d98ef3f2ab320eacf7ba9d5489a05053c4dbea` |
| `CARGO_TARGET_DIR=/root/lx-shared-target/agent cargo test -p layerx-sdk -p layerx-client --no-fail-fast` (full workspace, pre-rebase) | 101 | `qual-logs/agent-tests.log` | `c52c80a02` |
| `CARGO_TARGET_DIR=/root/lx-shared-target/platform cargo test -p layerx-platform-core --no-fail-fast` (full package, pre-rebase) | 101 | `qual-logs/platform-tests.log` | `c52c80a02` |
| `CARGO_TARGET_DIR=/root/lx-shared-target/agent cargo clippy -p layerx-sdk -p layerx-client --all-targets` | 101 | `qual-logs/agent-clippy.log` | `c52c80a02` |
| clippy over owned targets (`-p layerx-client --lib --test maintenance_reads`, `-p layerx-sdk --lib --test account_reads`) | 0 | `qual-logs/agent-clippy-owned.log` | `c52c80a02` |

Every non-zero exit is a pre-existing failure outside this change, each recorded
below:

- agent tests: every target passes except `real_daemon_availability_refusals`,
  whose native harness exits 1 during bootstrap with `genesis request has an
  unexpected length`. The `account_reads` target passes 5/5 and
  `maintenance_reads` passes 5/5.
- platform boundary: 12 of 14 pass, failing only
  `supervisor_reset_rebuilds_genesis_and_replays_once` (bootstrap `SOURCE_ROOT`)
  and `public_read_selectors_use_real_node_and_refuse_missing_evidence` (the DID
  listing contract). `account_proof_export_preserves_exact_native_verified_bytes`
  passes with the new offline verification of real daemon evidence.
- clippy: `layerx-client/tests/supply_receipt.rs` uses `expect()` twice under a
  workspace `expect_used` denial; clippy over both crate libraries and both
  owned tests exits 0.

## Observations added

`spec/layerx-beta/qualification.kvx`: `6.2.4100` (the `STATE_PROVEN` decision and
the refusal it makes contract-visible), `6.2.4101` (`did_accounts`/
`lx_getBalances` deliberately left unverified), `6.2.4102` (native availability
harness bootstrap refusal), `6.2.4103` (pre-existing `expect_used` clippy
failure), `6.2.4104` (the two pre-existing boundary failures reproduced),
`6.2.4105` (`read.rs::verify_state_value` now duplicates
`verify_account_evidence` and the two live-only checks that keep them separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
