### PR TITLE
Execute and verify a batch before a replica acknowledges it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,10 +871,13 @@ test-sequencer-recovery: $(BUILD_DIR)/tests/test_sequencer_recovery
 test-wave-10: test-batch test-sequencer test-batch-time test-batch-seal \
 		test-batch-distribute test-sequencer-recovery
 
-$(BUILD_DIR)/tests/test_replica_ingest: tests/test_replica_ingest.c $(LIBRARY)
+$(BUILD_DIR)/tests/test_replica_ingest: tests/test_replica_ingest.c \
+		$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) tests/support/lxp_real_replay.h \
+		| programs-build
 	@mkdir -p $(@D)
-	$(CC) $(CPPFLAGS) $(CFLAGS) $< $(LIBRARY) $(EXTRA_LDFLAGS) \
-		-lcrypto -o $@
+	$(CC) $(CPPFLAGS) -Itests $(CFLAGS) $< $(LIBRARY) \
+		$(PROGRAMS_RUNTIME_LIB) $(LIBRARY) $(EXTRA_LDFLAGS) \
+		-lcrypto -pthread -ldl -lm -o $@
 
 test-replica: $(BUILD_DIR)/tests/test_replica_ingest
 	$(RUN_PREFIX) $(BUILD_DIR)/tests/test_replica_ingest
@@ -1219,7 +1222,9 @@ LAYERXD_SOURCES = \
 	cmd/layerxd/lxp_daemon_artifact.c \
 	cmd/layerxd/lxp_daemon_process.c \
 	cmd/layerxd/lxp_daemon_authority_replica.c \
-	cmd/layerxd/lxp_daemon_cli.c
+	cmd/layerxd/lxp_daemon_replica.c \
+	cmd/layerxd/lxp_daemon_cli.c \
+	cmd/layerx-guarantor/runtime.c
 
 LAYERXD_OBJECTS = $(patsubst %.c,$(BUILD_DIR)/obj/%.o,cmd/layerxd/main.c $(LAYERXD_SOURCES))
 -include $(LAYERXD_OBJECTS:.o=.d)
@@ -3297,7 +3302,7 @@ test-daemon-availability: $(BUILD_DIR)/tests/lxp_test_daemon_finality_authority 
 
 GUARANTOR_SOURCES = cmd/layerx-guarantor/main.c cmd/layerx-guarantor/lni.c \
 	cmd/layerx-guarantor/producer.c cmd/layerx-guarantor/exchange.c \
-	cmd/layerx-guarantor/runtime.c cmd/layerx-guarantor/settlement.c
+	cmd/layerx-guarantor/settlement.c
 GUARANTOR_OBJECTS = $(patsubst %.c,$(BUILD_DIR)/obj/%.o,$(GUARANTOR_SOURCES))
 -include $(GUARANTOR_OBJECTS:.o=.d)
 GUARANTOR_PYTHON ?= python3
@@ -3352,7 +3357,6 @@ test-daemon-guarantor-settlement:
 	$(GUARANTOR_PYTHON) tests/daemon/guarantor-settlement-chain.py
 test-daemon-guarantor: test-daemon-guarantor-settlement
 $(BUILD_DIR)/tests/lxp_test_guarantor_runtime: tests/daemon/guarantor-runtime.c \
-	$(BUILD_DIR)/obj/cmd/layerx-guarantor/runtime.o \
 	$(filter-out $(BUILD_DIR)/obj/cmd/layerxd/main.o,$(LAYERXD_OBJECTS)) \
 	$(LIBRARY) $(PROGRAMS_RUNTIME_LIB) | programs-build
 	@mkdir -p $(@D)

--- a/cmd/layerxd/lxp_daemon_cli.c
+++ b/cmd/layerxd/lxp_daemon_cli.c
@@ -11,6 +11,8 @@ lxp_result lxp_daemon_main(int argc, char **argv)
         return lxp_daemon_config_load(argv[2], &configuration);
     if (strcmp(argv[1], "--serve") == 0)
         return lxp_daemon_serve(argv[2]);
+    if (strcmp(argv[1], "--replica") == 0)
+        return lxp_daemon_replica_serve(argv[2]);
     if (strcmp(argv[1], "--authority-replica") == 0)
         return lxp_daemon_authority_replica_serve(argv[2]);
     return LXP_ERR_NON_CANONICAL;

