### PR TITLE
Publish the hosted agentd readiness surface and check it on the cluster

### DIFF
--- a/platform/hosted/agentd/manifest_check.py
+++ b/platform/hosted/agentd/manifest_check.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+import copy
+import pathlib
+import re
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+NODE_MANIFEST = ROOT / "platform/hosted/node/deployment.yaml"
+AGENT_MATERIAL = ROOT / "platform/hosted/human/material.py"
+NAMESPACE = "layerx-testnet"
+WORKLOAD = "layerx-node"
+OWNER = "human-owner"
+BOUNDARY = "agentd-boundary"
+SERVICE = "layerx-agentd"
+POLICY = "layerx-node-ingress"
+TLS_VOLUME = "agentd-tls"
+TLS_MOUNT = "/run/layerx/agentd-tls"
+TRUST_MOUNT = "/run/layerx/trust"
+ENDPOINT = re.compile(r"(?:127\.0\.0\.1|0\.0\.0\.0|localhost):(\d+)")
+AGENT_KEYS = ("MODE", "HUMAN_SOCKET", "PROGRAM_LISTEN")
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def agent_config():
+    source = AGENT_MATERIAL.read_text(encoding="utf-8")
+    start = source.index("\n    agent = {")
+    block = source[start:source.index("\n    }\n", start)]
+    values = {}
+    for key in AGENT_KEYS:
+        found = re.search(r"'%s':\s*'([^']*)'" % key, block)
+        require(found is not None, f"{AGENT_MATERIAL.name} does not define the agent {key}")
+        values[key] = found.group(1)
+    return values
+
+
+def documents():
+    return [
+        document
+        for document in yaml.safe_load_all(NODE_MANIFEST.read_text(encoding="utf-8"))
+        if isinstance(document, dict)
+    ]
+
+
+def named(docs, kind, name):
+    for document in docs:
+        if document.get("kind") == kind and document.get("metadata", {}).get("name") == name:
+            return document
+    raise ValueError(f"no {kind} {name} is declared in {NODE_MANIFEST.name}")
+
+
+def env_of(container):
+    return {entry["name"]: entry.get("value") for entry in container.get("env", [])}
+
+
+EXPANSION = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)[^}]*\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def text_of(container):
+    environment = env_of(container)
+    parts = list(container.get("command", [])) + list(container.get("args", []))
+    parts += [value for value in environment.values() if value is not None]
+    for probe in ("readinessProbe", "livenessProbe", "startupProbe"):
+        step = container.get(probe, {}).get("exec", {}).get("command", [])
+        parts += list(step)
+    joined = "\n".join(str(part) for part in parts)
+    return EXPANSION.sub(lambda found: str(environment.get(found.group(1) or found.group(2), found.group(0))), joined)
+
+
+def endpoints(containers):
+    claimed = {}
+    for name, container in containers.items():
+        ports = {str(port) for port in ENDPOINT.findall(text_of(container))}
+        ports |= {str(port.get("containerPort")) for port in container.get("ports", [])}
+        for port in ports:
+            claimed.setdefault(port, set()).add(name)
+    return claimed
+
+
+def listen_port(value, message):
+    host, _, port = value.rpartition(":")
+    require(host == "127.0.0.1", message)
+    require(port.isdigit(), message)
+    return port
+
+
+def validate(docs, config):
+    require(config["MODE"] == "human-owner", "the hosted agent must run the human owner mode")
+    socket = config["HUMAN_SOCKET"]
+    require(socket.startswith("/run/layerx/human/owner/"), "the agent owner socket must stay in the owner-only run directory")
+    health = listen_port(config["PROGRAM_LISTEN"], "the agent health listener must bind loopback")
+
+    node = named(docs, "StatefulSet", WORKLOAD)
+    pod = node["spec"]["template"]["spec"]
+    containers = {container["name"]: container for container in pod["containers"]}
+    volumes = {volume["name"]: volume for volume in pod["volumes"]}
+    require(OWNER in containers, f"the node pod does not run the {OWNER} container")
+    require(BOUNDARY in containers, f"the node pod does not run the {BOUNDARY} container")
+
+    owner = containers[OWNER]
+    require(owner.get("command") == ["/usr/local/bin/human-entrypoint", "agent"], "the owner container must start agentd through the human entry point")
+    sources = [entry.get("secretRef", {}).get("name") for entry in owner.get("envFrom", [])]
+    require("layerx-human-agent-config" in sources, "the owner container must take its configuration from the agent config secret")
+    probe = "\n".join(owner["readinessProbe"]["exec"]["command"])
+    require(f"http://127.0.0.1:{health}/healthz" in probe, "the owner readiness probe must query the configured loopback health listener")
+    require("--config /run/human-private/agent/probe.conf" in probe, "the owner readiness probe must present the agent program bearer")
+
+    boundary = containers[BOUNDARY]
+    values = env_of(boundary)
+    published = str(boundary["ports"][0]["containerPort"])
+    require(len(boundary["ports"]) == 1 and boundary["ports"][0]["name"] == "agentd-tls", "the boundary must publish exactly one named port")
+    require(values.get("LAYERX_AGENTD_HEALTH_PORT") == health, "the boundary must forward to the configured agent health listener")
+    require(values.get("LAYERX_AGENTD_BOUNDARY_PORT") == published, "the boundary listener must match its published container port")
+    relay = "\n".join(str(argument) for argument in boundary["args"])
+    require(socket not in text_of(boundary), "the boundary must never reach the agent owner socket")
+    require("UNIX-CONNECT" not in relay and "UNIX:" not in relay, "the boundary must never relay to a unix socket")
+    require(f'"TCP:127.0.0.1:${{LAYERX_AGENTD_HEALTH_PORT}}"' in relay, "the boundary must forward to loopback only")
+    require("OPENSSL-LISTEN:${LAYERX_AGENTD_BOUNDARY_PORT}" in relay, "the boundary must terminate TLS on its published port")
+    require("verify=1" in relay, "the boundary must require a client certificate")
+    require(f"cafile={TRUST_MOUNT}/ca.crt" in relay, "the boundary must verify clients against the internal CA")
+    require(f"cert={TLS_MOUNT}/tls.crt" in relay and f"key={TLS_MOUNT}/tls.key" in relay, "the boundary must serve the agentd server identity")
+    security = boundary["securityContext"]
+    require(int(security["runAsUser"]) == 4021, "the boundary must run as the owner identity")
+    require(security["readOnlyRootFilesystem"] in (True, "true"), "the boundary root filesystem must be read only")
+    require(security["allowPrivilegeEscalation"] in (False, "false"), "the boundary must not allow privilege escalation")
+    require(security["capabilities"]["drop"] == ["ALL"], "the boundary must drop every capability")
+    mounts = {mount["mountPath"]: mount for mount in boundary["volumeMounts"]}
+    require(set(mounts) == {TLS_MOUNT, TRUST_MOUNT}, "the boundary must mount its own identity and the trust root and nothing else")
+    for path in (TLS_MOUNT, TRUST_MOUNT):
+        require(mounts[path].get("readOnly") in (True, "true"), f"the boundary must mount {path} read only")
+    require(mounts[TLS_MOUNT]["name"] == TLS_VOLUME, "the boundary server identity must come from the agentd TLS volume")
+    require(volumes.get(TLS_VOLUME, {}).get("secret", {}).get("secretName") == "layerx-agentd-tls", "the agentd TLS volume must come from the agentd TLS secret")
+
+    claimed = endpoints(containers)
+    require(claimed.get(health) == {OWNER, BOUNDARY}, f"port {health} is claimed by {sorted(claimed.get(health, ()))}, not by the agent health listener and its boundary alone")
+    require(claimed.get(published) == {BOUNDARY}, f"port {published} is claimed by {sorted(claimed.get(published, ()))}, not by the boundary alone")
+
+    service = named(docs, "Service", SERVICE)
+    require(service["metadata"]["namespace"] == NAMESPACE, "the agentd Service must live beside the node")
+    require(service["spec"]["selector"] == {"app": WORKLOAD}, "the agentd Service must select the node pod that runs agentd")
+    ports = service["spec"]["ports"]
+    require(len(ports) == 1, "the agentd Service must publish exactly one port")
+    require(str(ports[0]["targetPort"]) == "agentd-tls", "the agentd Service must publish the boundary port by name")
+    for other in docs:
+        if other.get("kind") != "Service" or other["spec"].get("selector", {}).get("app") != WORKLOAD:
+            continue
+        exposed = {str(port.get("targetPort")) for port in other["spec"]["ports"]}
+        require(health not in exposed, f"Service {other['metadata']['name']} exposes the agent loopback health listener")
+
+    isolated = False
+    for policy in docs:
+        if policy.get("kind") != "NetworkPolicy":
+            continue
+        spec = policy["spec"]
+        if spec.get("podSelector") != {"matchLabels": {"app": WORKLOAD}} or "Ingress" not in spec.get("policyTypes", []):
+            continue
+        isolated = True
+        for rule in spec.get("ingress", []):
+            ports = {str(port.get("port")) for port in rule.get("ports", [])}
+            require(ports, f"NetworkPolicy {policy['metadata']['name']} admits every port of the node pod")
+            require(published not in ports, f"NetworkPolicy {policy['metadata']['name']} admits the agentd boundary to a cluster workload")
+            require(health not in ports, f"NetworkPolicy {policy['metadata']['name']} admits the agent loopback health listener")
+    require(isolated, "the node pod must carry an ingress policy, so the agentd boundary is closed to the cluster by default")
+
+
+def negative_tests(docs, config):
+    def boundary(bundle):
+        node = next(d for d in bundle if d.get("kind") == "StatefulSet" and d["metadata"]["name"] == WORKLOAD)
+        return next(c for c in node["spec"]["template"]["spec"]["containers"] if c["name"] == BOUNDARY)
+
+    def owner(bundle):
+        node = next(d for d in bundle if d.get("kind") == "StatefulSet" and d["metadata"]["name"] == WORKLOAD)
+        return next(c for c in node["spec"]["template"]["spec"]["containers"] if c["name"] == OWNER)
+
+    def relay(bundle, old, new):
+        container = boundary(bundle)
+        container["args"] = [str(argument).replace(old, new) for argument in container["args"]]
+
+    def relay_to_owner_socket(bundle, values):
+        container = boundary(bundle)
+        container["env"].append({"name": "LAYERX_AGENTD_OWNER_SOCKET", "value": values["HUMAN_SOCKET"]})
+        container["args"] = list(container["args"]) + ['socat -T 30 "TCP-LISTEN:9455,fork" "UNIX-CONNECT:${LAYERX_AGENTD_OWNER_SOCKET}"']
+
+    def mount_the_owner_run_directory(bundle, values):
+        boundary(bundle)["volumeMounts"].append({"name": "run", "mountPath": "/run/layerx", "readOnly": True})
+
+    def collide(bundle, values):
+        values["PROGRAM_LISTEN"] = "127.0.0.1:9451"
+        for entry in boundary(bundle)["env"]:
+            if entry["name"] == "LAYERX_AGENTD_HEALTH_PORT":
+                entry["value"] = "9451"
+        probe = owner(bundle)["readinessProbe"]["exec"]["command"]
+        probe[:] = [step.replace("127.0.0.1:9453", "127.0.0.1:9451") for step in probe]
+
+    def unprotected_probe(bundle, values):
+        probe = owner(bundle)["readinessProbe"]["exec"]["command"]
+        probe[:] = [step.replace("--config /run/human-private/agent/probe.conf ", "") for step in probe]
+
+    def service_exposes_health(bundle, values):
+        service = next(d for d in bundle if d.get("kind") == "Service" and d["metadata"]["name"] == SERVICE)
+        service["spec"]["ports"][0]["targetPort"] = 9453
+
+    def service_selects_nothing(bundle, values):
+        service = next(d for d in bundle if d.get("kind") == "Service" and d["metadata"]["name"] == SERVICE)
+        service["spec"]["selector"] = {"app": "layerx-elsewhere"}
+
+    def policy_admits_the_boundary(bundle, values):
+        policy = next(d for d in bundle if d.get("kind") == "NetworkPolicy" and d["metadata"]["name"] == POLICY)
+        policy["spec"]["ingress"].append({"from": [{"podSelector": {"matchLabels": {"app": "layerx-gateway"}}}], "ports": [{"protocol": "TCP", "port": 9454}]})
+
+    def policy_admits_every_port(bundle, values):
+        policy = next(d for d in bundle if d.get("kind") == "NetworkPolicy" and d["metadata"]["name"] == POLICY)
+        policy["spec"]["ingress"].append({"from": [{"podSelector": {"matchLabels": {"app": "layerx-gateway"}}}]})
+
+    def drop_ingress_isolation(bundle, values):
+        policy = next(d for d in bundle if d.get("kind") == "NetworkPolicy" and d["metadata"]["name"] == POLICY)
+        bundle.remove(policy)
+
+    mutations = [
+        ("health-port-collides-with-the-guarantor-exchange", collide),
+        ("boundary-forwards-beyond-loopback", lambda bundle, values: relay(bundle, "TCP:127.0.0.1:", "TCP:0.0.0.0:")),
+        ("boundary-accepts-unverified-clients", lambda bundle, values: relay(bundle, ",verify=1", "")),
+        ("boundary-trusts-a-foreign-authority", lambda bundle, values: relay(bundle, f"cafile={TRUST_MOUNT}/ca.crt", "cafile=/tmp/ca.crt")),
+        ("boundary-root-filesystem-writable", lambda bundle, values: boundary(bundle)["securityContext"].update(readOnlyRootFilesystem=False)),
+        ("owner-probe-drops-the-bearer", unprotected_probe),
+        ("service-exposes-the-loopback-health-listener", service_exposes_health),
+        ("service-selects-no-agentd-workload", service_selects_nothing),
+        ("policy-admits-the-agentd-boundary", policy_admits_the_boundary),
+        ("policy-admits-every-node-port", policy_admits_every_port),
+        ("node-pod-loses-ingress-isolation", drop_ingress_isolation),
+        ("boundary-relays-the-owner-socket", relay_to_owner_socket),
+        ("boundary-mounts-the-owner-run-directory", mount_the_owner_run_directory),
+    ]
+    for name, mutate in mutations:
+        bundle = copy.deepcopy(docs)
+        values = dict(config)
+        mutate(bundle, values)
+        try:
+            validate(bundle, values)
+        except (ValueError, KeyError, IndexError, StopIteration):
+            print(f"agentd-manifest: negative {name} rejected")
+        else:
+            raise ValueError(f"negative agentd manifest case unexpectedly accepted: {name}")
+    return len(mutations)
+
+
+def main():
+    config = agent_config()
+    docs = documents()
+    validate(docs, config)
+    rejected = negative_tests(docs, config)
+    print(
+        "agentd-manifest: %s Service, mutually authenticated boundary on the %s loopback health listener,"
+        " owner socket %s held private, and %d negative mutations passed"
+        % (SERVICE, config["PROGRAM_LISTEN"], config["HUMAN_SOCKET"], rejected)
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (ValueError, KeyError, IndexError, StopIteration, OSError) as error:
+        print(f"agentd-manifest: FAIL {error}", file=sys.stderr)
+        sys.exit(1)

--- a/platform/hosted/agentd/probe.sh
+++ b/platform/hosted/agentd/probe.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+set -eu
+umask 077
+
+usage() {
+    cat <<'USAGE'
+usage: probe.sh --url URL --ca FILE --client-cert FILE --client-key FILE --bearer-file FILE
+
+Probes the hosted agentd Service. The Service publishes the agentd loopback
+health surface through a mutually authenticated TLS boundary, so a ready
+deployment answers only when the caller presents both a client certificate the
+internal CA issued and the agent program bearer. The probe asserts all three
+properties: the authenticated request reports ready, the same request without
+the bearer is refused, and a request without a client certificate never reaches
+HTTP at all.
+USAGE
+}
+
+url=
+ca=
+client_cert=
+client_key=
+bearer_file=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --url) url=${2:?probe.sh: --url needs a value}; shift 2 ;;
+        --ca) ca=${2:?probe.sh: --ca needs a value}; shift 2 ;;
+        --client-cert) client_cert=${2:?probe.sh: --client-cert needs a value}; shift 2 ;;
+        --client-key) client_key=${2:?probe.sh: --client-key needs a value}; shift 2 ;;
+        --bearer-file) bearer_file=${2:?probe.sh: --bearer-file needs a value}; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'probe.sh: unknown argument %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+for required in url ca client_cert client_key bearer_file; do
+    eval "value=\$$required"
+    if [ -z "$value" ]; then
+        printf 'probe.sh: --%s is required\n' "$(printf '%s' "$required" | tr '_' '-')" >&2
+        exit 2
+    fi
+done
+for file in "$ca" "$client_cert" "$client_key" "$bearer_file"; do
+    [ -r "$file" ] || { printf 'probe.sh: %s is not readable\n' "$file" >&2; exit 2; }
+done
+[ -s "$bearer_file" ] || { printf 'probe.sh: the agent program bearer is empty\n' >&2; exit 2; }
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT INT TERM
+printf 'header = "Authorization: Bearer %s"\n' "$(cat "$bearer_file")" > "$work/bearer.conf"
+
+status=0
+curl --silent --show-error --max-time 10 --output "$work/ready.json" --write-out '%{http_code}' \
+    --cacert "$ca" --cert "$client_cert" --key "$client_key" --config "$work/bearer.conf" \
+    "$url/healthz" > "$work/ready.code" 2> "$work/ready.err" || status=$?
+if [ "$status" != 0 ]; then
+    printf 'agentd-probe: authenticated health request failed (curl %s)\n' "$status" >&2
+    sed -n '1,10p' "$work/ready.err" >&2
+    exit 1
+fi
+if [ "$(cat "$work/ready.code")" != 200 ]; then
+    printf 'agentd-probe: health returned HTTP %s\n' "$(cat "$work/ready.code")" >&2
+    sed -n '1,10p' "$work/ready.json" >&2
+    exit 1
+fi
+if ! grep -q '"ready":true' "$work/ready.json"; then
+    printf 'agentd-probe: health did not report a ready owner\n' >&2
+    sed -n '1,10p' "$work/ready.json" >&2
+    exit 1
+fi
+
+status=0
+curl --silent --show-error --max-time 10 --output "$work/anonymous.json" --write-out '%{http_code}' \
+    --cacert "$ca" --cert "$client_cert" --key "$client_key" \
+    "$url/healthz" > "$work/anonymous.code" 2> "$work/anonymous.err" || status=$?
+if [ "$status" != 0 ]; then
+    printf 'agentd-probe: unauthenticated health request failed before HTTP (curl %s)\n' "$status" >&2
+    sed -n '1,10p' "$work/anonymous.err" >&2
+    exit 1
+fi
+if [ "$(cat "$work/anonymous.code")" != 401 ]; then
+    printf 'agentd-probe: health without the agent program bearer returned HTTP %s, not 401\n' \
+        "$(cat "$work/anonymous.code")" >&2
+    exit 1
+fi
+
+status=0
+curl --silent --show-error --max-time 10 --output /dev/null \
+    --cacert "$ca" --config "$work/bearer.conf" \
+    "$url/healthz" > /dev/null 2> "$work/unverified.err" || status=$?
+if [ "$status" = 0 ]; then
+    printf 'agentd-probe: the boundary accepted a client without a certificate\n' >&2
+    exit 1
+fi
+
+printf 'agentd-probe: %s ready; bearer and client certificate both enforced\n' "$url"

