### PR TITLE
Give the gateway a registrar identity role that cannot mint sessions

### DIFF
--- a/docs/wiki/HostedFaucet.md
+++ b/docs/wiki/HostedFaucet.md
@@ -294,7 +294,7 @@ The in-cluster funding URL is
 | `LAYERX_OUTBOUND_CA_DER` | Trust bundle for HTTPS and Redis; mounted `/run/layerx/tls/ca.crt.der` |
 | `LAYERX_IDENTITY_INTROSPECTION_URL` | Identity HTTPS origin including introspect path |
 | `LAYERX_IDENTITY_SERVICE_TOKEN_FILE` | Bearer to identity; mounted `/run/layerx/identity/token` |
-| `LAYERX_FAUCET_SERVICE_CLAIM_TOKEN_FILE` | Optional shared secret admitting `POST /v1/faucet/service-claims`; absent means that route is `404 not_found` (`platform/hosted/faucet/src/main.rs:218-223`; `platform/hosted/faucet/src/main.rs:285`). The Deployment does not set this key |
+| `LAYERX_FAUCET_SERVICE_CLAIM_TOKEN_FILE` | Optional shared secret admitting `POST /v1/faucet/service-claims`; absent means that route is `404 not_found` (`platform/hosted/faucet/src/main.rs:218-223`; `platform/hosted/faucet/src/main.rs:285`). The Deployment sets it to `/run/layerx/gateway-faucet/token`, the `token` key of Secret `layerx-gateway-faucet-client`, the same file the gateway reads through `LAYERX_GATEWAY_FAUCET_SERVICE_TOKEN_FILE` (`platform/hosted/testnet/deployment.yaml:147`; `platform/hosted/testnet/deployment.yaml:168`; `platform/hosted/testnet/deployment.yaml:175`; `platform/hosted/gateway/deployment.yaml:87`) |
 | `LAYERX_TESTNET_FUNDING_URL` | Testnet-control admin fund origin including path |
 | `LAYERX_TESTNET_ADMIN_TOKEN_FILE` | Bearer to testnet-control; mounted `/run/layerx/control-admin/token` |
 | `LAYERX_FAUCET_REDIS_URL` | `rediss://` origin |
@@ -313,9 +313,10 @@ Secret files are read, trailing CR/LF stripped, and refused when empty
 or longer than 4096 bytes (`platform/hosted/faucet/src/main.rs:205-215`).
 Volume mounts are TLS Secret `layerx-faucet-tls` at `/run/layerx/tls`,
 `layerx-testnet-identity-client` at `/run/layerx/identity`,
-`layerx-testnet-control-admin` at `/run/layerx/control-admin`, and
+`layerx-testnet-control-admin` at `/run/layerx/control-admin`,
+`layerx-gateway-faucet-client` at `/run/layerx/gateway-faucet`, and
 `layerx-faucet-redis-client` at `/run/layerx/redis-auth`
-(`platform/hosted/testnet/deployment.yaml:163-172`).
+(`platform/hosted/testnet/deployment.yaml:164-175`).
 
 ---
 

--- a/platform/hosted/gateway/deployment.yaml
+++ b/platform/hosted/gateway/deployment.yaml
@@ -124,7 +124,7 @@ spec:
         - {name: component, secret: {secretName: layerx-gateway-component-client}}
         - {name: authority, secret: {secretName: layerx-gateway-authority-client}}
         - {name: identity, secret: {secretName: layerx-gateway-identity-client}}
-        - {name: identity-provisioning, secret: {secretName: layerx-identity-service-tokens, items: [{key: provisioning, path: token}]}}
+        - {name: identity-provisioning, secret: {secretName: layerx-identity-service-tokens, items: [{key: registrar, path: token}]}}
         - {name: faucet, secret: {secretName: layerx-gateway-faucet-client}}
         - {name: registry, secret: {secretName: layerx-program-registry-request-client}}
         - {name: redis, secret: {secretName: layerx-gateway-redis-client}}