--- a/cmd/layerxd/lxp_daemon_replica.c
+++ b/cmd/layerxd/lxp_daemon_replica.c
@@ -1,0 +1,342 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "layerx/lxp_daemon.h"
+#include "layerx/lxp_da.h"
+#include "layerx/lxp_kernel.h"
+#include "layerx/lxp_replica.h"
+
+#include "../layerx-guarantor/runtime.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define LXP_REPLICA_ARENA_BYTES (128U * 1024U * 1024U)
+#define LXP_REPLICA_LOG_BYTES (UINT64_C(64) * 1024U * 1024U)
+#define LXP_REPLICA_DEFAULT_POLL_MS 250U
+
+static volatile sig_atomic_t replica_stop_requested;
+
+static void replica_signal(int signal_number)
+{
+    (void)signal_number;
+    replica_stop_requested = 1;
+}
+
+static const char *replica_environment(const char *name)
+{
+    const char *value = getenv(name);
+    return value != NULL && value[0] != '\0' ? value : NULL;
+}
+
+static lxp_result replica_parse_u64(const char *text, uint64_t *value)
+{
+    uint64_t parsed = 0U;
+    size_t index = 0U;
+    if (text == NULL || value == NULL || text[0] == '\0')
+        return LXP_ERR_NON_CANONICAL;
+    for (index = 0U; text[index] != '\0'; ++index) {
+        uint64_t digit;
+        if (text[index] < '0' || text[index] > '9')
+            return LXP_ERR_NON_CANONICAL;
+        digit = (uint64_t)(text[index] - '0');
+        if (parsed > (UINT64_MAX - digit) / 10U)
+            return LXP_ERR_LENGTH_LIMIT;
+        parsed = parsed * 10U + digit;
+    }
+    *value = parsed;
+    return LXP_OK;
+}
+
+static lxp_result replica_decode_hex(const char *text, size_t text_length,
+                                     uint8_t *bytes, size_t length)
+{
+    size_t index;
+    if (text == NULL || bytes == NULL || text_length != length * 2U)
+        return LXP_ERR_NON_CANONICAL;
+    for (index = 0U; index < length; ++index) {
+        uint8_t value = 0U;
+        size_t nibble;
+        for (nibble = 0U; nibble < 2U; ++nibble) {
+            char digit = text[index * 2U + nibble];
+            uint8_t decoded;
+            if (digit >= '0' && digit <= '9')
+                decoded = (uint8_t)(digit - '0');
+            else if (digit >= 'a' && digit <= 'f')
+                decoded = (uint8_t)(digit - 'a' + 10);
+            else if (digit >= 'A' && digit <= 'F')
+                decoded = (uint8_t)(digit - 'A' + 10);
+            else
+                return LXP_ERR_NON_CANONICAL;
+            value = (uint8_t)((value << 4U) | decoded);
+        }
+        bytes[index] = value;
+    }
+    return LXP_OK;
+}
+
+static lxp_result replica_authorization(
+    lxp_sequencer_authorization *authorization)
+{
+    const char *sequencer_id = replica_environment("LAYERX_NODE_SEQUENCER_ID");
+    const char *public_key =
+        replica_environment("LAYERX_NODE_SEQUENCER_PUBLIC_KEY");
+    const char *first_batch = replica_environment("LAYERX_NODE_FIRST_BATCH");
+    const char *last_batch = replica_environment("LAYERX_NODE_LAST_BATCH");
+    lxp_result status;
+    if (authorization == NULL || sequencer_id == NULL || public_key == NULL ||
+        first_batch == NULL || last_batch == NULL)
+        return LXP_ERR_NON_CANONICAL;
+    (void)memset(authorization, 0, sizeof(*authorization));
+    status = replica_decode_hex(sequencer_id, strlen(sequencer_id),
+                                authorization->sequencer_id, 32U);
+    if (status == LXP_OK)
+        status = replica_decode_hex(public_key, strlen(public_key),
+                                    authorization->public_key, 32U);
+    if (status == LXP_OK)
+        status = replica_parse_u64(first_batch,
+                                   &authorization->first_batch_number);
+    if (status == LXP_OK)
+        status = replica_parse_u64(last_batch,
+                                   &authorization->last_batch_number);
+    if (status == LXP_OK &&
+        authorization->last_batch_number < authorization->first_batch_number)
+        status = LXP_ERR_NON_CANONICAL;
+    if (status == LXP_OK) authorization->authorized = 1U;
+    return status;
+}
+
+static lxp_result replica_roster(const uint8_t replica_id[32],
+                                 uint8_t (*replica_ids)[32],
+                                 size_t *replica_count, size_t *threshold)
+{
+    const char *set = replica_environment("LAYERX_REPLICA_SET");
+    const char *configured = replica_environment("LAYERX_REPLICA_ACK_THRESHOLD");
+    size_t count = 0U;
+    uint64_t value = 1U;
+    lxp_result status = LXP_OK;
+    if (replica_id == NULL || replica_ids == NULL || replica_count == NULL ||
+        threshold == NULL)
+        return LXP_ERR_NON_CANONICAL;
+    if (set == NULL) {
+        (void)memcpy(replica_ids[0], replica_id, 32U);
+        count = 1U;
+    } else {
+        const char *cursor = set;
+        while (status == LXP_OK && *cursor != '\0') {
+            const char *comma = strchr(cursor, ',');
+            size_t length = comma == NULL ? strlen(cursor)
+                                          : (size_t)(comma - cursor);
+            if (count == (size_t)LXP_MAX_BATCH_REPLICAS)
+                return LXP_ERR_LENGTH_LIMIT;
+            status = replica_decode_hex(cursor, length, replica_ids[count],
+                                        32U);
+            if (status != LXP_OK) return status;
+            count += 1U;
+            cursor = comma == NULL ? cursor + length : comma + 1U;
+        }
+        if (count == 0U) return LXP_ERR_NON_CANONICAL;
+    }
+    if (configured != NULL) {
+        status = replica_parse_u64(configured, &value);
+        if (status != LXP_OK) return status;
+    }
+    if (value == 0U || value > (uint64_t)count) return LXP_ERR_NON_CANONICAL;
+    *replica_count = count;
+    *threshold = (size_t)value;
+    return LXP_OK;
+}
+
+static void replica_wait(uint64_t poll_ms)
+{
+    struct timespec interval;
+    interval.tv_sec = (time_t)(poll_ms / 1000U);
+    interval.tv_nsec = (long)((poll_ms % 1000U) * 1000000U);
+    (void)nanosleep(&interval, NULL);
+}
+
+static lxp_result replica_await_body(lxp_log *log, const char *path,
+                                     bool *opened, uint64_t batch_number,
+                                     uint64_t poll_ms, lxp_arena *arena,
+                                     lxp_batch_body *body)
+{
+    lxp_result status;
+    for (;;) {
+        (void)lxp_arena_reset(arena, 0U);
+        status = lxp_da_log_read_body(log, batch_number, arena, body);
+        if (status != LXP_ERR_DA_MISSING) return status;
+        if (replica_stop_requested != 0) return LXP_ERR_DA_MISSING;
+        replica_wait(poll_ms);
+        status = lxp_log_close(log);
+        *opened = false;
+        if (status != LXP_OK) return status;
+        status = lxp_log_open(log, path);
+        if (status != LXP_OK) return status;
+        *opened = true;
+    }
+}
+
+lxp_result lxp_daemon_replica_serve(const char *configuration_path)
+{
+    lxp_daemon_configuration configuration;
+    lxp_sequencer_authorization authorization;
+    lxp_replica replica;
+    lxp_log availability_log;
+    lxp_log replica_log;
+    lxp_arena arena;
+    struct sigaction action;
+    gp_runtime *runtime = NULL;
+    lxp_replay_engine *engine = NULL;
+    uint8_t (*replica_ids)[32] = NULL;
+    uint8_t *memory = NULL;
+    uint8_t replica_id[32];
+    const char *availability_path;
+    const char *replica_log_path;
+    const char *state_directory;
+    const char *identifier;
+    const char *text;
+    uint64_t first_batch = 1U;
+    uint64_t batch_limit = 0U;
+    uint64_t poll_ms = LXP_REPLICA_DEFAULT_POLL_MS;
+    uint64_t batch;
+    size_t replica_count = 0U;
+    size_t threshold = 0U;
+    bool availability_open = false;
+    bool replica_open = false;
+    lxp_result status;
+    if (configuration_path == NULL) return LXP_ERR_NON_CANONICAL;
+    (void)memset(&replica, 0, sizeof(replica));
+    status = lxp_daemon_config_load(configuration_path, &configuration);
+    if (status == LXP_OK && configuration.role != LXP_DAEMON_REPLICA)
+        status = LXP_ERR_NON_CANONICAL;
+    if (status != LXP_OK) return status;
+    state_directory = replica_environment("LAYERX_REPLICA_STATE_DIRECTORY");
+    availability_path = replica_environment("LAYERX_REPLICA_AVAILABILITY_LOG");
+    replica_log_path = replica_environment("LAYERX_REPLICA_LOG");
+    identifier = replica_environment("LAYERX_REPLICA_ID");
+    if (state_directory == NULL || availability_path == NULL ||
+        replica_log_path == NULL || identifier == NULL)
+        return LXP_ERR_NON_CANONICAL;
+    status = replica_decode_hex(identifier, strlen(identifier), replica_id,
+                                32U);
+    text = replica_environment("LAYERX_REPLICA_FIRST_BATCH");
+    if (status == LXP_OK && text != NULL)
+        status = replica_parse_u64(text, &first_batch);
+    text = replica_environment("LAYERX_REPLICA_BATCH_LIMIT");
+    if (status == LXP_OK && text != NULL)
+        status = replica_parse_u64(text, &batch_limit);
+    text = replica_environment("LAYERX_REPLICA_POLL_MS");
+    if (status == LXP_OK && text != NULL)
+        status = replica_parse_u64(text, &poll_ms);
+    if (status == LXP_OK && (poll_ms == 0U || poll_ms > 60000U))
+        status = LXP_ERR_NON_CANONICAL;
+    if (status == LXP_OK) status = replica_authorization(&authorization);
+    if (status == LXP_OK) {
+        replica_ids = malloc(sizeof(*replica_ids) * LXP_MAX_BATCH_REPLICAS);
+        memory = malloc(LXP_REPLICA_ARENA_BYTES);
+        if (replica_ids == NULL || memory == NULL) status = LXP_ERR_IO;
+    }
+    if (status == LXP_OK) {
+        (void)memset(replica_ids, 0,
+                     sizeof(*replica_ids) * LXP_MAX_BATCH_REPLICAS);
+        status = replica_roster(replica_id, replica_ids, &replica_count,
+                                &threshold);
+    }
+    if (status == LXP_OK)
+        status = lxp_arena_init(&arena, memory, LXP_REPLICA_ARENA_BYTES);
+    if (status == LXP_OK)
+        status = gp_runtime_open(&runtime, configuration_path,
+                                 state_directory);
+    if (status == LXP_OK) {
+        engine = gp_runtime_engine(runtime);
+        if (engine == NULL || engine->kernel == NULL ||
+            engine->kernel->state == NULL)
+            status = LXP_ERR_MODULE_DISABLED;
+    }
+    if (status == LXP_OK) {
+        status = lxp_log_open_or_create(&replica_log, replica_log_path,
+                                        LXP_REPLICA_LOG_BYTES);
+        replica_open = status == LXP_OK;
+    }
+    if (status == LXP_OK)
+        status = lxp_log_recover_complete_records(&replica_log, NULL, NULL);
+    if (status == LXP_OK) {
+        status = lxp_log_open(&availability_log, availability_path);
+        availability_open = status == LXP_OK;
+    }
+    if (status == LXP_OK) status = lxp_replica_init(&replica, &replica_log);
+    if (status == LXP_OK)
+        status = lxp_replica_bind_execution(
+            &replica, engine, engine->kernel->current_state_root, first_batch,
+            engine->kernel->state->next_sequence);
+    if (status == LXP_OK)
+        status = lxp_replica_bind_eligibility(
+            &replica, replica_id, (const uint8_t (*)[32])replica_ids,
+            replica_count, threshold);
+    if (status == LXP_OK) {
+        (void)memset(&action, 0, sizeof(action));
+        action.sa_handler = replica_signal;
+        if (sigemptyset(&action.sa_mask) != 0 ||
+            sigaction(SIGINT, &action, NULL) != 0 ||
+            sigaction(SIGTERM, &action, NULL) != 0)
+            status = LXP_ERR_IO;
+    }
+    for (batch = first_batch; status == LXP_OK; ++batch) {
+        lxp_batch_body body;
+        lxp_byte_span canonical;
+        bool acknowledged = false;
+        bool eligible = false;
+        if (replica_stop_requested != 0) break;
+        if (batch_limit != 0U && batch - first_batch >= batch_limit) break;
+        status = replica_await_body(&availability_log, availability_path,
+                                    &availability_open, batch, poll_ms,
+                                    &arena, &body);
+        if (status == LXP_ERR_DA_MISSING && replica_stop_requested != 0) {
+            status = LXP_OK;
+            break;
+        }
+        if (status == LXP_OK) status = gp_runtime_prepare(runtime, &body);
+        if (status == LXP_OK)
+            status = lxp_batch_body_encode(&body, &arena, &canonical);
+        if (status == LXP_OK)
+            status = lxp_replica_ingest_batch(
+                &replica, canonical.bytes, canonical.length,
+                configuration.network_id, &authorization, &arena,
+                &acknowledged);
+        if (status != LXP_OK) break;
+        if (!acknowledged) {
+            status = LXP_FATAL_REPLAY_DIVERGENCE;
+            break;
+        }
+        (void)lxp_replica_batch_eligible(&replica, &eligible);
+        (void)fprintf(stdout,
+            "layerxd replica executed batch=%llu first_sequence=%llu "
+            "last_sequence=%llu acknowledged=%llu eligible=%d\n",
+            (unsigned long long)replica.head.batch_number,
+            (unsigned long long)replica.head.first_sequence,
+            (unsigned long long)replica.head.last_sequence,
+            (unsigned long long)replica.acknowledged_batch_count,
+            eligible ? 1 : 0);
+        (void)fflush(stdout);
+    }
+    if (status != LXP_OK)
+        (void)fprintf(stderr,
+            "layerxd replica refused batch=%llu status=%d halted=%d\n",
+            (unsigned long long)batch, (int)status,
+            replica.halted ? 1 : 0);
+    if (availability_open) {
+        lxp_result closed = lxp_log_close(&availability_log);
+        if (status == LXP_OK) status = closed;
+    }
+    if (replica_open) {
+        lxp_result closed = lxp_log_close(&replica_log);
+        if (status == LXP_OK) status = closed;
+    }
+    gp_runtime_close(runtime);
+    free(memory);
+    free(replica_ids);
+    return status;
+}