--- a/platform/hosted/human/material.py
+++ b/platform/hosted/human/material.py
@@ -123,7 +123,7 @@ def main():
         'HUMAN_RECONNECT_JITTER_PERCENT': 10,
         'HUMAN_AUTHORITY_ENDPOINT': 'https://layerx-receipt-authority.layerx-testnet.svc.cluster.local:9443',
         'HUMAN_AUTHORITY_MAX_BYTES': 1048576,
-        'PROGRAM_LISTEN': '127.0.0.1:9451', 'PROGRAM_MAX_STALENESS_MS': 60000,
+        'PROGRAM_LISTEN': '127.0.0.1:9453', 'PROGRAM_MAX_STALENESS_MS': 60000,
         'NODE_ENDPOINT': 'http://127.0.0.1:9401',
         'AUTHORITY_ENDPOINT': 'https://layerx-receipt-authority.layerx-testnet.svc.cluster.local:9443',
         'AUTHORITY_REPLICA_ID': (root.parent / 'receipt-authority-replica-id').read_text().strip(),

--- a/platform/hosted/node/deployment.yaml
+++ b/platform/hosted/node/deployment.yaml
@@ -370,6 +370,28 @@ spec:
             - {name: gateway-component, mountPath: /run/layerx/gateway-component, readOnly: true}
             - {name: webhooks-component, mountPath: /run/layerx/webhooks-component, readOnly: true}
             - {name: registry-component, mountPath: /run/layerx/registry-component, readOnly: true}