--- a/platform/hosted/identity/src/main.rs
+++ b/platform/hosted/identity/src/main.rs
@@ -41,10 +41,18 @@ enum Service {
     Testnet,
     Ramp,
     Provisioning,
+    Registrar,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Capabilities {
+    introspect: bool,
+    create_principals: bool,
+    manage_sessions: bool,
 }
 
 impl Service {
-    const ALL: [Self; 7] = [
+    const ALL: [Self; 8] = [
         Self::Gateway,
         Self::Webhooks,
         Self::Dashboard,
@@ -52,6 +60,7 @@ impl Service {
         Self::Testnet,
         Self::Ramp,
         Self::Provisioning,
+        Self::Registrar,
     ];
 
     const fn name(self) -> &'static str {
@@ -63,6 +72,32 @@ impl Service {
             Self::Testnet => "testnet",
             Self::Ramp => "ramp",
             Self::Provisioning => "provisioning",
+            Self::Registrar => "registrar",
+        }
+    }
+
+    const fn capabilities(self) -> Capabilities {
+        match self {
+            Self::Gateway
+            | Self::Webhooks
+            | Self::Dashboard
+            | Self::Faucet
+            | Self::Testnet
+            | Self::Ramp => Capabilities {
+                introspect: true,
+                create_principals: false,
+                manage_sessions: false,
+            },
+            Self::Provisioning => Capabilities {
+                introspect: false,
+                create_principals: true,
+                manage_sessions: true,
+            },
+            Self::Registrar => Capabilities {
+                introspect: false,
+                create_principals: true,
+                manage_sessions: false,
+            },
         }
     }
 }
@@ -690,7 +725,7 @@ fn introspection_shape(
                 },
             )
         }
-        Service::Provisioning => refusal(403, "service_not_permitted", None),
+        Service::Provisioning | Service::Registrar => refusal(403, "service_not_permitted", None),
     }
 }
 
@@ -893,27 +928,28 @@ fn route(shared: &Shared, request: &Request) -> Response {
         Ok(service) => service,
         Err(response) => return response,
     };