--- a/include/layerx/lxp_batch.h
+++ b/include/layerx/lxp_batch.h
@@ -157,6 +157,8 @@ lxp_result lxp_batch_publish(const lxp_batch_body *body,
 lxp_result lxp_batch_eligibility_init(
     lxp_batch_eligibility_state *state, uint64_t batch_number,
     const uint8_t (*replica_ids)[32], size_t replica_count, size_t threshold);
+lxp_result lxp_batch_eligibility_reset(lxp_batch_eligibility_state *state,
+                                       uint64_t batch_number);
 lxp_result lxp_replica_ack(lxp_batch_eligibility_state *state,
                            const uint8_t replica_id[32], lxp_log *log);
 lxp_result lxp_batch_eligibility(const lxp_batch_eligibility_state *state,

--- a/include/layerx/lxp_daemon.h
+++ b/include/layerx/lxp_daemon.h
@@ -584,6 +584,7 @@ lxp_result lxp_daemon_submit(
 lxp_result lxp_daemon_shutdown(lxp_daemon *daemon);
 lxp_result lxp_daemon_main(int argc, char **argv);
 lxp_result lxp_daemon_serve(const char *configuration_path);
+lxp_result lxp_daemon_replica_serve(const char *configuration_path);
 lxp_result lxp_daemon_authority_replica_serve(
     const char *configuration_path);
 lxp_result lxp_daemon_authority_replica_publish(

--- a/include/layerx/lxp_replica.h
+++ b/include/layerx/lxp_replica.h
@@ -7,10 +7,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct lxp_replay_engine;
+
 typedef struct lxp_replica {
     lxp_log *log;
+    struct lxp_replay_engine *engine;
     lxp_batch_header head;
+    lxp_batch_eligibility_state eligibility;
     uint64_t durable_batch_count;
+    uint64_t executed_batch_count;
+    uint64_t acknowledged_batch_count;
+    uint64_t next_batch_number;
+    uint64_t next_sequence;
+    uint8_t state_root[32];
+    uint8_t replica_id[32];
+    bool has_execution;
+    bool has_eligibility;
     bool has_head;
     bool halted;
     bool execution_enabled;
@@ -103,6 +115,18 @@ typedef struct lxp_replay_batch_result {
 } lxp_replay_batch_result;
 
 lxp_result lxp_replica_init(lxp_replica *replica, lxp_log *log);
+lxp_result lxp_replica_bind_execution(lxp_replica *replica,
+                                      lxp_replay_engine *engine,
+                                      const uint8_t starting_state_root[32],
+                                      uint64_t next_batch_number,
+                                      uint64_t next_sequence);
+lxp_result lxp_replica_bind_eligibility(lxp_replica *replica,
+                                        const uint8_t replica_id[32],
+                                        const uint8_t (*replica_ids)[32],
+                                        size_t replica_count,
+                                        size_t threshold);
+lxp_result lxp_replica_batch_eligible(const lxp_replica *replica,
+                                      bool *eligible);
 lxp_result lxp_replica_validate_header(
     const lxp_batch_body *body, uint32_t configured_network_id,
     const lxp_sequencer_authorization *authorization, lxp_arena *arena);

--- a/spec/layerx-beta/qualification.kvx
+++ b/spec/layerx-beta/qualification.kvx
@@ -3279,6 +3279,38 @@ observed = "formerly observation.6.3.owner-decision-1. Owner decision (decider: 
 assumption = "Files changed: spec/layerx-beta/spec.kvx and spec/layerx-beta/qualification.kvx. This record applies the decision only to the named contract or Make recipe."
 severity = "note"
 
+[observation.6.3.3400]
+task = "6.3"
+file = "src/replica/lxp_replica_ingest.c include/layerx/lxp_replica.h"
+symbol = "lxp_replica_ingest_batch lxp_replica_bind_execution lxp_replay_batch_publication"
+observed = "Before this change lxp_replica_ingest_batch decoded a body, checked the header chain link and appended a durable acknowledgement without ever executing the body or recomputing any root, and no production caller existed: lxp_replay_batch_publication (src/replica/lxp_replay.c:275) and lxp_replay_verify_roots (line 284) were reached only from cmd/layerx-guarantor/producer.c and from tests, and lxp_replica_ack was likewise test-only. Ingest now refuses with LXP_ERR_MODULE_DISABLED unless an execution engine is bound (line 121), runs lxp_replay_batch_publication against the decoded body (line 150) and only then appends the body record, advances the head and acknowledges (lines 173-176). Because replay_batch requires engine->kernel->current_state_root to equal the starting root and mutates the kernel in place with no rollback, any non-OK replay result halts the replica (line 154) instead of leaving it able to ingest the next batch on a diverged kernel. The former genesis rule (first batch must be number 0, first sequence 0 and a zero previous state root) is replaced by an explicit bound bootstrap position taken by lxp_replica_bind_execution (line 22), which refuses unless the engine kernel root already equals the declared starting root; binding at a zero root with 0/0 reproduces the old rule exactly, and binding at any other verified position pins the exact expected previous root, so no check is loosened and a snapshot-bootstrapped replica becomes expressible."
+assumption = "The row default execute before acknowledge is taken: an acknowledgement is a statement that this replica reproduced the batch, so it may only follow a successful replay and root verification. Halting on any replay failure is the conservative reading of replay_batch's in-place mutation; a replica that could continue would need a kernel snapshot mechanism that does not exist."
+severity = "note"
+
+[observation.6.3.3401]
+task = "6.3"
+file = "cmd/layerxd/lxp_daemon_replica.c Makefile"
+symbol = "lxp_daemon_replica_serve gp_runtime_open gp_runtime_prepare LAYERXD_SOURCES"
+observed = "The replica daemon mode needs a real replay engine over a real kernel. Rather than add a fifth site that synthesises execution authority, lxp_daemon_replica_serve reuses the guarantor's existing independent replay node: gp_runtime_open, gp_runtime_engine and gp_runtime_prepare from cmd/layerx-guarantor/runtime.c (lines 251, 254 and 301 of the new file). That required moving cmd/layerx-guarantor/runtime.c from GUARANTOR_SOURCES into LAYERXD_SOURCES in the Makefile and dropping the now duplicate explicit runtime.o prerequisite from the lxp_test_guarantor_runtime rule; the guarantor binary and lxp_test_guarantor_integration already link LAYERXD_OBJECTS, so the object still appears exactly once in every link. runtime.c has no openssl/ssl or sqlite3 reference, and producer.c has no gp_runtime reference, so lxp_test_guarantor_core is unaffected. Three header declarations also had to be added outside the row's owned paths: the replica struct and bind API in include/layerx/lxp_replica.h, lxp_batch_eligibility_reset in include/layerx/lxp_batch.h and lxp_daemon_replica_serve in include/layerx/lxp_daemon.h."
+assumption = "Reusing the existing replay node is preferred to duplicating replay_execute_activity, which would multiply the sites that must be corrected together. The header and Makefile edits are the minimum surface needed to expose the new entry points and are recorded as out-of-path changes rather than avoided, because the row cannot be delivered without them."
+severity = "note"
+
+[observation.6.3.3402]
+task = "6.3"
+file = "cmd/layerx-guarantor/runtime.c cmd/layerxd/lxp_daemon_lni.c platform/emulator/core/emulator_core.c"
+symbol = "replay_execute_activity lxp_authority_resolve_activity grant_id"
+observed = "The replica ingest path inherits whatever authority the replay node it is bound to resolves, so a replica reproduces the sequencer's execution only where both sides resolve the same authority. When this row was written replay_execute_activity synthesised a zero grant identity; after rebasing onto the revision that resolves activity authority from persisted grants, both of the reused node's execution entries (cmd/layerx-guarantor/runtime.c:339 and 998) go through lxp_authority_resolve_activity, and the daemon replica mode picks that up unchanged. Two sites still declare a zero grant identity outside the replayed path: cmd/layerxd/lxp_daemon_lni.c:2758 and platform/emulator/core/emulator_core.c:767. Because lxp_replay_verify_roots compares recomputed roots and the receipt and event section bytes, any future divergence between the authority a sequencer resolves and the one a replica resolves surfaces as LXP_FATAL_REPLAY_DIVERGENCE at the replica rather than as a silent acknowledgement."
+assumption = "Authority resolution is outside this row and its replayed paths are now resolved rather than synthesised, so the remaining declarations are recorded for their owners; the replica ingest gates were re-run on the rebased tip so the executed and acknowledged behaviour is qualified against the resolved authority."
+severity = "note"
+
+[observation.6.3.3403]
+task = "6.3"
+file = "tests/daemon/guarantor-settlement.py platform/hosted/node/bootstrap.sh"
+symbol = "test-daemon-guarantor-unit test-daemon-guarantor-integration eth_keys genesis-metadata"
+observed = "Moving cmd/layerx-guarantor/runtime.c from GUARANTOR_SOURCES into LAYERXD_SOURCES was verified by building and running every target that links either group. layerx-guarantor, lxp_test_guarantor_integration, lxp_test_guarantor_runtime, lxp_test_guarantor_core, lxp_test_guarantor_exchange and test_layerxd all build and link with runtime.o appearing exactly once, and lxp_test_guarantor_core and the mTLS exchange suite pass. Two targets beyond the row's gate set still refuse for reasons that precede this change: test-daemon-guarantor-unit stops in tests/daemon/guarantor-settlement.py at `from eth_keys.exceptions import BadSignature` with ModuleNotFoundError because eth_keys is not installed in this environment, and test-daemon-guarantor-integration stops in platform/hosted/node/bootstrap.sh with `bootstrap: --genesis-metadata requires an authoritative LXGB v2 metadata file`, before layerxd is started at all. Evidence: qual-logs/test-waves-daemon.log and qual-logs/gp1/guarantor-daemon-27ce0ewk/bootstrap.log. make CC=gcc test, test-wave-10, test-wave-11 and test-layerxd all pass on this branch."
+assumption = "Neither refusal can be produced by a link-group move or by a new daemon mode: the first is a missing local Python dependency and the second is an argument refusal raised before any binary from this branch runs. Both are recorded rather than repaired because the bootstrap metadata contract and the settlement test's dependencies belong to other tasks."
+severity = "note"
+
 [observation.6.2.7]
 task = "6.2"
 file = "spec/layerx-beta/spec.kvx"

--- a/src/replica/lxp_replica_ingest.c
+++ b/src/replica/lxp_replica_ingest.c
@@ -1,5 +1,6 @@
 #include "layerx/lxp_replica.h"
 #include "layerx/lxp_crypto.h"
+#include "layerx/lxp_kernel.h"
 #include "layerx/lxp_protocol.h"
 #include "layerx/lxp_sequencer.h"
 
@@ -16,6 +17,63 @@ lxp_result lxp_replica_init(lxp_replica *replica, lxp_log *log)
     replica->serving_current_state = true;
     replica->serving_finalised_history = true;
     return LXP_OK;
+}
+
+lxp_result lxp_replica_bind_execution(lxp_replica *replica,
+                                      lxp_replay_engine *engine,
+                                      const uint8_t starting_state_root[32],
+                                      uint64_t next_batch_number,
+                                      uint64_t next_sequence)
+{
+    if (replica == NULL || replica->log == NULL || engine == NULL ||
+        starting_state_root == NULL || engine->kernel == NULL ||
+        replica->has_execution || replica->has_head || replica->halted)
+        return LXP_ERR_NON_CANONICAL;
+    if (lxp_ct_memcmp(engine->kernel->current_state_root,
+                      starting_state_root, 32U) != 0)
+        return LXP_ERR_ROOT_MISMATCH;
+    replica->engine = engine;
+    (void)memcpy(replica->state_root, starting_state_root, 32U);
+    replica->next_batch_number = next_batch_number;
+    replica->next_sequence = next_sequence;
+    replica->has_execution = true;
+    return LXP_OK;
+}
+
+lxp_result lxp_replica_bind_eligibility(lxp_replica *replica,
+                                        const uint8_t replica_id[32],
+                                        const uint8_t (*replica_ids)[32],
+                                        size_t replica_count,
+                                        size_t threshold)
+{
+    size_t i;
+    lxp_result status;
+    if (replica == NULL || replica_id == NULL || replica_ids == NULL ||
+        replica->has_eligibility || replica->halted)
+        return LXP_ERR_NON_CANONICAL;
+    status = lxp_batch_eligibility_init(&replica->eligibility,
+                                        replica->next_batch_number,
+                                        replica_ids, replica_count,
+                                        threshold);
+    if (status != LXP_OK) return status;
+    for (i = 0U; i < replica_count; ++i)
+        if (lxp_ct_memcmp(replica_id, replica_ids[i], 32U) == 0) break;
+    if (i == replica_count) {
+        (void)memset(&replica->eligibility, 0, sizeof(replica->eligibility));
+        return LXP_ERR_AUTH_SCOPE;
+    }
+    (void)memcpy(replica->replica_id, replica_id, 32U);
+    replica->has_eligibility = true;
+    return LXP_OK;
+}
+
+lxp_result lxp_replica_batch_eligible(const lxp_replica *replica,
+                                      bool *eligible)
+{
+    if (replica == NULL || eligible == NULL) return LXP_ERR_NON_CANONICAL;
+    *eligible = false;
+    if (!replica->has_eligibility) return LXP_ERR_MODULE_DISABLED;
+    return lxp_batch_eligibility(&replica->eligibility, eligible);
 }
 
 lxp_result lxp_replica_validate_header(
@@ -47,7 +105,9 @@ lxp_result lxp_replica_ingest_batch(
     bool *acknowledge)
 {
     lxp_batch_body decoded;
+    lxp_replay_batch_result executed;
     lxp_byte_span reencoded;
+    uint8_t resulting_state_root[32];
     size_t mark;
     lxp_result status;
     if (replica == NULL || replica->log == NULL ||
@@ -57,6 +117,8 @@ lxp_result lxp_replica_ingest_batch(
     if (replica->halted || !replica->execution_enabled ||
         !replica->acknowledgements_enabled)
         return LXP_FATAL_REPLAY_DIVERGENCE;
+    if (!replica->has_execution || replica->engine == NULL)
+        return LXP_ERR_MODULE_DISABLED;
     mark = lxp_arena_mark(arena);
     status = lxp_batch_body_decode(canonical_body, body_length, &decoded);
     if (status == LXP_OK)
@@ -71,22 +133,51 @@ lxp_result lxp_replica_ingest_batch(
     if (status == LXP_OK && replica->has_head)
         status = lxp_replica_chain_link(&replica->head, &decoded.header);
     if (status == LXP_OK && !replica->has_head &&
-        (decoded.header.batch_number != 0U ||
-         decoded.header.first_sequence != 0U ||
-         decoded.header.last_sequence < decoded.header.first_sequence ||
-         !lxp_ct_is_zero(decoded.header.previous_state_root, 32U)))
+        (decoded.header.batch_number != replica->next_batch_number ||
+         decoded.header.first_sequence != replica->next_sequence ||
+         decoded.header.last_sequence < decoded.header.first_sequence))
         status = LXP_ERR_BATCH_GAP;
+    if (status == LXP_OK &&
+        lxp_ct_memcmp(decoded.header.previous_state_root,
+                      replica->state_root, 32U) != 0)
+        status = LXP_ERR_ROOT_MISMATCH;
     if (status == LXP_OK && body_length > UINT32_MAX)
         status = LXP_ERR_LENGTH_LIMIT;
-    if (status == LXP_OK)
-        status = lxp_log_append(replica->log, LXP_LOG_BATCH_BODY,
-                                decoded.header.last_sequence, canonical_body,
-                                (uint32_t)body_length, NULL);
+    if (status != LXP_OK) {
+        (void)lxp_arena_reset(arena, mark);
+        return status;
+    }
+    status = lxp_replay_batch_publication(replica->engine, &decoded,
+                                          replica->state_root, arena,
+                                          &executed);
+    if (status != LXP_OK) {
+        (void)lxp_replica_halt(replica);
+        (void)lxp_arena_reset(arena, mark);
+        return status;
+    }
+    (void)memcpy(resulting_state_root, executed.resulting_state_root, 32U);
+    status = lxp_log_append(replica->log, LXP_LOG_BATCH_BODY,
+                            decoded.header.last_sequence, canonical_body,
+                            (uint32_t)body_length, NULL);
     if (status == LXP_OK) status = lxp_log_write_boundary(replica->log);
     if (status == LXP_OK) {
         replica->head = decoded.header;
         replica->has_head = true;
         replica->durable_batch_count += 1U;
+        replica->executed_batch_count += 1U;
+        (void)memcpy(replica->state_root, resulting_state_root, 32U);
+        replica->next_batch_number = decoded.header.batch_number + 1U;
+        replica->next_sequence = decoded.header.last_sequence + 1U;
+    }
+    if (status == LXP_OK && replica->has_eligibility) {
+        status = lxp_batch_eligibility_reset(&replica->eligibility,
+                                             decoded.header.batch_number);
+        if (status == LXP_OK)
+            status = lxp_replica_ack(&replica->eligibility,
+                                     replica->replica_id, replica->log);
+    }
+    if (status == LXP_OK) {
+        replica->acknowledged_batch_count += 1U;
         *acknowledge = true;
     }
     (void)lxp_arena_reset(arena, mark);

--- a/src/sequencer/lxp_eligibility.c
+++ b/src/sequencer/lxp_eligibility.c
@@ -26,6 +26,23 @@ lxp_result lxp_batch_eligibility_init(
     return LXP_OK;
 }
 
+lxp_result lxp_batch_eligibility_reset(lxp_batch_eligibility_state *state,
+                                       uint64_t batch_number)
+{
+    size_t i;
+    if (state == NULL || state->replica_count == 0U ||
+        state->replica_count > LXP_MAX_BATCH_REPLICAS ||
+        state->threshold == 0U || state->threshold > state->replica_count ||
+        state->acknowledgement_count > state->replica_count)
+        return LXP_ERR_NON_CANONICAL;
+    if (batch_number < state->batch_number) return LXP_ERR_BATCH_GAP;
+    if (batch_number == state->batch_number) return LXP_OK;
+    for (i = 0U; i < LXP_MAX_BATCH_REPLICAS; ++i) state->acknowledged[i] = 0U;
+    state->acknowledgement_count = 0U;
+    state->batch_number = batch_number;
+    return LXP_OK;
+}
+
 lxp_result lxp_replica_ack(lxp_batch_eligibility_state *state,
                            const uint8_t replica_id[32], lxp_log *log)
 {

--- a/tests/test_batch_publish.c
+++ b/tests/test_batch_publish.c
@@ -50,6 +50,8 @@ int main(void)
     size_t canonical_length;
     lxp_arena arena;
     lxp_log log;
+    lxp_log_record_header record;
+    uint8_t acknowledged_id[32];
     sink output;
     bool eligible = true;
     char directory[] = "/tmp/lxp-batch-publish-XXXXXX";
@@ -106,7 +108,35 @@ int main(void)
         lxp_replica_ack(&eligibility, replica_ids[1], &log) != LXP_OK ||
         lxp_batch_eligibility(&eligibility, &eligible) != LXP_OK || !eligible)
         return 15;
+    if (lxp_log_read(&log, 0U, &record, acknowledged_id,
+                     sizeof(acknowledged_id)) != LXP_OK ||
+        record.record_kind != (uint8_t)LXP_LOG_REPLICA_ACK ||
+        record.global_sequence != 14U || record.body_length != 32U ||
+        memcmp(acknowledged_id, replica_ids[0], 32U) != 0)
+        return 16;
+    if (lxp_batch_eligibility_reset(&eligibility, 13U) !=
+            LXP_ERR_BATCH_GAP ||
+        lxp_batch_eligibility_reset(&eligibility, 14U) != LXP_OK ||
+        eligibility.acknowledgement_count != 2U ||
+        lxp_batch_eligibility(&eligibility, &eligible) != LXP_OK ||
+        !eligible ||
+        lxp_batch_eligibility_reset(&eligibility, 15U) != LXP_OK ||
+        eligibility.batch_number != 15U ||
+        eligibility.acknowledgement_count != 0U ||
+        eligibility.replica_count != 3U || eligibility.threshold != 2U ||
+        lxp_batch_eligibility(&eligibility, &eligible) !=
+            LXP_ERR_ATTESTATION_THRESHOLD || eligible)
+        return 17;
+    if (lxp_replica_ack(&eligibility, replica_ids[2], &log) != LXP_OK ||
+        lxp_replica_ack(&eligibility, replica_ids[2], &log) != LXP_OK ||
+        eligibility.acknowledgement_count != 1U ||
+        lxp_batch_eligibility(&eligibility, &eligible) !=
+            LXP_ERR_ATTESTATION_THRESHOLD || eligible ||
+        lxp_replica_ack(&eligibility, replica_ids[0], &log) != LXP_OK ||
+        eligibility.acknowledgement_count != 2U ||
+        lxp_batch_eligibility(&eligibility, &eligible) != LXP_OK || !eligible)
+        return 18;
     if (lxp_log_close(&log) != LXP_OK || unlink(path) != 0 ||
-        rmdir(directory) != 0) return 16;
+        rmdir(directory) != 0) return 19;
     return 0;
 }

--- a/tests/test_replica_ingest.c
+++ b/tests/test_replica_ingest.c
@@ -1,19 +1,21 @@
 #define _POSIX_C_SOURCE 200809L
 
+#include "support/lxp_real_replay.h"
+
 #include "layerx/lxp_replica.h"
 
-#include <openssl/evp.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 
-static int public_key_for(const uint8_t private_key[32], uint8_t public_key[32])
+#define CHECK(value) do { if (!(value)) { \
+    (void)fprintf(stderr, "replica ingest check failed at %d\n", __LINE__); \
+    return 1; \
+} } while (0)
+
+static int public_key_for(const uint8_t private_key[32],
+                          uint8_t public_key[32])
 {
     EVP_PKEY *key = EVP_PKEY_new_raw_private_key(EVP_PKEY_ED25519, NULL,
-                                                  private_key, 32U);
+                                                 private_key, 32U);
     size_t length = 32U;
     int ok = key != NULL && EVP_PKEY_get_raw_public_key(
         key, public_key, &length) == 1 && length == 32U;
@@ -21,106 +23,146 @@ static int public_key_for(const uint8_t private_key[32], uint8_t public_key[32])
     return ok ? 0 : 1;
 }
 
-static int make_body(lxp_batch_body *body, uint64_t batch_number,
-                     uint64_t sequence, const uint8_t previous_root[32],
-                     const uint8_t private_key[32],
-                     const lxp_sequencer_authorization *authorization,
-                     lxp_arena *arena, lxp_byte_span *encoded)
-{
-    static const uint8_t content[] = { 1U, 2U, 3U };
-    (void)memset(body, 0, sizeof(*body));
-    body->header.protocol_version = 1U;
-    body->header.network_id = 55U;
-    body->header.epoch = 1U;
-    body->header.batch_number = batch_number;
-    body->header.first_sequence = sequence;
-    body->header.last_sequence = sequence;
-    (void)memcpy(body->header.previous_state_root, previous_root, 32U);
-    body->header.resulting_state_root[0] = (uint8_t)(batch_number + 1U);
-    body->header.timestamp_ms = 100U + batch_number;
-    (void)memcpy(body->header.sequencer_id, authorization->sequencer_id, 32U);
-    body->activities = (lxp_byte_span){ content, sizeof(content) };
-    body->receipts = (lxp_byte_span){ content, sizeof(content) };
-    body->events = (lxp_byte_span){ content, sizeof(content) };
-    body->oracle_inputs = (lxp_byte_span){ content, sizeof(content) };
-    body->state_diff = (lxp_byte_span){ content, sizeof(content) };
-    body->recovery_metadata = (lxp_byte_span){ content, sizeof(content) };
-    if (lxp_batch_sign(&body->header, private_key, authorization,
-                       body->sequencer_signature, arena) != LXP_OK)
-        return 1;
-    return lxp_batch_body_encode(body, arena, encoded) == LXP_OK ? 0 : 1;
-}
-
 int main(void)
 {
-    uint8_t build_storage[32768];
-    uint8_t ingest_storage[32768];
-    uint8_t private_key[32] = { 4U };
-    uint8_t zero_root[32] = { 0U };
-    uint8_t first_bytes[4096];
-    uint8_t second_bytes[4096];
-    size_t first_length;
-    size_t second_length;
-    lxp_arena build_arena;
+    static uint8_t history_storage[16U * 1024U * 1024U];
+    static uint8_t ingest_storage[16U * 1024U * 1024U];
+    static uint8_t bodies[3][65536];
+    static uint8_t stored[65536];
+    lxp_real_replay_fixture *builder = calloc(1U, sizeof(*builder));
+    lxp_real_replay_fixture *follower = calloc(1U, sizeof(*follower));
+    lxp_arena history_arena;
     lxp_arena ingest_arena;
-    lxp_batch_body first;
-    lxp_batch_body second;
-    lxp_byte_span encoded;
+    lxp_byte_span activities[6];
+    lxp_batch_body batches[3];
     lxp_sequencer_authorization authorization;
     lxp_replica replica;
     lxp_log log;
     lxp_log_record_header record;
-    uint8_t stored[4096];
+    size_t lengths[3];
+    uint8_t private_key[32] = { 9U };
+    uint8_t replica_ids[3][32] = { { 1U }, { 2U }, { 3U } };
+    uint8_t genesis[32];
     bool ack = true;
+    bool eligible = true;
+    size_t i;
     char directory[] = "/tmp/lxp-replica-ingest-XXXXXX";
     char path[128];
+    CHECK(builder != NULL && follower != NULL);
+    CHECK(lxp_real_replay_init(builder) == 0);
+    CHECK(lxp_real_replay_init(follower) == 0);
+    CHECK(lxp_arena_init(&history_arena, history_storage,
+                         sizeof(history_storage)) == LXP_OK);
+    CHECK(lxp_arena_init(&ingest_arena, ingest_storage,
+                         sizeof(ingest_storage)) == LXP_OK);
+    (void)memcpy(genesis, follower->kernel.current_state_root, 32U);
+    CHECK(memcmp(genesis, builder->kernel.current_state_root, 32U) == 0);
     (void)memset(&authorization, 0, sizeof(authorization));
-    if (public_key_for(private_key, authorization.public_key) != 0) return 1;
-    (void)memcpy(authorization.sequencer_id, authorization.public_key, 32U);
+    CHECK(public_key_for(private_key, authorization.public_key) == 0);
     authorization.first_batch_number = 0U;
     authorization.last_batch_number = 10U;
     authorization.authorized = 1U;
-    if (lxp_arena_init(&build_arena, build_storage, sizeof(build_storage)) !=
-        LXP_OK || make_body(&first, 0U, 0U, zero_root, private_key,
-                            &authorization, &build_arena, &encoded) != 0)
-        return 1;
-    first_length = encoded.length;
-    (void)memcpy(first_bytes, encoded.bytes, first_length);
-    if (lxp_arena_reset(&build_arena, 0U) != LXP_OK ||
-        make_body(&second, 1U, 1U, first.header.resulting_state_root,
-                  private_key, &authorization, &build_arena, &encoded) != 0)
-        return 1;
-    second_length = encoded.length;
-    (void)memcpy(second_bytes, encoded.bytes, second_length);
-    if (mkdtemp(directory) == NULL ||
-        snprintf(path, sizeof(path), "%s/%020u.lxp", directory, 0U) < 0 ||
-        lxp_log_segment_create(&log, directory, 0U, 32768U) != LXP_OK ||
-        lxp_replica_init(&replica, &log) != LXP_OK ||
-        lxp_arena_init(&ingest_arena, ingest_storage,
-                       sizeof(ingest_storage)) != LXP_OK) return 1;
-    if (lxp_replica_ingest_batch(&replica, second_bytes, second_length, 55U,
-                                 &authorization, &ingest_arena, &ack) !=
-            LXP_ERR_BATCH_GAP || ack || replica.has_head ||
-        lxp_replica_ingest_batch(&replica, first_bytes, first_length - 1U, 55U,
-                                 &authorization, &ingest_arena, &ack) ==
-            LXP_OK || ack || replica.has_head ||
-        lxp_replica_ingest_batch(&replica, first_bytes, first_length, 55U,
-                                 &authorization, &ingest_arena, &ack) !=
-            LXP_OK || !ack || !replica.has_head ||
-        replica.durable_batch_count != 1U ||
-        lxp_replica_ingest_batch(&replica, first_bytes, first_length, 55U,
-                                 &authorization, &ingest_arena, &ack) !=
-            LXP_ERR_BATCH_GAP || ack || replica.durable_batch_count != 1U)
-        return 1;
-    if (lxp_replica_ingest_batch(&replica, second_bytes, second_length, 55U,
-                                 &authorization, &ingest_arena, &ack) !=
-            LXP_OK || !ack || replica.durable_batch_count != 2U ||
-        lxp_log_read(&log, 0U, &record, stored, sizeof(stored)) != LXP_OK ||
-        record.record_kind != (uint8_t)LXP_LOG_BATCH_BODY ||
-        record.body_length != first_length ||
-        memcmp(stored, first_bytes, first_length) != 0)
-        return 1;
-    if (lxp_log_close(&log) != LXP_OK || unlink(path) != 0 ||
-        rmdir(directory) != 0) return 1;
+    for (i = 0U; i < 6U; ++i)
+        CHECK(lxp_real_replay_activity(builder, i, &history_arena,
+                                       &activities[i]) == 0);
+    for (i = 0U; i < 3U; ++i) {
+        lxp_byte_span encoded;
+        CHECK(lxp_real_replay_build(builder, i + 1U, activities + i * 2U, 2U,
+                                    NULL, 0U, &history_arena,
+                                    &batches[i]) == 0);
+        CHECK(lxp_batch_sign(&batches[i].header, private_key, &authorization,
+                             batches[i].sequencer_signature,
+                             &history_arena) == LXP_OK);
+        if (i == 2U) {
+            lxp_byte_span section = batches[i].receipts;
+            CHECK(section.length != 0U);
+            ((uint8_t *)section.bytes)[section.length - 1U] ^= 1U;
+        }
+        CHECK(lxp_batch_body_encode(&batches[i], &history_arena,
+                                    &encoded) == LXP_OK);
+        CHECK(encoded.length <= sizeof(bodies[i]));
+        (void)memcpy(bodies[i], encoded.bytes, encoded.length);
+        lengths[i] = encoded.length;
+    }
+    CHECK(mkdtemp(directory) != NULL);
+    CHECK(snprintf(path, sizeof(path), "%s/%020u.lxp", directory, 0U) > 0);
+    CHECK(lxp_log_segment_create(&log, directory, 0U,
+                                 1024U * 1024U) == LXP_OK);
+    CHECK(lxp_replica_init(&replica, &log) == LXP_OK);
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[0], lengths[0], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_ERR_MODULE_DISABLED);
+    CHECK(!ack && !replica.has_head && replica.durable_batch_count == 0U);
+    CHECK(lxp_replica_bind_execution(&replica, &follower->engine, genesis,
+                                     batches[0].header.batch_number,
+                                     batches[0].header.first_sequence) ==
+          LXP_OK);
+    CHECK(lxp_replica_bind_eligibility(&replica, replica_ids[0],
+              (const uint8_t (*)[32])replica_ids, 3U, 2U) == LXP_OK);
+    follower->execution.batch_number = batches[1].header.batch_number;
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[1], lengths[1], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_ERR_BATCH_GAP);
+    CHECK(!ack && !replica.has_head && !replica.halted);
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[0], lengths[0] - 1U, 7U,
+                                   &authorization, &ingest_arena, &ack) !=
+          LXP_OK);
+    CHECK(!ack && !replica.has_head && !replica.halted);
+    CHECK(memcmp(follower->kernel.current_state_root, genesis, 32U) == 0);
+    follower->execution.batch_number = batches[0].header.batch_number;
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[0], lengths[0], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_OK);
+    CHECK(ack && replica.has_head && replica.durable_batch_count == 1U);
+    CHECK(replica.executed_batch_count == 1U &&
+          replica.acknowledged_batch_count == 1U);
+    CHECK(memcmp(replica.state_root, batches[0].header.resulting_state_root,
+                 32U) == 0);
+    CHECK(memcmp(follower->kernel.current_state_root,
+                 batches[0].header.resulting_state_root, 32U) == 0);
+    CHECK(replica.eligibility.batch_number ==
+              batches[0].header.batch_number &&
+          replica.eligibility.acknowledgement_count == 1U);
+    CHECK(lxp_replica_batch_eligible(&replica, &eligible) ==
+          LXP_ERR_ATTESTATION_THRESHOLD && !eligible);
+    CHECK(lxp_replica_ack(&replica.eligibility, replica_ids[1], &log) ==
+          LXP_OK);
+    CHECK(lxp_replica_batch_eligible(&replica, &eligible) == LXP_OK &&
+          eligible);
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[0], lengths[0], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_ERR_BATCH_GAP);
+    CHECK(!ack && replica.durable_batch_count == 1U && !replica.halted);
+    follower->execution.batch_number = batches[1].header.batch_number;
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[1], lengths[1], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_OK);
+    CHECK(ack && replica.durable_batch_count == 2U &&
+          replica.acknowledged_batch_count == 2U);
+    CHECK(memcmp(replica.state_root, batches[1].header.resulting_state_root,
+                 32U) == 0);
+    CHECK(replica.eligibility.batch_number ==
+              batches[1].header.batch_number &&
+          replica.eligibility.acknowledgement_count == 1U);
+    CHECK(lxp_log_read(&log, 0U, &record, stored, sizeof(stored)) == LXP_OK);
+    CHECK(record.record_kind == (uint8_t)LXP_LOG_BATCH_BODY);
+    CHECK(record.body_length == lengths[0]);
+    CHECK(memcmp(stored, bodies[0], lengths[0]) == 0);
+    follower->execution.batch_number = batches[2].header.batch_number;
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[2], lengths[2], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_FATAL_REPLAY_DIVERGENCE);
+    CHECK(!ack && replica.halted && replica.durable_batch_count == 2U &&
+          replica.acknowledged_batch_count == 2U);
+    CHECK(lxp_replica_ingest_batch(&replica, bodies[2], lengths[2], 7U,
+                                   &authorization, &ingest_arena, &ack) ==
+          LXP_FATAL_REPLAY_DIVERGENCE);
+    CHECK(!ack);
+    CHECK(lxp_log_close(&log) == LXP_OK);
+    CHECK(unlink(path) == 0 && rmdir(directory) == 0);
+    CHECK(lxp_state_store_destroy(&builder->state) == LXP_OK);
+    CHECK(lxp_state_store_destroy(&follower->state) == LXP_OK);
+    free(builder);
+    free(follower);
     return 0;
 }