+        - name: agentd-boundary
+          image: ghcr.io/sidiora-labs/layerx-node:0.1.0
+          imagePullPolicy: Always
+          command: [/bin/sh, -ec]
+          args:
+            - |
+              : "${LAYERX_AGENTD_BOUNDARY_PORT:?agentd boundary port is required}"
+              : "${LAYERX_AGENTD_HEALTH_PORT:?agentd health port is required}"
+              while ! socat -T 2 /dev/null "TCP:127.0.0.1:${LAYERX_AGENTD_HEALTH_PORT}" > /dev/null 2>&1; do sleep 1; done
+              exec socat -T 30 \
+                "OPENSSL-LISTEN:${LAYERX_AGENTD_BOUNDARY_PORT},bind=0.0.0.0,reuseaddr,fork,cert=/run/layerx/agentd-tls/tls.crt,key=/run/layerx/agentd-tls/tls.key,cafile=/run/layerx/trust/ca.crt,verify=1" \
+                "TCP:127.0.0.1:${LAYERX_AGENTD_HEALTH_PORT}"
+          env:
+            - {name: LAYERX_AGENTD_BOUNDARY_PORT, value: "9454"}
+            - {name: LAYERX_AGENTD_HEALTH_PORT, value: "9453"}
+          ports: [{name: agentd-tls, containerPort: 9454}]
+          readinessProbe: {tcpSocket: {port: agentd-tls}, periodSeconds: 10, timeoutSeconds: 5}
+          resources: {requests: {cpu: 50m, memory: 32Mi}, limits: {cpu: 500m, memory: 128Mi}}
+          securityContext: {runAsUser: 4021, runAsGroup: 4020, allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: {drop: [ALL]}}
+          volumeMounts:
+            - {name: agentd-tls, mountPath: /run/layerx/agentd-tls, readOnly: true}
+            - {name: trust, mountPath: /run/layerx/trust, readOnly: true}
         - name: human
           image: ghcr.io/sidiora-labs/layerx-human:0.1.0
           imagePullPolicy: Always