+    let capabilities = service.capabilities();
     match (request.method.as_str(), request.path.as_str()) {
         ("POST", "/v1/sessions/introspect" | "/v1/introspect") => {
-            if service == Service::Provisioning {
+            if !capabilities.introspect {
                 return refusal(403, "service_not_permitted", None);
             }
             introspect(shared, service, request)
         }
         ("POST", "/v1/principals") => {
-            if service != Service::Provisioning {
+            if !capabilities.create_principals {
                 return refusal(403, "service_not_permitted", None);
             }
             create_principal(shared, request)
         }
         ("POST", "/v1/sessions") => {
-            if service != Service::Provisioning {
+            if !capabilities.manage_sessions {
                 return refusal(403, "service_not_permitted", None);
             }
             create_session(shared, request)
         }
         ("DELETE", path) => {
-            if service != Service::Provisioning {
+            if !capabilities.manage_sessions {
                 return refusal(403, "service_not_permitted", None);
             }
             let session_id = path.strip_prefix("/v1/sessions/").unwrap_or_default();
@@ -1073,6 +1109,10 @@ mod tests {
             Some(Service::Provisioning)
         );
         assert_eq!(
+            resolve_service(&tokens, "registrar-token-0123456789abcdef"),
+            Some(Service::Registrar)
+        );
+        assert_eq!(
             resolve_service(&tokens, "gateway-token-0123456789abcde"),
             None
         );
@@ -1081,6 +1121,64 @@ mod tests {
             None
         );
         assert_eq!(resolve_service(&tokens, ""), None);
+    }
+
+    #[test]
+    fn the_registrar_creates_principals_without_session_authority() {
+        let registrar = Service::Registrar.capabilities();
+        assert!(registrar.create_principals);
+        assert!(!registrar.manage_sessions);
+        assert!(!registrar.introspect);
+        let provisioning = Service::Provisioning.capabilities();
+        assert!(provisioning.create_principals);
+        assert!(provisioning.manage_sessions);
+        assert!(!provisioning.introspect);
+    }
+
+    #[test]
+    fn session_authority_belongs_to_provisioning_alone() {
+        let minting: Vec<&'static str> = Service::ALL
+            .iter()
+            .filter(|service| service.capabilities().manage_sessions)
+            .map(|service| service.name())
+            .collect();
+        assert_eq!(minting, ["provisioning"]);
+        let provisioning: Vec<&'static str> = Service::ALL
+            .iter()
+            .filter(|service| service.capabilities().create_principals)
+            .map(|service| service.name())
+            .collect();
+        assert_eq!(provisioning, ["provisioning", "registrar"]);
+        let introspecting: Vec<&'static str> = Service::ALL
+            .iter()
+            .filter(|service| service.capabilities().introspect)
+            .map(|service| service.name())
+            .collect();
+        assert_eq!(
+            introspecting,
+            [
+                "gateway",
+                "webhooks",
+                "dashboard",
+                "faucet",
+                "testnet",
+                "ramp"
+            ]
+        );
+    }
+
+    #[test]
+    fn service_names_are_distinct_and_file_name_safe() {
+        let names: Vec<&'static str> = Service::ALL.iter().map(|service| service.name()).collect();
+        assert_eq!(names.len(), Service::ALL.len());
+        for (index, name) in names.iter().enumerate() {
+            assert!(!names[..index].contains(name), "{name} is not distinct");
+            assert!(
+                name.bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte == b'-'),
+                "{name} is not a safe Secret key"
+            );
+        }
     }
 
     #[test]

--- a/platform/hosted/identity/tests/service.rs
+++ b/platform/hosted/identity/tests/service.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 use std::time::Duration;
 
-const SERVICES: [&str; 7] = [
+const SERVICES: [&str; 8] = [
     "gateway",
     "webhooks",
     "dashboard",
@@ -18,7 +18,20 @@ const SERVICES: [&str; 7] = [
     "testnet",
     "ramp",
     "provisioning",
+    "registrar",
 ];
+const INTROSPECTING_SERVICES: [&str; 6] = [
+    "gateway",
+    "webhooks",
+    "dashboard",
+    "faucet",
+    "testnet",
+    "ramp",
+];
+const REGISTRAR_SUB: &str = "did:key:z6mkregistrar-principal";
+const REGISTRAR_ACCOUNT: &str = "agent:did:key:z6mkregistrar-principal:main";
+const SERVICE_NOT_PERMITTED: &str =
+    "{\"error\":{\"code\":\"service_not_permitted\",\"retry\":\"never\"}}";
 const SIGNER_KEY: &str = "1f2e3d4c5b6a79880123456789abcdef1f2e3d4c5b6a79880123456789abcdef";
 const OTHER_SIGNER_KEY: &str = "0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9";
 const SUB: &str = "did:key:z6mkbeta-principal_1";
@@ -202,8 +215,9 @@ fn token_for(service: &str) -> String {
 }
 
 impl Fixture {
-    fn spawn(&self, state_dir: &Path) -> Server {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_layerx-identity"))
+    fn command(&self, state_dir: &Path) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_layerx-identity"));
+        command
             .env_clear()
             .env("LAYERX_IDENTITY_LISTEN", "127.0.0.1:0")
             .env(
@@ -226,7 +240,26 @@ impl Fixture {
             .env("LAYERX_IDENTITY_SESSION_TTL_SECONDS", "3600")
             .stdin(Stdio::null())
             .stdout(Stdio::null())
-            .stderr(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    }
+
+    fn boot_refusal(&self, state_dir: &Path) -> String {
+        let output = self
+            .command(state_dir)
+            .output()
+            .unwrap_or_else(|error| panic!("run: {error}"));
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "layerx-identity must refuse to boot"
+        );
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    }
+
+    fn spawn(&self, state_dir: &Path) -> Server {
+        let mut child = self
+            .command(state_dir)
             .spawn()
             .unwrap_or_else(|error| panic!("spawn: {error}"));
         let stderr = child.stderr.take().unwrap_or_else(|| panic!("stderr pipe"));
@@ -685,26 +718,26 @@ fn wrong_service_tokens_are_refused() {
         Some(&body),
     );
     assert_eq!(unknown.status, 401);
-    let provisioning_introspect = fixture.request(
-        &server,
-        "POST",
-        "/v1/sessions/introspect",
-        Some(&token_for("provisioning")),
-        Some(&body),
-    );
-    assert_eq!(provisioning_introspect.status, 403);
-    assert_eq!(
-        provisioning_introspect.body,
-        "{\"error\":{\"code\":\"service_not_permitted\",\"retry\":\"never\"}}"
-    );
-    for service in [
-        "gateway",
-        "webhooks",
-        "dashboard",
-        "faucet",
-        "testnet",
-        "ramp",
+    for (service, path) in [
+        ("provisioning", "/v1/sessions/introspect"),
+        ("provisioning", "/v1/introspect"),
+        ("registrar", "/v1/sessions/introspect"),
+        ("registrar", "/v1/introspect"),
     ] {
+        let refused = fixture.request(
+            &server,
+            "POST",
+            path,
+            Some(&token_for(service)),
+            Some(&body),
+        );
+        assert_eq!(
+            refused.status, 403,
+            "{service} must not introspect at {path}"
+        );
+        assert_eq!(refused.body, SERVICE_NOT_PERMITTED);
+    }
+    for service in INTROSPECTING_SERVICES {
         let principal = fixture.request(
             &server,
             "POST",
@@ -735,6 +768,30 @@ fn wrong_service_tokens_are_refused() {
         );
         assert_eq!(revoke.status, 403, "{service} must not revoke sessions");
     }
+    let registrar_session = fixture.request(
+        &server,
+        "POST",
+        "/v1/sessions",
+        Some(&token_for("registrar")),
+        Some(&format!("{{\"sub\":\"{SUB}\"}}")),
+    );
+    assert_eq!(
+        registrar_session.status, 403,
+        "the registrar must not mint sessions"
+    );
+    assert_eq!(registrar_session.body, SERVICE_NOT_PERMITTED);
+    let registrar_revoke = fixture.request(
+        &server,
+        "DELETE",
+        &format!("/v1/sessions/{session_id}"),
+        Some(&token_for("registrar")),
+        None,
+    );
+    assert_eq!(
+        registrar_revoke.status, 403,
+        "the registrar must not revoke sessions"
+    );
+    assert_eq!(registrar_revoke.body, SERVICE_NOT_PERMITTED);
     let still_active = introspect(&fixture, &server, "faucet", "/v1/introspect", &token);
     assert_eq!(
         still_active.body,
@@ -764,6 +821,157 @@ fn wrong_service_tokens_are_refused() {
         Some("{\"tenant\":\"beta\",\"sub\":\"did:key:other\",\"allowed_signer_public_keys\":[\"abc\"]}"),
     );
     assert_eq!(invalid_key.status, 400);
+}
+
+#[test]
+fn the_registrar_creates_principals_and_only_provisioning_mints_their_sessions() {
+    let fixture = fixture("registrar");
+    let state = fixture.root.join("state");
+    let server = fixture.spawn(&state);
+    let registrar = token_for("registrar");
+    let principal = format!(
+        "{{\"tenant\":\"beta\",\"sub\":\"{REGISTRAR_SUB}\",\"allowed_signer_public_keys\":[\"{SIGNER_KEY}\"],\"account\":\"{REGISTRAR_ACCOUNT}\",\"audiences\":[\"ramp-reference\"]}}"
+    );
+    let created = fixture.request(
+        &server,
+        "POST",
+        "/v1/principals",
+        Some(&registrar),
+        Some(&principal),
+    );
+    assert_eq!(created.status, 200, "{}", created.body);
+    assert_eq!(created.body, principal);
+    let conflict = fixture.request(
+        &server,
+        "POST",
+        "/v1/principals",
+        Some(&registrar),
+        Some(
+            &serde_json::json!({
+                "tenant": "rival",
+                "sub": REGISTRAR_SUB,
+                "allowed_signer_public_keys": [OTHER_SIGNER_KEY]
+            })
+            .to_string(),
+        ),
+    );
+    assert_eq!(conflict.status, 409, "{}", conflict.body);
+    assert_eq!(
+        conflict.body,
+        "{\"error\":{\"code\":\"subject_tenant_conflict\",\"retry\":\"never\"}}"
+    );
+    for body in [
+        format!("{{\"sub\":\"{REGISTRAR_SUB}\"}}"),
+        format!("{{\"tenant\":\"beta\",\"sub\":\"{REGISTRAR_SUB}\"}}"),
+        format!("{{\"sub\":\"{REGISTRAR_SUB}\",\"ttl_seconds\":60}}"),
+    ] {
+        let minted = fixture.request(
+            &server,
+            "POST",
+            "/v1/sessions",
+            Some(&registrar),
+            Some(&body),
+        );
+        assert_eq!(minted.status, 403, "{}", minted.body);
+        assert_eq!(minted.body, SERVICE_NOT_PERMITTED);
+    }
+    let journal = fs::read_to_string(state.join("journal.log")).unwrap_or_default();
+    assert!(
+        journal.contains("\"Principal\"") && journal.contains(REGISTRAR_SUB),
+        "the registrar's principal reaches the journal: {journal}"
+    );
+    assert!(
+        !journal.contains("\"Session\""),
+        "the registrar's refused mints leave no session record: {journal}"
+    );
+    let session = fixture.request(
+        &server,
+        "POST",
+        "/v1/sessions",
+        Some(&token_for("provisioning")),
+        Some(&format!("{{\"sub\":\"{REGISTRAR_SUB}\"}}")),
+    );
+    assert_eq!(session.status, 200, "{}", session.body);
+    let value = json(&session);
+    assert_eq!(value["tenant"], "beta");
+    assert_eq!(value["sub"], REGISTRAR_SUB);
+    let token = value["token"].as_str().unwrap_or_default().to_owned();
+    let session_id = value["session_id"].as_str().unwrap_or_default().to_owned();
+    let gateway = introspect(
+        &fixture,
+        &server,
+        "gateway",
+        "/v1/sessions/introspect",
+        &token,
+    );
+    assert_eq!(
+        gateway.body,
+        format!(
+            "{{\"active\":true,\"sub\":\"{REGISTRAR_SUB}\",\"allowed_signer_public_keys\":[\"{SIGNER_KEY}\"]}}"
+        )
+    );
+    let ramp = introspect(&fixture, &server, "ramp", "/v1/introspect", &token);
+    assert_eq!(json(&ramp)["principal_id"], REGISTRAR_SUB);
+    assert_eq!(json(&ramp)["account"], REGISTRAR_ACCOUNT);
+    for path in ["/v1/sessions/introspect", "/v1/introspect"] {
+        let refused = fixture.request(
+            &server,
+            "POST",
+            path,
+            Some(&registrar),
+            Some(&format!("{{\"token\":\"{token}\"}}")),
+        );
+        assert_eq!(refused.status, 403, "{}", refused.body);
+        assert_eq!(refused.body, SERVICE_NOT_PERMITTED);
+    }
+    let revoke = fixture.request(
+        &server,
+        "DELETE",
+        &format!("/v1/sessions/{session_id}"),
+        Some(&registrar),
+        None,
+    );
+    assert_eq!(revoke.status, 403, "{}", revoke.body);
+    assert_eq!(revoke.body, SERVICE_NOT_PERMITTED);
+    let still_active = introspect(&fixture, &server, "faucet", "/v1/introspect", &token);
+    assert_eq!(
+        still_active.body,
+        format!("{{\"active\":true,\"sub\":\"{REGISTRAR_SUB}\"}}")
+    );
+    let revoked = fixture.request(
+        &server,
+        "DELETE",
+        &format!("/v1/sessions/{session_id}"),
+        Some(&token_for("provisioning")),
+        None,
+    );
+    assert_eq!(revoked.status, 200, "{}", revoked.body);
+    assert_inactive(&fixture, &server, &token);
+}
+
+#[test]
+fn boot_requires_a_distinct_registrar_token() {
+    let fixture = fixture("registrar-token");
+    let state = fixture.root.join("state");
+    let registrar = fixture.root.join("tokens").join("registrar");
+    fs::remove_file(&registrar).unwrap_or_else(|error| panic!("remove registrar token: {error}"));
+    let missing = fixture.boot_refusal(&state);
+    assert!(
+        missing.contains("service token for registrar"),
+        "boot names the missing registrar token: {missing}"
+    );
+    fs::write(&registrar, format!("{}\n", token_for("provisioning")))
+        .unwrap_or_else(|error| panic!("write registrar token: {error}"));
+    let duplicate = fixture.boot_refusal(&state);
+    assert!(
+        duplicate.contains("service token for registrar duplicates another service"),
+        "boot refuses a registrar token equal to the provisioning token: {duplicate}"
+    );
+    fs::write(&registrar, format!("{}\n", token_for("registrar")))
+        .unwrap_or_else(|error| panic!("restore registrar token: {error}"));
+    let server = fixture.spawn(&state);
+    let ready = fixture.request(&server, "GET", "/readyz", None, None);
+    assert_eq!(ready.status, 200, "{}", ready.body);
 }
 
 #[test]

--- a/platform/hosted/tests/beta-cluster.sh
+++ b/platform/hosted/tests/beta-cluster.sh
@@ -560,7 +560,7 @@ secrets_generate() {
     cp "$d/developer-identity.token" "$d/identity-tokens/webhooks"
     cp "$d/identity-client.token" "$d/identity-tokens/faucet"
     local service
-    for service in dashboard testnet ramp provisioning; do
+    for service in dashboard testnet ramp provisioning registrar; do
         write_token "$d/identity-tokens/$service"
     done
     write_token "$d/identity-store.key"


### PR DESCRIPTION
## Summary

The identity service admitted `POST /v1/principals` and `POST /v1/sessions` on
the same `provisioning` token, so the gateway Deployment's projection of that
key (for `lx_register`) also placed a session-minting credential in the public
gateway pod, which never calls `/v1/sessions` (ledger observation 3.6.9201,
blocker). This change adds a narrower `registrar` identity role that
`create_principal` accepts and `create_session`, `revoke_session` and both
introspection paths refuse with `403 service_not_permitted`; the bring-up
script generates its token key in the `layerx-identity-service-tokens` Secret;
and the gateway projects `registrar` in place of `provisioning`. The public pod
now holds only the identity capability it uses. It also corrects
`docs/wiki/HostedFaucet.md:297`, which still said the faucet Deployment does not
set `LAYERX_FAUCET_SERVICE_CLAIM_TOKEN_FILE`.

## Files changed

- `platform/hosted/identity/src/main.rs`: `Service::Registrar` (token file
  name `registrar`) and a `Capabilities` table (`introspect`,
  `create_principals`, `manage_sessions`) returned by
  `Service::capabilities`; `route` gates each path on the capability instead of
  comparing against `Service::Provisioning`; `introspection_shape` refuses the
  registrar as it refuses provisioning. Unit tests pin that only `provisioning`
  holds `manage_sessions`, that `provisioning` and `registrar` alone hold
  `create_principals`, that the six consumer services alone introspect, and
  that service names stay distinct and Secret-key safe.
- `platform/hosted/identity/tests/service.rs`: the fixture writes eight token
  files; `wrong_service_tokens_are_refused` refuses provisioning and registrar
  on both introspect paths and refuses the registrar's mint and revoke;
  `the_registrar_creates_principals_and_only_provisioning_mints_their_sessions`
  creates a principal with the registrar token, refuses three session bodies,
  reads the store journal to prove a `Principal` record exists and no `Session`
  record does, then mints a session with the provisioning token for that
  principal, introspects it as gateway and ramp, refuses the registrar's
  introspect and revoke, and revokes with provisioning;
  `boot_requires_a_distinct_registrar_token` runs the binary against a token
  directory missing `registrar` and against one whose `registrar` equals the
  provisioning token and asserts exit 2 with the named refusal, then boots with
  the full set. `Fixture::command` is the shared process builder for `spawn`
  and the new `boot_refusal`.
- `platform/hosted/gateway/deployment.yaml:127`: projection key `provisioning`
  becomes `registrar`; volume name, mount path and the
  `LAYERX_GATEWAY_IDENTITY_PROVISIONING_TOKEN_FILE` variable are unchanged as
  the row scopes this file to the projection key.
- `platform/hosted/tests/beta-cluster.sh:562`: `secrets_generate` writes
  `identity-tokens/registrar` beside `dashboard`, `testnet`, `ramp` and
  `provisioning`, so `apply_secret layerx-identity-service-tokens
  --from-file=identity-tokens` carries the key and the identity pod, which
  mounts the whole Secret, boots with every `Service::ALL` name present.
- `docs/wiki/HostedFaucet.md:297` and `:314-319`: the config row now states the
  Deployment sets the variable to `/run/layerx/gateway-faucet/token` from
  Secret `layerx-gateway-faucet-client`, and the mounts paragraph lists that
  mount with the current manifest lines.

## Design decisions

- A capability table rather than a second special-cased variant: every route
  reads one boolean, so adding the role touched no handler and the tests can
  enumerate `Service::ALL` and assert which names hold each capability.
- The registrar does not introspect. The gateway already holds the `gateway`
  token for introspection; the registrar key is scoped to the one call
  `rpc_register.rs` makes.
- Bring-up keeps using the `provisioning` token for its own principal and
  session steps (`identity_request`), which is the trusted operator path; only
  the public pod's projection narrows.
- Boot refuses a `registrar` token equal to the `provisioning` token through
  the existing duplicate check, so the two roles cannot be collapsed by reusing
  one secret value.
- `docs/wiki/HostedIdentity.md` describes seven callers and is outside this
  row's paths; the needed edits are listed under Follow-ups.

## Static checks

- `rustfmt --edition 2021 --check platform/hosted/identity/src/main.rs platform/hosted/identity/tests/service.rs`: exit 0
- `bash -n platform/hosted/tests/beta-cluster.sh`: exit 0
- `git diff --check origin/main HEAD`: exit 0
- PyYAML `safe_load_all` of `platform/hosted/gateway/deployment.yaml`, reading the `identity-provisioning` volume: exit 0, `items: [{key: registrar, path: token}]`
- `python3 kvx_verify.py <origin/main ledger> spec/layerx-beta/qualification.kvx`: `missing=[] differ=[] extra=[]`; `git diff origin/main --numstat -- spec/layerx-beta/qualification.kvx spec/layerx-beta/report.md`: no output (both files are main's bytes)
- `tools/ci/beta-report.sh --check`: exit 0

## Build and test: not run in this lane

`cargo test -p layerx-platform-identity`, `make platform-hosted-topology-check`,
`python3 platform/hosted/tests/topology-regressions.py` and
`make beta-ledger-check` were not run here; the owner runs them on main.

## Generated artifacts pending

none

## Follow-ups

- `docs/wiki/HostedIdentity.md` (lines 8-13, 42, 54, 66, 185, 318, 400): eight
  callers, a Registrar row in the caller table, the token-file list, the
  `LAYERX_IDENTITY_SERVICE_TOKENS_DIR` row and the test table.
- `spec/layerx-beta/qualification.kvx` observation 3.6.9201 records the
  capability this change removes from the gateway pod; the ledger is outside
  this row's paths and no gate ran here, so the resolution is left for the
  owner to record after the gates run on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