### PR DESCRIPTION
## Issue

A replica acknowledged a batch without executing it. `lxp_replica_ingest_batch`
decoded the canonical body, checked the header chain link and appended a durable
acknowledgement record; it never executed the body and never recomputed a root.
Root recomputation existed — `lxp_replay_batch_publication` and
`lxp_replay_verify_roots` in `src/replica/lxp_replay.c` — but only the guarantor
reached it, and `lxp_replica_ack` was exercised only from tests. `lxp_replica_ingest_batch`
itself had no production caller at all: there was no replica mode in `layerxd`.

## What changed and why

**Execute before acknowledge (`src/replica/lxp_replica_ingest.c`).**
Ingest refuses with `LXP_ERR_MODULE_DISABLED` unless an execution engine is bound,
replays the decoded body through `lxp_replay_batch_publication`, and only after the
recomputed state, activity, receipt, event, oracle and availability roots and the
receipt and event section bytes all match the header does it append the body record,
advance the head and acknowledge. `replay_batch` requires the kernel to sit at the
declared starting root and mutates it in place with no rollback, so any replay
refusal halts the replica rather than leaving it able to ingest the next batch over
a diverged kernel.

**Explicit bootstrap position (`lxp_replica_bind_execution`).**
The implicit genesis rule (first batch must be number 0, first sequence 0, zero
previous state root) is replaced by a bound position that refuses unless the engine
kernel root already equals the declared starting root. Binding at a zero root with
0/0 reproduces the old rule exactly; binding anywhere else pins the exact previous
root the first batch must carry, so a replica restored from a verified checkpoint
becomes expressible without loosening any check.