@@ -734,7 +756,7 @@ spec:
               command:
                 - /bin/sh
                 - -ec
-                - exec curl --fail --silent --show-error --max-time 5 --config /run/human-private/agent/probe.conf http://127.0.0.1:9451/healthz
+                - exec curl --fail --silent --show-error --max-time 5 --config /run/human-private/agent/probe.conf http://127.0.0.1:9453/healthz
             timeoutSeconds: 6
             periodSeconds: 10
       volumes:
@@ -762,6 +784,7 @@ spec:
         - {name: core-admin-tls, secret: {secretName: layerx-pending-core-admin-tls}}
         - {name: authority-tls, secret: {secretName: layerx-receipt-authority-tls}}
         - {name: agent-tls, secret: {secretName: layerx-agent-boundary-tls}}
+        - {name: agentd-tls, secret: {secretName: layerx-agentd-tls, defaultMode: 0440}}
         - {name: gateway-authority, secret: {secretName: layerx-gateway-authority-client}}
         - {name: registry-authority, secret: {secretName: layerx-program-registry-authority-client}}
         - {name: webhooks-authority, secret: {secretName: layerx-webhooks-authority-client}}
@@ -873,3 +896,8 @@ spec:
       ports: [{protocol: TCP, port: 9444}]
     - to: [{podSelector: {matchLabels: {app: layerx-node}}}]
       ports: [{protocol: TCP, port: 9445}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: layerx-agentd, namespace: layerx-testnet}