**Acknowledgement wiring (`src/sequencer/lxp_eligibility.c`).**
`lxp_replica_bind_eligibility` installs the roster and requires the replica's own
identity to be a member. The new `lxp_batch_eligibility_reset` re-arms the
acknowledgement set for the next batch number, preserving the roster and threshold
and refusing to move backwards. Ingest calls both, so `lxp_replica_ack` now has a
production caller.

**Replica mode for the daemon (`cmd/layerxd/lxp_daemon_replica.c`, new).**
`layerxd --replica <config>` loads a replica-role configuration, opens the existing
independent replay node (`gp_runtime_*`) over the configured state directory,
recovers its own durable log, binds execution at the kernel's current root and
follows the availability log batch by batch — reading each body, executing it,
acknowledging it and halting on the first divergence. Rather than adding a fifth
site that resolves execution authority, it reuses the replay node the guarantor
already runs, so `cmd/layerx-guarantor/runtime.c` moves into `LAYERXD_SOURCES`; the
guarantor binary and its integration tests already link the layerxd objects, so the
object still appears exactly once in every link. The daemon entry change is the two
line mode switch in `cmd/layerxd/lxp_daemon_cli.c`.

**Tests.**
`tests/test_replica_ingest.c` is rebuilt on the real replay fixture: three signed
batches built from real activities against a real kernel, asserting the refusal
without a bound engine, the sequence and root gap refusals, the durable body record,
the acknowledgement and the eligibility threshold, the re-armed set for the following
batch, and that a batch whose receipt bytes were flipped is refused with
`LXP_FATAL_REPLAY_DIVERGENCE`, halts the replica and stays refused on retry.
`tests/test_batch_publish.c` reads back the durable acknowledgement record and covers
the reset semantics including the backwards refusal and a duplicate acknowledgement.

## Gates

| Command | Exit | Log | SHA |
|---|---|---|---|
| `make CC=gcc build/bin/layerxd build/bin/layerx-genesis-build` | 0 | `qual-logs/build-layerxd.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |
| `make CC=gcc test` | 0 | `qual-logs/make-test.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |
| `make CC=gcc test-wave-10 test-wave-11 test-layerxd` | 0 | `qual-logs/test-waves.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |
| `make CC=gcc test-replica test-batch-distribute` | 0 | `qual-logs/focused-tests.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |
| `make beta-ledger-check` | 0 | `qual-logs/beta-ledger-check.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |
| `git diff --check origin/main` | 0 | `qual-logs/git-diff-check.log` | `e5d664661d230ce5473e475e4b1f92e0b59eef33` |

`make test` does not reach `test-replica` or `test-batch-distribute`, so the wave and
focused targets that do are listed separately.

## Observations added

`spec/layerx-beta/qualification.kvx`

- `[observation.6.3.3400]` — execute before acknowledge, and the bootstrap position
  that replaces the implicit genesis rule without loosening it.
- `[observation.6.3.3401]` — reusing the existing replay node inside layerxd, the
  link group move, and the three header declarations added outside this change's
  primary paths.
- `[observation.6.3.3402]` — the replica inherits the replay node's authority
  resolution; both reused entries now resolve from persisted grants, and the two
  remaining synthesised declarations are recorded for their owners.
- `[observation.6.3.3403]` — `test-daemon-guarantor-unit` and
  `test-daemon-guarantor-integration` refuse for reasons that precede this change (a
  missing `eth_keys` module and a bootstrap genesis metadata refusal raised before any
  binary starts); every target that links either side of the moved object builds and
  passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