+spec: {type: ClusterIP, selector: {app: layerx-node}, ports: [{name: https, port: 9443, targetPort: agentd-tls}]}

--- a/platform/hosted/tests/beta-cluster.sh
+++ b/platform/hosted/tests/beta-cluster.sh
@@ -414,6 +414,9 @@ ca_generate() {
         "DNS:layerx-receipt-authority.$svc,DNS:layerx-receipt-authority.$TESTNET_NAMESPACE.svc,DNS:layerx-receipt-authority,DNS:authority.$internal,DNS:authority.$INTERNAL_NAMESPACE.svc"
     issue_cert agent-boundary layerx-agent-boundary serverAuth \
         "DNS:layerx-agent-boundary.$svc,DNS:layerx-agent-boundary.$TESTNET_NAMESPACE.svc,DNS:layerx-agent-boundary,DNS:component.$internal,DNS:component.$INTERNAL_NAMESPACE.svc,DNS:localhost,IP:127.0.0.1"
+    issue_cert agentd layerx-agentd serverAuth \
+        "DNS:layerx-agentd.$svc,DNS:layerx-agentd.$TESTNET_NAMESPACE.svc,DNS:layerx-agentd,DNS:localhost,IP:127.0.0.1"
+    issue_cert agentd-client layerx-agentd-client clientAuth ""
     issue_cert identity layerx-identity serverAuth \
         "DNS:layerx-identity.$svc,DNS:layerx-identity.$TESTNET_NAMESPACE.svc,DNS:layerx-identity,DNS:identity.$internal,DNS:identity.$INTERNAL_NAMESPACE.svc,DNS:localhost,IP:127.0.0.1"
     issue_cert paxeer-boundary paxeer-boundary serverAuth \
@@ -805,6 +808,7 @@ secrets_apply() {
     apply_secret "$ns" layerx-pending-core-admin-tls --from-file=server.crt.der="$c/pending-core-admin/cert.der" --from-file=server.key.der="$c/pending-core-admin/key.der"
     apply_secret "$ns" layerx-receipt-authority-tls --from-file=server.crt.der="$c/receipt-authority/cert.der" --from-file=server.key.der="$c/receipt-authority/key.der"
     apply_secret "$ns" layerx-agent-boundary-tls --from-file=server.crt.der="$c/agent-boundary/cert.der" --from-file=server.key.der="$c/agent-boundary/key.der"
+    apply_secret "$ns" layerx-agentd-tls --from-file=tls.crt="$c/agentd/cert.pem" --from-file=tls.key="$c/agentd/key.pem"
     apply_secret "$ns" layerx-webhooks-authority-client --from-file=token="$s/developer-authority.token"
     apply_secret "$ns" layerx-identity-server-tls --from-file=server.crt.der="$c/identity/cert.der" --from-file=server.key.der="$c/identity/key.der"
     apply_secret "$ns" layerx-identity-service-tokens --from-file="$s/identity-tokens"
@@ -1649,6 +1653,9 @@ env_write() {
         printf 'export LAYERX_GATEWAY_CA_FILE=%s\n' "$CA_DIR/ca.crt"
         printf 'export WEBHOOKS_URL=%s\n' "$DEVELOPER_URL"
         printf 'export LAYERX_AGENT_BOUNDARY_URL=%s\n' "$AGENT_URL"
+        printf 'export LAYERX_AGENTD_URL=%s\n' "$AGENTD_URL"
+        printf 'export LAYERX_AGENTD_CLIENT_CERT_FILE=%s\n' "$CA_DIR/agentd-client/cert.pem"
+        printf 'export LAYERX_AGENTD_CLIENT_KEY_FILE=%s\n' "$CA_DIR/agentd-client/key.pem"
         printf 'export LAYERX_IDENTITY_URL=%s\n' "$IDENTITY_URL"
         printf 'export LAYERX_PAXEER_BOUNDARY_URL=%s\n' "$PAXEER_URL"
         printf 'export LAYERX_PAXEER_SETTLEMENT_CONTRACT=%s\n' "$GUARANTOR_BOND"
@@ -1660,8 +1667,8 @@ env_write() {
     cat "$WORK_DIR/human-owner.env" >> "$ENV_FILE"
     qualification_url LAYERX_QUALIFICATION_NODE_URL LAYERX_BETA_QUALIFICATION_NODE_URL "$NODE_URL" \
         "beta_driver.py --node-url: the core boundary Service layerx-pending-core (node readiness, state and receipts)"
-    qualification_url LAYERX_QUALIFICATION_AGENT_URL LAYERX_BETA_QUALIFICATION_AGENT_URL "" \
-        "beta_driver.py --agentd-url requires agentd; no hosted agentd Service is declared"
+    qualification_url LAYERX_QUALIFICATION_AGENT_URL LAYERX_BETA_QUALIFICATION_AGENT_URL "$AGENTD_URL" \
+        "beta_driver.py --agentd-url: the agentd Service layerx-agentd (owner daemon readiness behind a mutually authenticated boundary)"
     qualification_url LAYERX_QUALIFICATION_HUMAN_URL LAYERX_BETA_QUALIFICATION_HUMAN_URL "$HUMAN_URL" \
         "beta_driver.py --human-service-url: layerx-human HTTPS API; /readyz verifies all production components"
     qualification_url LAYERX_QUALIFICATION_PAXEER_URL LAYERX_BETA_QUALIFICATION_PAXEER_URL "$PAXEER_URL" \
@@ -1706,6 +1713,17 @@ identity_write() {
     } > "$IDENTITY_FILE"
     printf 'beta-cluster: cluster identity\n' >&2
     sed 's/^/beta-cluster:   /' "$IDENTITY_FILE" >&2
+}
+
+agentd_check() {
+    log "agentd: probing the published owner daemon readiness surface at $AGENTD_URL"
+    sh "$REPO_ROOT/platform/hosted/agentd/probe.sh" \
+        --url "$AGENTD_URL" \
+        --ca "$CA_DIR/ca.crt" \
+        --client-cert "$CA_DIR/agentd-client/cert.pem" \
+        --client-key "$CA_DIR/agentd-client/key.pem" \
+        --bearer-file "$SECRETS_DIR/human/agent/program-token" \
+        || fail "the hosted agentd Service did not answer as a ready, mutually authenticated owner daemon"
 }
 
 boundary_checks() {
@@ -1816,6 +1834,7 @@ beta_cluster_up() {
     DEVELOPER_URL="https://localhost:19450"
     NODE_URL="https://localhost:19446"
     AGENT_URL="https://localhost:19447"
+    AGENTD_URL="https://localhost:19456"
     PAXEER_URL="https://localhost:19449"
     PAXEER_OBSERVER_URL="https://localhost:19452"
     IDENTITY_URL="https://localhost:$IDENTITY_PORT"
@@ -1869,7 +1888,9 @@ beta_cluster_up() {
     port_forward developer "$DEVELOPER_NAMESPACE" layerx-webhooks 19450 443
     port_forward pending-core "$TESTNET_NAMESPACE" layerx-pending-core 19446 9443
     port_forward agent-boundary "$TESTNET_NAMESPACE" layerx-agent-boundary 19447 9443
+    port_forward agentd "$TESTNET_NAMESPACE" layerx-agentd 19456 9443
     wait_for_pod_ready "$TESTNET_NAMESPACE" app=layerx-node 600
+    agentd_check
     module_registry_verify
     if [ "${LAYERX_BETA_RETAIN_MATERIAL:-0}" != 1 ]; then material_save; fi
     env_write

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -8942,3 +8942,59 @@ symbol = "verify_state_value verify_account_evidence"
 observed = "read.rs verify_state_value and the evidence.rs verify_account_evidence this row added now perform the same nested account verification: decode the evidence, bind the root selector and account, pin the sequencer key, and run verify_nested_account or verify_nested_account_maintenance. They are not interchangeable, because verify_state_value additionally requires the signed header's response authorization to equal the live handshake authorization and a Latest selector to name the currently sealed batch, neither of which an offline receiver of exported bytes can evaluate. Routing the live read through the shared verifier would need those two live checks factored out of the shared body."
 assumption = "read.rs is outside this row's owned files and the duplication is exact rather than divergent, so the live read path was left unchanged and the consolidation is recorded for the owner of the point-read path."
 severity = "note"
+
+[observation.3.7.4400]
+task = "3.7"
+file = "platform/hosted/human/material.py platform/hosted/node/deployment.yaml cmd/layerx-guarantor/exchange.c cmd/layerx-guarantor/main.c"
+symbol = "PROGRAM_LISTEN LAYERX_AGENT_PROGRAM_LISTEN guarantor-1 lxp_guarantor_exchange_listen"
+observed = "The node pod placed two unrelated listeners on the same loopback port. platform/hosted/human/material.py wrote LAYERX_AGENT_PROGRAM_LISTEN as 127.0.0.1:9451 into the layerx-human-agent-config secret, and the human-owner container's readiness probe in platform/hosted/node/deployment.yaml queried http://127.0.0.1:9451/healthz, while the guarantor-1 container of the same pod declares containerPort 9451 and cmd/layerx-guarantor/exchange.c binds htonl(INADDR_LOOPBACK) on the port named by LAYERX_GUARANTOR_LISTEN_PORT, opened unconditionally from cmd/layerx-guarantor/main.c. Containers of one pod share a network namespace, so whichever of the two started second could not bind and the pod could never satisfy wait_for_pod_ready app=layerx-node."
+assumption = "The guarantor exchange port is protocol surface fixed by the two guarantor identities, their peer URLs and the topology check, while the agent program listener is a private readiness surface named only by the generated agent configuration and its own probe. The listener was therefore moved to 127.0.0.1:9453 in material.py and in the human-owner readiness probe; no guarantor value, assertion or port was touched, and platform/hosted/agentd/manifest_check.py now proves every loopback port of the pod is claimed by exactly the containers entitled to it."
+severity = "note"
+
+[observation.3.7.4401]
+task = "3.7"
+file = "platform/hosted/node/deployment.yaml platform/hosted/human/material.py platform/hosted/human/entrypoint.sh"
+symbol = "human-owner human-entrypoint LAYERX_AGENT_MODE"
+observed = "The hosted stack was recorded as carrying no agentd. The daemon is in fact deployed: the human-owner container of the layerx-node StatefulSet runs /usr/local/bin/human-entrypoint agent, platform/hosted/human/entrypoint.sh execs layerx-agentd with the material it installs, and platform/hosted/human/material.py sets LAYERX_AGENT_MODE to human-owner. What was absent is publication and proof: no Service selected the daemon, nothing outside the pod could reach it, and platform/hosted/tests/beta-cluster.sh recorded the absence in place of the qualification agent URL rather than checking anything."
+assumption = "The deployed daemon is the real agentd, so the work is to publish and prove the surface it already serves rather than to add a second copy of it. A layerx-agentd Service, a mutually authenticated boundary container, a manifest gate and a cluster probe were added; the daemon, its mode and its entry point are unchanged."
+severity = "note"
+
+[observation.3.7.4402]
+task = "3.7"
+file = "agent/crates/layerx-agentd/src/main.rs agent/crates/layerx-agentd/src/human_owner_mode.rs platform/hosted/node/deployment.yaml"
+symbol = "config serve_human_owner LAYERX_AGENT_PROGRAM_LISTEN LAYERX_AGENT_HUMAN_NODE_LNI agentd-boundary"
+observed = "agentd cannot be published as a workload of its own. Its configuration refuses to start unless LAYERX_AGENT_PROGRAM_LISTEN begins with 127.0.0.1:, and its human-owner mode requires the node's LNI unix socket and an owner socket guarded by SO_PEERCRED, all of which exist only inside the node pod. A Service can therefore reach the daemon only through a process that shares that network namespace."
+assumption = "Rather than relax the loopback refusal or duplicate the daemon, the deployment publishes the surface through an agentd-boundary container in the same pod that terminates TLS with the layerx-agentd-tls identity, requires a client certificate the internal CA issued, and forwards to 127.0.0.1 alone. Only the readiness surface is published: the bearer that GET /healthz demands is still enforced inside the daemon, the owner unix socket and its peer-credential check are never relayed, the boundary mounts nothing but its own identity and the trust root, and the existing layerx-node ingress policy leaves the boundary port closed to every cluster workload, so the surface is reachable only through the API server."
+severity = "assumption"
+
+[observation.3.7.4403]
+task = "3.7"
+file = "platform/hosted/node/deployment.yaml platform/hosted/human/material.py"
+symbol = "agentd-boundary layerx-agentd PROGRAM_LISTEN"
+observed = "Two changes fall outside the shape this work was scoped to. The Service is appended at the end of platform/hosted/node/deployment.yaml as scoped, but the boundary container and its volume must sit inside the StatefulSet, so two hunks land in the middle of that file; the container is placed immediately after agent-boundary, away from the daemon containers and from the end of the container list. The port repair also touches platform/hosted/human/material.py, which is the only source of the agent program listener value."
+assumption = "A boundary that shares the pod network namespace is the only way to publish a loopback-only listener, and a Service that resolves to a colliding, never-ready pod would be evidence of nothing, so both changes are required for the published surface to be real. The mid-file hunks are as far from the container list boundaries as the pod layout allows."
+severity = "note"
+
+[observation.3.7.4404]
+task = "3.7"
+file = "platform/hosted/tests/beta-cluster.sh platform/hosted/agentd/probe.sh platform/hosted/agentd/manifest_check.py"
+symbol = "agentd_check qualification_url beta_cluster_up"
+observed = "beta-cluster.sh now issues the layerx-agentd server and client identities, applies the layerx-agentd-tls secret, forwards the Service, calls agentd_check once the node pod reports ready, and passes the real address to the qualification driver in place of the record of absence. The bring-up itself could not be executed here: kind and kubectl are absent from this environment, so no cluster exists to stand up."
+assumption = "The cluster path is exercised only by its own gates: the shell parses, and platform/hosted/agentd/manifest_check.py loads the manifest and proves the boundary, the Service, the port disjointness of the pod and the ingress closure, together with thirteen mutations that must be refused. The probe asserts the three properties a ready deployment must show, and it is wired into the bring-up so that a cluster that does not show them fails the bring-up rather than being recorded as unavailable."
+severity = "note"
+
+[observation.3.7.4405]
+task = "3.7"
+file = "platform/hosted/tests/topology-regressions.py platform/hosted/tests/topology-check.sh platform/Makefile.inc"
+symbol = "baseline platform-hosted-topology-check"
+observed = "make platform-hosted-topology-check exits 2 on an unmodified tree. platform/hosted/tests/topology-check.sh resolves every edge of the nine hosted manifests with no failure under both parsers, and platform/hosted/tests/topology_check.py passes with its seven refusals, but platform/hosted/tests/topology-regressions.py:26 asserts the baseline without the Human manifest holds exactly forty resolved edges and the tree holds forty one, and line 88 asserts the complete topology holds forty two where the tree holds forty three. Both parsers report the same forty four edges, one external and zero failed, before and after the agentd Service is added, so the counts those assertions pin moved when hosted edges were added by other work and the failure reproduces on an unmodified checkout of the branch point."
+assumption = "The assertion is a real regression fence over a count that other lanes changed, so raising the number here would weaken a check that belongs to the topology owner and would hide whichever addition moved it. Both literals were left exactly as written; the agentd Service adds no edge and no failure to either parser."
+severity = "blocker"
+
+[observation.3.7.4406]
+task = "3.7"
+file = "platform/hosted/tests/beta-cluster.sh"
+symbol = "beta_cluster_render secrets_generate module_registry_generate"
+observed = "beta-cluster.sh render, the one cluster path that needs no cluster, cannot run in this environment either: secrets_generate calls module_registry_generate, which runs the layerx-node image through docker to produce the module registry, and the beta image tags name a local build that does not exist, so docker refuses the pull and the render exits before ca_generate reaches the new agentd identities or manifests_render reaches the boundary container."
+assumption = "Building the beta images is the images subcommand of the same script and is not part of this work, so the render was left as it is. The manifest that render would emit is checked directly instead: platform/hosted/agentd/manifest_check.py loads platform/hosted/node/deployment.yaml, and the certificate and secret hunks are covered by the shell parse."
+severity = "note"


### PR DESCRIPTION
## Issue

The hosted stack had no reachable agentd. The owner agent daemon is deployed — the `human-owner` container of the `layerx-node` StatefulSet runs `human-entrypoint agent`, and `platform/hosted/human/material.py` sets `LAYERX_AGENT_MODE` to `human-owner` — but no Service selected it, nothing outside the pod could reach it, and `platform/hosted/tests/beta-cluster.sh` recorded the absence in place of the qualification agent URL instead of checking anything.

## What changed and why

**The program listener collided with the guarantor exchange.** `material.py` wrote `LAYERX_AGENT_PROGRAM_LISTEN` as `127.0.0.1:9451` and the owner readiness probe queried the same address, while `guarantor-1` of the same pod declares `containerPort: 9451` and `cmd/layerx-guarantor/exchange.c` binds `INADDR_LOOPBACK` on `LAYERX_GUARANTOR_LISTEN_PORT`. Containers of one pod share a network namespace, so the second of the two could never bind and the pod could never satisfy `wait_for_pod_ready app=layerx-node`. The agent listener and its probe move to `9453`; no guarantor value or assertion is touched.

**agentd cannot be a workload of its own.** Its configuration refuses any `LAYERX_AGENT_PROGRAM_LISTEN` that does not begin with `127.0.0.1:`, and human-owner mode needs the node LNI socket and an owner socket guarded by `SO_PEERCRED`. A Service can reach it only through a process sharing that namespace, so an `agentd-boundary` container in the node pod terminates TLS with its own `layerx-agentd-tls` identity, requires a client certificate the internal CA issued (`verify=1`), and forwards to the loopback health listener alone. Only the readiness surface is published: the bearer that `GET /healthz` demands is still enforced inside the daemon, the owner unix socket is never relayed and the boundary mounts nothing but its own identity and the trust root. The existing `layerx-node-ingress` policy leaves the boundary port closed to every cluster workload, so the surface is reachable only through the API server. A ClusterIP `layerx-agentd` Service publishes the boundary port by name.

**The record of absence becomes a check.** `platform/hosted/agentd/probe.sh` asserts the three properties a ready deployment shows: the authenticated mutually-TLS request reports a ready owner, the same request without the bearer is refused 401, and a caller with no client certificate never reaches HTTP. `beta-cluster.sh` issues the server and client identities, applies the `layerx-agentd-tls` secret, forwards the Service, runs the probe once the node pod reports ready, and hands the real address to `beta_driver.py --agentd-url`.

**The manifest gains a gate.** `platform/hosted/agentd/manifest_check.py` loads the manifest with `yaml.safe_load_all`, checks the fields the deployment depends on against the generated agent configuration, proves every loopback port of the pod is claimed by exactly the containers entitled to it, and refuses thirteen mutations — including the port collision this change repairs, a boundary that forwards past loopback, one that drops `verify=1`, one that trusts a foreign authority, one that relays the owner socket, a Service that exposes the health listener, and any policy that admits the boundary port to a cluster workload.

## Gates

| Command | Exit | Log | Revision |
|---|---|---|---|
| `python3 platform/hosted/agentd/manifest_check.py` | 0 | `qual-logs/agentd-manifest-check.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `sh -n platform/hosted/agentd/probe.sh` | 0 | `qual-logs/probe-shell-parse.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `bash -n platform/hosted/tests/beta-cluster.sh` | 0 | `qual-logs/beta-cluster-shell-parse.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `python3 platform/hosted/tests/topology_check.py` | 0 | `qual-logs/guarantor-topology-check.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `make beta-ledger-check` | 0 | `qual-logs/beta-ledger-check.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `make platform-hosted-topology-check` | 2 | `qual-logs/platform-hosted-topology-check.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |
| `bash platform/hosted/tests/beta-cluster.sh render` | 125 | `qual-logs/beta-cluster-render.log` | `c38adc305d9699c31a15e1da80cb5e2711a301a7` |

`make platform-hosted-topology-check` fails identically on an unmodified checkout of the branch point: `topology-check.sh` resolves all 44 edges with 0 failures under both parsers and `topology_check.py` passes, but `topology-regressions.py:26` pins the pre-Human baseline at 40 resolved edges (the tree holds 41) and the complete topology at 42 (the tree holds 43). Both parsers report the same counts before and after this change, so the agentd Service adds no edge and no failure; both literals were left as written and the staleness is recorded rather than raised.

`beta-cluster.sh render` exits before reaching the new hunks because `secrets_generate` runs the `layerx-node` image through docker to produce the module registry and the beta images are not built here. `kind` and `kubectl` are absent, so the bring-up and its probe could not be executed; the manifest is checked directly instead.

## Observations added

`spec/layerx-beta/qualification.kvx`, task 3.7: 4400 (the guarantor/agent bind collision and its repair), 4401 (the daemon was deployed but unpublished and unchecked), 4402 (why the boundary container is the only non-fake publication, and what stays private), 4403 (the hunks that fall outside the scoped shape), 4404 (the bring-up could not be executed), 4405 (the stale topology regression baseline), 4406 (render blocked by unbuilt images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
