### PR TITLE
Deliver the sequencer seed to layerxd from the supervisor instead of exporting sequencer.env

### DIFF
--- a/docs/wiki/HostedNode.md
+++ b/docs/wiki/HostedNode.md
@@ -396,6 +396,22 @@ command line, in the supervisor's own environment, in
 `node.env`, `replica.env`, `core.env`, or the guarantor
 identity directories.
 
+Callers outside the supervisor that start `layerxd --serve`
+from a bootstrap-generated `sequencer.env` (the daemon test
+scripts under `tests/daemon/`) source
+`platform/hosted/node/sequencer-env.sh` and call
+`layerx_sequencer_environment <sequencer.env>` in the subshell
+that execs the daemon instead of `set -a; source`. The helper
+exports the `LAYERX_*` lines with the same validation, refuses a
+seed line, reads the key file named by
+`LAYERX_NODE_SEQUENCER_KEY_FILE` and exports
+`LAYERX_NODE_SEQUENCER_PRIVATE_KEY` for the exec'd daemon only.
+`tests/daemon/guarantor-integration.py` performs the same
+derivation in Python before it launches the daemon. Tools that
+only replay the checkpoint log with `sequencer.env` sourced
+(`tests/daemon/guarantor-publication-chain.py`) never read the
+seed and are unaffected.
+
 Refusals, all exit `1` before a generation is published:
 `must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY`,
 `LAYERX_NODE_SEQUENCER_KEY_FILE missing`, `sequencer key file is

--- a/docs/wiki/HostedNode.md
+++ b/docs/wiki/HostedNode.md
@@ -128,7 +128,7 @@ Outputs under the data directory
 | `secrets/treasury-key.hex` | Treasury seed hex |
 | `secrets/guarantor-key.pem` | secp256k1 guarantor private key |
 | `sequencer.conf` / `replica.conf` | Eight-line `layerxd` configurations; both pass `layerxd --check-config` (`platform/hosted/node/bootstrap.sh:449-455`) |
-| `sequencer.env` / `replica.env` | Daemon environments |
+| `sequencer.env` / `replica.env` | Daemon environments, mode `0600`; `sequencer.env` names the sequencer seed file as `LAYERX_NODE_SEQUENCER_KEY_FILE` and never carries the seed |
 | `node.env` | Published node facts, mode `0644` |
 | `treasury.json` | Treasury DID, public key, account, asset, genesis balance, network id (`platform/hosted/node/bootstrap.sh:543-546`) |
 
@@ -339,13 +339,16 @@ values before `layerxd --serve`
 | `LAYERX_NODE_REPLICA_ENV` | `{data}/replica.env` |
 
 `sequencer.env` additionally carries snapshot, manifest,
-registration, identities, logs, history database, sequencer
-keys, batch range `1`..`18446744073709551615`, replica
+registration, identities, logs, history database, the sequencer
+id and public key, `LAYERX_NODE_SEQUENCER_KEY_FILE` (the
+`--sequencer-key` path, absolute, outside the data directory),
+batch range `1`..`18446744073709551615`, replica
 address/port/id/token, program address/port/token, LNI socket,
 allowed uid/gid, `LAYERX_NODE_LNI_FRAME_BYTES=1212416`, and
 `LAYERX_NODE_LNI_DEADLINE_MS=2000`, or
 `LAYERX_NODE_SETTLEMENT_ENV` in place of the five settlement
 keys (`platform/hosted/node/bootstrap.sh:457-494`).
+
 `replica.env` carries replica log, replica id, sequencer id
 and public key, batch range, bearer token, and
 `LAYERX_AUTHORITY_ADDRESS=127.0.0.1` plus port
@@ -358,6 +361,56 @@ and public key, batch range, bearer token, and
 writes `1212416` (`platform/hosted/node/bootstrap.sh:492`).
 `cmd/layerxd/lni.env.example:23` writes `1146902`. Those two
 values differ.
+
+---
+
+## Sequencer seed delivery
+
+The sequencer seed is read by `bootstrap.sh` once, to sign the
+genesis request, and is not copied under the data directory:
+the temporary signer key under `work/` is deleted after
+`layerx-genesis-build` returns and `sequencer.env` records only
+the key file path. `--sequencer-key` must name a readable
+regular file outside the data directory (also after resolving
+symlinks), because `--force` and the supervisor reset discard
+that directory.
+
+The supervisor never sources an environment file with
+`set -a`. `load_environment` validates every line as a
+`LAYERX_*` `KEY=VALUE` pair without control characters, exports
+it, and refuses a `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` line.
+Before the sequencer supervisor publishes a generation (first
+start, restart against a retained data directory, and every
+reset) `check_sequencer_environment` refuses a seed line in
+`sequencer.env`, reads the seed named by
+`LAYERX_NODE_SEQUENCER_KEY_FILE` (32 raw bytes or 64 hex
+characters) through a read-only descriptor it opens itself, and
+refuses to continue unless the derived public key equals
+`LAYERX_NODE_SEQUENCER_PUBLIC_KEY`. When it starts
+`layerxd --serve` it reads the seed the same way inside the
+subshell that execs the daemon and exports
+`LAYERX_NODE_SEQUENCER_PRIVATE_KEY` there only; the daemon
+reads that variable (`cmd/layerxd/lxp_daemon_process.c`,
+`cmd/layerxd/lxp_daemon_lni.c`). The seed never appears on a
+command line, in the supervisor's own environment, in
+`node.env`, `replica.env`, `core.env`, or the guarantor
+identity directories.
+
+Refusals, all exit `1` before a generation is published:
+`must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY`,
+`LAYERX_NODE_SEQUENCER_KEY_FILE missing`, `sequencer key file is
+not a regular file`, `sequencer key file must hold 32 raw bytes
+or 64 hex characters`, `does not match the bound sequencer
+public key`.
+
+The pod keeps `shareProcessNamespace: true`
+(`platform/hosted/node/deployment.yaml:28`): the LNI peer
+credential check refuses a `SO_PEERCRED` pid of `0`, which is
+what a sibling container in its own pid namespace reports, so
+the boundary containers must share the daemon's pid namespace.
+Processes with the daemon's uid in that namespace can therefore
+still read the daemon environment; the daemon container is the
+only one that mounts `/run/layerx/keys/sequencer.key`.
 
 ---
 

--- a/platform/Makefile.inc
+++ b/platform/Makefile.inc
@@ -138,8 +138,9 @@ platform-test-registry:
 	$(PLATFORM_CARGO) test --offline --manifest-path $(PLATFORM_MANIFEST) --locked -p layerx-platform-registry
 
 platform-test-node: test-layerxctl
-	bash -n platform/hosted/node/bootstrap.sh platform/hosted/node/supervisor.sh platform/hosted/node/tests/node-test.sh
+	bash -n platform/hosted/node/bootstrap.sh platform/hosted/node/supervisor.sh platform/hosted/node/sequencer-env.sh platform/hosted/node/tests/node-test.sh
 	PLATFORM_CARGO="$(PLATFORM_CARGO)" bash platform/hosted/node/tests/node-test.sh
+	python3 platform/hosted/node/tests/sequencer-seed-test.py
 
 platform-test-core:
 	$(PLATFORM_CARGO) test --offline --manifest-path $(PLATFORM_MANIFEST) --locked -p layerx-platform-core

--- a/platform/hosted/node/bootstrap.sh
+++ b/platform/hosted/node/bootstrap.sh
@@ -21,7 +21,12 @@
 #   --network-id N          Decimal network id, 1..4294967295.
 #   --genesis-metadata FILE LXGB v2 suffix: canonical Asset records and named fees.
 #   --sequencer-key FILE    Sequencer ed25519 seed: 32 raw bytes or 64 hex
-#                           characters. Signs genesis and every batch.
+#                           characters. Signs genesis and every batch. FILE
+#                           must lie outside DATA_DIR; it is read here once to
+#                           sign genesis and its path is recorded in
+#                           sequencer.env as LAYERX_NODE_SEQUENCER_KEY_FILE.
+#                           The seed itself is never written into DATA_DIR:
+#                           the supervisor reads FILE when it starts layerxd.
 #   --treasury-key FILE     Treasury ed25519 seed (same format). The treasury
 #                           DID did:layerx:<public-key-hex> is registered as
 #                           an identity so the admin plane can sign from it.
@@ -216,6 +221,9 @@ case "$GENESIS_METADATA" in "$(readlink -m "$DATA_DIR")"/*) fail "genesis metada
 [ -n "$RUN_DIR" ] || fail "--run-dir is required"
 [ -n "$NETWORK_ID" ] || fail "--network-id is required"
 [ -n "$SEQUENCER_KEY_FILE" ] || fail "--sequencer-key is required"
+[[ $SEQUENCER_KEY_FILE = /* ]] || SEQUENCER_KEY_FILE="$PWD/$SEQUENCER_KEY_FILE"
+[ -f "$SEQUENCER_KEY_FILE" ] && [ -r "$SEQUENCER_KEY_FILE" ] || fail "--sequencer-key must name a readable regular file: $SEQUENCER_KEY_FILE"
+[[ $SEQUENCER_KEY_FILE != *[[:cntrl:]]* ]] || fail "--sequencer-key path must not contain control characters"
 if [ -n "$TREASURY_KEY_FILE" ]; then
     [ -z "$TREASURY_SIGNER_SOCKET" ] \
         || fail "--treasury-key and --treasury-signer-socket are exclusive"
@@ -408,6 +416,8 @@ mkdir -p "$RUN_DIR"
 RUN_DIR=$(readlink -f "$RUN_DIR")
 [ "$DATA_DIR" != "$RUN_DIR" ] || fail "--data-dir and --run-dir must differ"
 case "$RUN_DIR" in "$DATA_DIR"/*) fail "--run-dir must not be inside --data-dir" ;; esac
+case "$SEQUENCER_KEY_FILE" in "$DATA_DIR"/*) fail "the sequencer key file must be outside the data directory: $SEQUENCER_KEY_FILE" ;; esac
+case "$(readlink -f "$SEQUENCER_KEY_FILE")" in "$DATA_DIR"/*) fail "the sequencer key file must be outside the data directory: $SEQUENCER_KEY_FILE" ;; esac
 if [ "$FORCE" -eq 1 ]; then
     find "$DATA_DIR" -mindepth 1 -delete
 fi
@@ -568,7 +578,7 @@ LAYERX_NODE_HISTORY_DATABASE=$DATA_DIR/history.sqlite
 LAYERX_NODE_HISTORY_MIGRATIONS=$MIGRATIONS
 LAYERX_NODE_SEQUENCER_ID=$SEQUENCER_ID
 LAYERX_NODE_SEQUENCER_PUBLIC_KEY=$SEQUENCER_PUBLIC
-LAYERX_NODE_SEQUENCER_PRIVATE_KEY=$SEQUENCER_PRIVATE
+LAYERX_NODE_SEQUENCER_KEY_FILE=$SEQUENCER_KEY_FILE
 LAYERX_NODE_FIRST_BATCH=1
 LAYERX_NODE_LAST_BATCH=$LAST_BATCH
 LAYERX_NODE_AUTHORITY_REPLICA_ADDRESS=127.0.0.1

--- a/platform/hosted/node/sequencer-env.sh
+++ b/platform/hosted/node/sequencer-env.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Sourced by the callers that start `layerxd --serve` from a
+# bootstrap-generated sequencer.env outside the supervisor (the daemon test
+# scripts). sequencer.env no longer carries the seed; it names the key file
+# as LAYERX_NODE_SEQUENCER_KEY_FILE and the supervisor reads it. This file
+# gives every other caller the same delivery:
+#
+#   source platform/hosted/node/sequencer-env.sh
+#   layerx_sequencer_environment "$data/sequencer.env"
+#   exec layerxd --serve "$data/sequencer.conf"
+#
+# layerx_sequencer_environment exports every LAYERX_* KEY=VALUE line of the
+# file, refuses a LAYERX_NODE_SEQUENCER_PRIVATE_KEY line, reads the seed
+# (32 raw bytes or 64 hex characters) from LAYERX_NODE_SEQUENCER_KEY_FILE
+# through a read-only descriptor and exports it as
+# LAYERX_NODE_SEQUENCER_PRIVATE_KEY, the only form cmd/layerxd reads. It
+# returns 1 with a message on stderr instead of exporting anything partial.
+
+layerx_sequencer_environment() {
+    local env_file=$1 line key key_file size descriptor seed
+    [ -r "$env_file" ] || { printf 'sequencer-env: environment file missing: %s\n' "$env_file" >&2; return 1; }
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -n "$line" ] || continue
+        [[ $line =~ ^(LAYERX_[A-Z0-9_]+)=([^[:cntrl:]]*)$ ]] || {
+            printf 'sequencer-env: %s carries a line that is not a LAYERX_* KEY=VALUE pair: %s\n' "$env_file" "${line%%=*}" >&2
+            return 1
+        }
+        key=${BASH_REMATCH[1]}
+        [ "$key" != LAYERX_NODE_SEQUENCER_PRIVATE_KEY ] || {
+            printf 'sequencer-env: %s must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY; the seed is read from LAYERX_NODE_SEQUENCER_KEY_FILE\n' "$env_file" >&2
+            return 1
+        }
+        export "$line"
+    done < "$env_file"
+    key_file=${LAYERX_NODE_SEQUENCER_KEY_FILE:-}
+    [ -n "$key_file" ] || { printf 'sequencer-env: LAYERX_NODE_SEQUENCER_KEY_FILE missing from %s\n' "$env_file" >&2; return 1; }
+    [[ $key_file = /* ]] || { printf 'sequencer-env: LAYERX_NODE_SEQUENCER_KEY_FILE must be an absolute path: %s\n' "$key_file" >&2; return 1; }
+    [ -f "$key_file" ] && [ -r "$key_file" ] || { printf 'sequencer-env: sequencer key file is not a readable regular file: %s\n' "$key_file" >&2; return 1; }
+    size=$(stat -L -c %s "$key_file")
+    [ "$size" -le 128 ] || { printf 'sequencer-env: sequencer key file must hold 32 raw bytes or 64 hex characters: %s\n' "$key_file" >&2; return 1; }
+    exec {descriptor}<"$key_file" || { printf 'sequencer-env: sequencer key file could not be opened: %s\n' "$key_file" >&2; return 1; }
+    if [ "$size" -eq 32 ]; then
+        seed=$(od -An -v -tx1 <&"$descriptor" | tr -d ' \n')
+    else
+        seed=$(tr -d ' \t\r\n' <&"$descriptor" | tr 'A-F' 'a-f')
+    fi
+    exec {descriptor}<&-
+    [[ $seed =~ ^[0-9a-f]{64}$ ]] || {
+        printf 'sequencer-env: sequencer key file must hold 32 raw bytes or 64 hex characters: %s\n' "$key_file" >&2
+        return 1
+    }
+    export LAYERX_NODE_SEQUENCER_PRIVATE_KEY="$seed"
+}

--- a/platform/hosted/node/supervisor.sh
+++ b/platform/hosted/node/supervisor.sh
@@ -39,6 +39,17 @@
 # default 3600), validates it with bootstrap.sh --check-settlement and exports
 # its five values to `layerxd --serve` before starting it.
 #
+# Environment files are never sourced: every KEY=VALUE line is validated and
+# exported one at a time, and a LAYERX_NODE_SEQUENCER_PRIVATE_KEY line is
+# refused. sequencer.env names the sequencer seed file as
+# LAYERX_NODE_SEQUENCER_KEY_FILE (the bootstrap --sequencer-key path). Before a
+# generation is published the sequencer supervisor checks that the file's
+# public key equals LAYERX_NODE_SEQUENCER_PUBLIC_KEY; when it starts
+# `layerxd --serve` it reads the seed through a read-only descriptor it opens
+# itself and exports LAYERX_NODE_SEQUENCER_PRIVATE_KEY only into the
+# environment of the daemon process it execs. The seed is never copied into
+# the data directory and never appears on a command line.
+#
 # A daemon that exits on its own ends the supervisor with status 1 so the pod
 # restarts it against the retained data directory.
 set -euo pipefail
@@ -142,6 +153,83 @@ LAYERXD=$(resolve_binary "$LAYERXD" layerxd)
 DAEMON_PID=""
 SOCAT=${SOCAT:-$(command -v socat || true)}
 [ -n "$SOCAT" ] && [ -x "$SOCAT" ] || fail "socat is required for daemon readiness and the supervisor socket"
+if [ "$ROLE" = sequencer ]; then
+    command -v openssl >/dev/null || fail "openssl is required to bind the sequencer seed"
+    command -v od >/dev/null || fail "od is required to bind the sequencer seed"
+fi
+
+bin_to_hex() { od -An -v -tx1 | tr -d ' \n'; }
+
+hex_to_bin() {
+    local hex=$1 i
+    for ((i = 0; i < ${#hex}; i += 2)); do
+        printf "\\$(printf '%03o' "0x${hex:i:2}")"
+    done
+}
+
+public_key_hex() {
+    # ed25519 public key from a 32-byte seed via the PKCS#8 wrapper openssl reads.
+    { hex_to_bin "302e020100300506032b657004220420"; hex_to_bin "$1"; } \
+        | openssl pkey -inform DER -pubout -outform DER | tail -c 32 | bin_to_hex
+}
+
+load_environment() {
+    # load_environment NAME < lines -> exports every validated KEY=VALUE line
+    local name=$1 line key
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -n "$line" ] || continue
+        [[ $line =~ ^(LAYERX_[A-Z0-9_]+)=([^[:cntrl:]]*)$ ]] \
+            || fail "$name carries a line that is not a LAYERX_* KEY=VALUE pair: ${line%%=*}"
+        key=${BASH_REMATCH[1]}
+        [ "$key" != LAYERX_NODE_SEQUENCER_PRIVATE_KEY ] \
+            || fail "$name must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY; the supervisor delivers the seed from LAYERX_NODE_SEQUENCER_KEY_FILE"
+        export "$line"
+    done
+}
+
+SEQUENCER_SEED=""
+
+sequencer_seed_hex() {
+    # sequencer_seed_hex FILE -> SEQUENCER_SEED holds the 64 hex character seed
+    # read through a private read-only descriptor; FILE holds 32 raw bytes or
+    # 64 hex characters, the same forms bootstrap.sh --sequencer-key accepts.
+    local file=$1 size descriptor
+    SEQUENCER_SEED=""
+    [[ $file = /* ]] || fail "LAYERX_NODE_SEQUENCER_KEY_FILE must be an absolute path"
+    [ -f "$file" ] || fail "sequencer key file is not a regular file: $file"
+    [ -r "$file" ] || fail "sequencer key file is not readable: $file"
+    size=$(stat -L -c %s "$file")
+    [ "$size" -le 128 ] || fail "sequencer key file must hold 32 raw bytes or 64 hex characters: $file"
+    exec {descriptor}<"$file" || fail "sequencer key file could not be opened: $file"
+    if [ "$size" -eq 32 ]; then
+        SEQUENCER_SEED=$(bin_to_hex <&"$descriptor")
+    else
+        SEQUENCER_SEED=$(tr -d ' \t\r\n' <&"$descriptor" | tr 'A-F' 'a-f')
+    fi
+    exec {descriptor}<&-
+    [[ $SEQUENCER_SEED =~ ^[0-9a-f]{64}$ ]] \
+        || fail "sequencer key file must hold 32 raw bytes or 64 hex characters: $file"
+}
+
+check_sequencer_environment() {
+    # check_sequencer_environment ENV_FILE -> refuses a seed carried in the
+    # file and binds the named key file to the published sequencer public key
+    local env_file=$1 key_file public_key derived
+    [ -r "$env_file" ] || fail "environment file missing: $env_file"
+    if grep -q '^LAYERX_NODE_SEQUENCER_PRIVATE_KEY=' "$env_file"; then
+        fail "$env_file must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY; the supervisor delivers the seed from LAYERX_NODE_SEQUENCER_KEY_FILE"
+    fi
+    key_file=$(sed -n 's/^LAYERX_NODE_SEQUENCER_KEY_FILE=//p' "$env_file" | tail -n 1)
+    [ -n "$key_file" ] || fail "LAYERX_NODE_SEQUENCER_KEY_FILE missing from $env_file"
+    public_key=$(sed -n 's/^LAYERX_NODE_SEQUENCER_PUBLIC_KEY=//p' "$env_file" | tail -n 1)
+    [[ $public_key =~ ^[0-9a-f]{64}$ ]] || fail "LAYERX_NODE_SEQUENCER_PUBLIC_KEY missing from $env_file"
+    sequencer_seed_hex "$key_file"
+    derived=$(public_key_hex "$SEQUENCER_SEED")
+    SEQUENCER_SEED=""
+    [ "$derived" = "$public_key" ] \
+        || fail "the sequencer key file $key_file does not match the bound sequencer public key"
+    log "sequencer seed bound from $key_file"
+}
 
 publish_core_environment() {
     local sequencer_id asset_id lni_gid temporary signer_socket
@@ -201,13 +289,15 @@ start_daemon() {
         wait_for_settlement "$env_file"
     fi
     (
-        set -a
-        # shellcheck disable=SC1090
-        . "$env_file"
+        load_environment "$env_file" < "$env_file"
         if [ -n "${SETTLEMENT_LINES:-}" ]; then
-            eval "$SETTLEMENT_LINES"
+            load_environment "the settlement environment" <<< "$SETTLEMENT_LINES"
         fi
-        set +a
+        if [ "$mode" = --serve ]; then
+            sequencer_seed_hex "${LAYERX_NODE_SEQUENCER_KEY_FILE:-}"
+            export LAYERX_NODE_SEQUENCER_PRIVATE_KEY="$SEQUENCER_SEED"
+            SEQUENCER_SEED=""
+        fi
         exec "$LAYERXD" "$mode" "$config"
     ) &
     DAEMON_PID=$!
@@ -244,7 +334,7 @@ wait_for_file() {
 
 wait_for_daemon_ready() (
     local env_file=$1 mode=$2 seconds=$3 address port bearer path expected response deadline unknown body record page
-    . "$env_file"
+    load_environment "$env_file" < "$env_file"
     if [ "$mode" = --serve ]; then
         address=$LAYERX_NODE_PROGRAM_ADDRESS
         port=$LAYERX_NODE_PROGRAM_PORT
@@ -387,6 +477,7 @@ if [ ! -r "$DATA_DIR/node.env" ]; then
     log "bootstrapping $DATA_DIR"
     run_bootstrap --force "${BOOTSTRAP_ARGS[@]}"
 fi
+check_sequencer_environment "$DATA_DIR/sequencer.env"
 GENERATION=$((GENERATION + 1))
 publish_generation "$GENERATION"
 start_daemon "$DATA_DIR/sequencer.env" --serve "$DATA_DIR/sequencer.conf"
@@ -416,6 +507,10 @@ perform_reset() {
     if ! run_bootstrap --force "${BOOTSTRAP_ARGS[@]}"; then
         : > "$RUN_DIR/reset-failed.$id"
         fail "reset $id: bootstrap failed"
+    fi
+    if ! (check_sequencer_environment "$DATA_DIR/sequencer.env"); then
+        : > "$RUN_DIR/reset-failed.$id"
+        fail "reset $id: the sequencer seed could not be bound"
     fi
     GENERATION=$((GENERATION + 1))
     publish_generation "$GENERATION"

--- a/platform/hosted/node/tests/node-test.sh
+++ b/platform/hosted/node/tests/node-test.sh
@@ -168,6 +168,26 @@ expect_contains "$HANDSHAKE" '"role":"Sequencer"'
 expect_contains "$HANDSHAKE" "\"sequencer_public_key\":\"$LAYERX_NODE_SEQUENCER_PUBLIC_KEY\""
 expect_contains "$HANDSHAKE" 'AccountRead'
 
+log "sequencer seed reaches only the daemon environment"
+SEQUENCER_SEED_HEX=$(od -An -v -tx1 "$WORK/sequencer.key" | tr -d ' \n')
+DAEMON_PID=$(pgrep -f "$LAYERXD --serve $DATA/" | head -n 1)
+[ -n "$DAEMON_PID" ] || fail "layerxd --serve pid not found"
+if grep -q '^LAYERX_NODE_SEQUENCER_PRIVATE_KEY=' "$DATA/sequencer.env"; then
+    fail "sequencer.env carries LAYERX_NODE_SEQUENCER_PRIVATE_KEY"
+fi
+[ "$(sed -n 's/^LAYERX_NODE_SEQUENCER_KEY_FILE=//p' "$DATA/sequencer.env")" = "$WORK/sequencer.key" ] \
+    || fail "sequencer.env does not name the sequencer key file"
+COPIES=$(grep -rlD skip --exclude=sequencer.key -- "$SEQUENCER_SEED_HEX" "$WORK" || true)
+[ -z "$COPIES" ] || fail "the sequencer seed was copied outside its key file: $COPIES"
+tr '\0' '\n' < "/proc/$DAEMON_PID/environ" | grep -qx "LAYERX_NODE_SEQUENCER_PRIVATE_KEY=$SEQUENCER_SEED_HEX" \
+    || fail "the layerxd --serve environment does not carry the sequencer seed"
+if tr '\0' '\n' < "/proc/$DAEMON_PID/cmdline" | grep -q -- "$SEQUENCER_SEED_HEX"; then
+    fail "the sequencer seed appears on the layerxd command line"
+fi
+if tr '\0' '\n' < "/proc/$SEQUENCER_PID/environ" | grep -q '^LAYERX_NODE_SEQUENCER_PRIVATE_KEY='; then
+    fail "the sequencer supervisor environment carries the sequencer seed"
+fi
+
 log "operator state read over the real LNI"
 OPERATOR_STATE=$(as_client "$WORK/layerxctl" read-state --socket "$LAYERX_NODE_LNI_SOCKET" \
     --network-id "$NETWORK_ID" --protocol-version 3 --actor "$LAYERX_NODE_TREASURY_DID")

--- a/platform/hosted/node/tests/sequencer-seed-test.py
+++ b/platform/hosted/node/tests/sequencer-seed-test.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+ROOT = Path(__file__).resolve().parents[4]
+NODE_DIR = ROOT / 'platform/hosted/node'
+BIN = Path(os.environ.get('LAYERX_TEST_NATIVE_BIN_DIR', ROOT / 'build/bin'))
+sys.path.insert(0, str(ROOT / 'tests/support'))
+from lxgb_metadata import metadata
+
+ASSET = bytes.fromhex('b5a32b12029f8ddfb905f90f280f664b46390de0fc62770fc197dd87b18cd898')
+PKCS8_PREFIX = bytes.fromhex('302e020100300506032b657004220420')
+SPKI_PREFIX = bytes.fromhex('302a300506032b6570032100')
+SEED_LINE = b'LAYERX_NODE_SEQUENCER_PRIVATE_KEY='
+
+
+def memory_file(value):
+    descriptor = os.memfd_create('sequencer-seed-test', 0)
+    os.write(descriptor, value)
+    return descriptor
+
+
+def public_key_of(seed):
+    descriptor = memory_file(PKCS8_PREFIX + seed)
+    try:
+        encoded = subprocess.run(
+            ['openssl', 'pkey', '-inform', 'DER', '-in', f'/proc/self/fd/{descriptor}',
+             '-pubout', '-outform', 'DER'],
+            stdout=subprocess.PIPE, pass_fds=(descriptor,), check=True).stdout
+    finally:
+        os.close(descriptor)
+    assert encoded.startswith(SPKI_PREFIX) and len(encoded) == 44
+    return encoded[12:]
+
+
+def write_seed(path, seed):
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, 'wb') as handle:
+        handle.write(seed)
+
+
+def environment_lines(path):
+    return dict(line.split('=', 1) for line in path.read_text().splitlines())
+
+
+class SequencerSeedTest(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory(prefix='lx-sequencer-seed-')
+        self.addCleanup(self.directory.cleanup)
+        self.work = Path(self.directory.name)
+        os.chmod(self.work, 0o755)
+        self.sequencer_seed = os.urandom(32)
+        self.treasury_seed = os.urandom(32)
+        self.sequencer_path = self.work / 'sequencer.key'
+        self.treasury_path = self.work / 'treasury.key'
+        write_seed(self.sequencer_path, self.sequencer_seed)
+        write_seed(self.treasury_path, self.treasury_seed)
+        (self.work / 'metadata').write_bytes(
+            metadata(ASSET, public_key_of(self.treasury_seed), os.urandom(32)))
+        self.data = self.work / 'data'
+        self.run_dir = self.work / 'run'
+
+    def settlement_document(self):
+        path = ROOT / 'contracts/config/checkpoint-settlement.json'
+        threshold = json.loads(path.read_text())['finality_policy']['certificate_threshold']
+        self.assertGreaterEqual(threshold, 1)
+        return path
+
+    def clean_environment(self):
+        return {key: value for key, value in os.environ.items() if not key.startswith('LAYERX_')}
+
+    def bootstrap_arguments(self, sequencer_key):
+        return [
+            '--network-id', '77',
+            '--sequencer-key', str(sequencer_key),
+            '--treasury-key', str(self.treasury_path),
+            '--genesis-metadata', str(self.work / 'metadata'),
+            '--settlement-document', str(self.settlement_document()),
+            '--settlement-env', str(self.work / 'settlement.env'),
+            '--lni-uid', str(os.getuid() + 1),
+            '--genesis-build', str(BIN / 'layerx-genesis-build'),
+        ]
+
+    def bootstrap(self, sequencer_key=None, extra=()):
+        if sequencer_key is None:
+            sequencer_key = self.sequencer_path
+        command = [
+            'bash', str(NODE_DIR / 'bootstrap.sh'),
+            '--data-dir', str(self.data), '--run-dir', str(self.run_dir),
+            '--layerxd', str(BIN / 'layerxd'),
+        ] + self.bootstrap_arguments(sequencer_key) + list(extra)
+        return subprocess.run(command, cwd=str(ROOT), env=self.clean_environment(),
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    def supervisor_command(self):
+        self.assertIsNotNone(shutil.which('socat'), 'socat is required by the supervisor')
+        return [
+            'bash', str(NODE_DIR / 'supervisor.sh'), '--role', 'sequencer',
+            '--data-dir', str(self.data), '--run-dir', str(self.run_dir),
+            '--layerxd', str(BIN / 'layerxd'), '--',
+        ] + self.bootstrap_arguments(self.sequencer_path)
+
+    def supervise(self):
+        return subprocess.run(self.supervisor_command(), cwd=str(ROOT), env=self.clean_environment(),
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=120)
+
+    def supervise_process(self):
+        return subprocess.Popen(self.supervisor_command(), cwd=str(ROOT), env=self.clean_environment(),
+                                stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+    def assert_seed_only_in_its_file(self):
+        seed_hex = self.sequencer_seed.hex().encode()
+        for entry in self.work.rglob('*'):
+            if entry.is_file() and entry != self.sequencer_path:
+                content = entry.read_bytes()
+                self.assertNotIn(self.sequencer_seed, content, str(entry))
+                self.assertNotIn(seed_hex, content, str(entry))
+                self.assertNotIn(seed_hex.upper(), content, str(entry))
+
+    def test_bootstrap_records_the_key_file_and_keeps_no_seed_copy(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        sequencer_env = self.data / 'sequencer.env'
+        exports = environment_lines(sequencer_env)
+        self.assertNotIn('LAYERX_NODE_SEQUENCER_PRIVATE_KEY', exports)
+        self.assertEqual(exports['LAYERX_NODE_SEQUENCER_KEY_FILE'], str(self.sequencer_path))
+        self.assertEqual(exports['LAYERX_NODE_SEQUENCER_PUBLIC_KEY'],
+                         public_key_of(self.sequencer_seed).hex())
+        self.assertEqual(sequencer_env.stat().st_mode & 0o777, 0o600)
+        self.assertNotIn(SEED_LINE, sequencer_env.read_bytes())
+        self.assertNotIn('LAYERX_NODE_SEQUENCER_KEY_FILE', environment_lines(self.data / 'node.env'))
+        self.assertNotIn('LAYERX_NODE_SEQUENCER_KEY_FILE', environment_lines(self.data / 'replica.env'))
+        self.assertFalse((self.data / 'work').exists())
+        self.assert_seed_only_in_its_file()
+
+    def test_bootstrap_resolves_a_relative_key_path_against_the_working_directory(self):
+        relative = Path(os.path.relpath(self.sequencer_path, ROOT))
+        result = self.bootstrap(sequencer_key=relative)
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        exports = environment_lines(self.data / 'sequencer.env')
+        self.assertEqual(exports['LAYERX_NODE_SEQUENCER_KEY_FILE'], str(ROOT / relative))
+
+    def test_bootstrap_refuses_a_key_file_inside_the_data_directory(self):
+        self.data.mkdir(mode=0o700)
+        inside = self.data / 'sequencer.key'
+        write_seed(inside, self.sequencer_seed)
+        result = self.bootstrap(sequencer_key=inside, extra=['--force'])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b'the sequencer key file must be outside the data directory', result.stderr)
+        self.assertTrue(inside.exists(), 'the refusal must happen before --force discards the directory')
+        self.assertFalse((self.data / 'sequencer.env').exists())
+
+    def test_bootstrap_refuses_a_key_file_linked_into_the_data_directory(self):
+        self.data.mkdir(mode=0o700)
+        write_seed(self.data / 'linked.key', self.sequencer_seed)
+        link = self.work / 'sequencer-link.key'
+        link.symlink_to(self.data / 'linked.key')
+        result = self.bootstrap(sequencer_key=link, extra=['--force'])
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b'the sequencer key file must be outside the data directory', result.stderr)
+        self.assertTrue((self.data / 'linked.key').exists())
+
+    def test_bootstrap_refuses_an_unreadable_key_file(self):
+        result = self.bootstrap(sequencer_key=self.work / 'absent.key')
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(b'--sequencer-key must name a readable regular file', result.stderr)
+        self.assertFalse(self.data.exists())
+
+    def test_supervisor_refuses_a_seed_line_in_sequencer_env(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        sequencer_env = self.data / 'sequencer.env'
+        with sequencer_env.open('ab') as handle:
+            handle.write(SEED_LINE + self.sequencer_seed.hex().encode() + b'\n')
+        supervised = self.supervise()
+        self.assertNotEqual(supervised.returncode, 0)
+        self.assertIn(b'must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY', supervised.stderr)
+        self.assertFalse((self.run_dir / 'generation').exists())
+        self.assertFalse((self.run_dir / 'supervisor.sock').exists())
+
+    def test_supervisor_refuses_a_key_file_that_does_not_match_the_bound_public_key(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.sequencer_path.unlink()
+        write_seed(self.sequencer_path, os.urandom(32))
+        supervised = self.supervise()
+        self.assertNotEqual(supervised.returncode, 0)
+        self.assertIn(b'does not match the bound sequencer public key', supervised.stderr)
+        self.assertFalse((self.run_dir / 'generation').exists())
+
+    def test_supervisor_refuses_a_missing_key_file(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.sequencer_path.unlink()
+        supervised = self.supervise()
+        self.assertNotEqual(supervised.returncode, 0)
+        self.assertIn(b'sequencer key file is not a regular file', supervised.stderr)
+        self.assertFalse((self.run_dir / 'generation').exists())
+
+    def test_supervisor_refuses_a_malformed_key_file(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.sequencer_path.unlink()
+        write_seed(self.sequencer_path, b'not a seed\n')
+        supervised = self.supervise()
+        self.assertNotEqual(supervised.returncode, 0)
+        self.assertIn(b'must hold 32 raw bytes or 64 hex characters', supervised.stderr)
+        self.assertFalse((self.run_dir / 'generation').exists())
+
+    def test_supervisor_binds_the_hex_form_of_the_same_seed_before_publishing(self):
+        result = self.bootstrap()
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.sequencer_path.unlink()
+        write_seed(self.sequencer_path, self.sequencer_seed.hex().upper().encode() + b'\n')
+        bound = b'sequencer seed bound from ' + str(self.sequencer_path).encode()
+        process = self.supervise_process()
+        seen = []
+        try:
+            for line in process.stderr:
+                seen.append(line)
+                if line.rstrip(b'\n').endswith(bound):
+                    break
+            self.assertTrue(seen and seen[-1].rstrip(b'\n').endswith(bound), b''.join(seen).decode())
+            self.assertNotIn(b'does not match the bound sequencer public key', b''.join(seen))
+            deadline = time.monotonic() + 60
+            while not (self.run_dir / 'generation').exists():
+                self.assertIsNone(process.poll(), 'the supervisor exited after binding the seed')
+                self.assertLess(time.monotonic(), deadline, 'the generation was not published')
+                time.sleep(0.05)
+            self.assertEqual((self.run_dir / 'generation').read_text(), '1')
+        finally:
+            process.terminate()
+            process.wait(timeout=60)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/daemon/guarantor-integration.py
+++ b/tests/daemon/guarantor-integration.py
@@ -22,6 +22,19 @@ def read_env(path):
     return dict(line.split("=", 1) for line in path.read_text().splitlines() if line)
 
 
+def sequencer_seed_hex(env):
+    if "LAYERX_NODE_SEQUENCER_PRIVATE_KEY" in env:
+        raise RuntimeError("sequencer.env must not carry LAYERX_NODE_SEQUENCER_PRIVATE_KEY; the seed is read from LAYERX_NODE_SEQUENCER_KEY_FILE")
+    key_file = Path(env["LAYERX_NODE_SEQUENCER_KEY_FILE"])
+    if not key_file.is_absolute() or not key_file.is_file():
+        raise RuntimeError(f"LAYERX_NODE_SEQUENCER_KEY_FILE must name an absolute regular file: {key_file}")
+    content = key_file.read_bytes()
+    seed = content.hex() if len(content) == 32 else "".join(content.decode("ascii").split()).lower()
+    if len(seed) != 64 or any(character not in "0123456789abcdef" for character in seed):
+        raise RuntimeError(f"sequencer key file must hold 32 raw bytes or 64 hex characters: {key_file}")
+    return seed
+
+
 def client_identity():
     os.setgroups([ROOT.stat().st_gid])
     os.setgid(4021)
@@ -147,7 +160,8 @@ def main():
             with socket.create_connection(("127.0.0.1", replica_port), timeout=1):
                 return True
         await_condition(replica_ready, [anvil, replica], "real receipt authority")
-        daemon_env = os.environ | read_env(work / "data/sequencer.env") | settlement
+        sequencer_env = read_env(work / "data/sequencer.env")
+        daemon_env = os.environ | sequencer_env | {"LAYERX_NODE_SEQUENCER_PRIVATE_KEY": sequencer_seed_hex(sequencer_env)} | settlement
         daemon = launch([str(native / "layerxd"), "--serve", str(work / "data/sequencer.conf")], "daemon.log", env=daemon_env)
         lni_socket = str(runtime / "layerxd.lni.sock")
         await_condition(lambda: Path(lni_socket).is_socket(), [anvil, replica, daemon], "real sequencer LNI")

--- a/tests/daemon/owner-production.py
+++ b/tests/daemon/owner-production.py
@@ -129,7 +129,11 @@ def run(work, asset, rpc_port):
     sequencer = None
     try:
         for role, option in (('replica', '--authority-replica'), ('sequencer', '--serve')):
-            launched = start(['bash', '-c', 'set -a; source "$1"; exec "$2" "$3" "$4"', 'owner-production',
+            if role == 'sequencer':
+                launcher = f'source "{repo / "platform/hosted/node/sequencer-env.sh"}"; layerx_sequencer_environment "$1"; exec "$2" "$3" "$4"'
+            else:
+                launcher = 'set -a; source "$1"; exec "$2" "$3" "$4"'
+            launched = start(['bash', '-c', launcher, 'owner-production',
                    str(work / f'node/{role}.env'), str(repo / 'build/bin/layerxd'), option,
                    str(work / f'node/{role}.conf')], role, env)
             if role == 'sequencer':

--- a/tests/daemon/pay1.py
+++ b/tests/daemon/pay1.py
@@ -130,7 +130,10 @@ def main():
     def start(role):
         log = (work / f'{role}.log').open('ab')
         logs.append(log)
-        command = 'set -a; source "$1"; export LAYERX_PAY_TIMING=1; exec "$2" "$3" "$4"'
+        if role == 'sequencer':
+            command = f'source "{ROOT / "platform/hosted/node/sequencer-env.sh"}"; layerx_sequencer_environment "$1"; export LAYERX_PAY_TIMING=1; exec "$2" "$3" "$4"'
+        else:
+            command = 'set -a; source "$1"; export LAYERX_PAY_TIMING=1; exec "$2" "$3" "$4"'
         process = subprocess.Popen(['bash', '-c', command, 'pay1', str(work / f'data/{role}.env'),
                                     str(native / 'layerxd'), '--serve' if role == 'sequencer' else '--authority-replica',
                                     str(work / f'data/{role}.conf')], cwd=ROOT, stdout=log, stderr=log)

--- a/tests/daemon/program-admission.sh
+++ b/tests/daemon/program-admission.sh
@@ -89,7 +89,7 @@ fi
 replica_pid=$!
 IFS= read -r -n 1 -t 20 replica_ready <&"$replica_ready_fd"
 [[ "$replica_ready" == R ]]
-(set -a; source "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$sequencer_binary" --serve "$work/data/sequencer.conf") > "$work/sequencer.log" 2>&1 &
+(source platform/hosted/node/sequencer-env.sh; layerx_sequencer_environment "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$sequencer_binary" --serve "$work/data/sequencer.conf") > "$work/sequencer.log" 2>&1 &
 sequencer_pid=$!
 for ((attempt=0; attempt<200; attempt++)); do
     [[ ! -S "$runtime/layerxd.lni.sock" ]] || break
@@ -149,7 +149,7 @@ with open(sys.argv[1], 'r+b') as bundle:
     bundle.flush()
     os.fsync(bundle.fileno())
 PYCORRUPT
-    (set -a; source "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$sequencer_binary" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 &
+    (source platform/hosted/node/sequencer-env.sh; layerx_sequencer_environment "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$sequencer_binary" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 &
     sequencer_pid=$!
     for ((attempt=0; attempt<200; attempt++)); do
         [[ ! -S "$runtime/layerxd.lni.sock" ]] || break
@@ -205,12 +205,12 @@ else:
     raise SystemExit('unknown marker mutation')
 PYMARKER
         result=0
-        (set -a; source "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$native_bin/layerxd" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 || result=$?
+        (source platform/hosted/node/sequencer-env.sh; layerx_sequencer_environment "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$native_bin/layerxd" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 || result=$?
         [[ "$result" != 0 ]]
         rg -q 'bootstrap .* failed with result' "$work/sequencer.log"
         exit 0
     fi
-    (set -a; source "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$native_bin/layerxd" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 &
+    (source platform/hosted/node/sequencer-env.sh; layerx_sequencer_environment "$work/data/sequencer.env"; if [[ ${2:-} == --availability-batches ]]; then export LAYERX_NODE_SETTLEMENT_CONTRACT="$availability_bond" LAYERX_NODE_CHECKPOINT_REGISTRY="$availability_registry" LAYERX_NODE_PAXEER_RPC_PORT="$availability_port"; fi; exec "$native_bin/layerxd" --serve "$work/data/sequencer.conf") >> "$work/sequencer.log" 2>&1 &
     sequencer_pid=$!
     python3 - "$runtime/layerxd.lni.sock" "$sequencer_pid" <<'PYWAIT'
 import os, socket, sys, time


### PR DESCRIPTION
## Summary

The sequencer seed no longer lives in `sequencer.env` and is no longer exported wholesale by `set -a`. `bootstrap.sh` records the `--sequencer-key` path as `LAYERX_NODE_SEQUENCER_KEY_FILE` (readable regular file, outside the data directory even after resolving symlinks, because `--force` and the reset discard that directory) and keeps deleting the temporary genesis signer key. `supervisor.sh` loads every environment file line by line through a strict `LAYERX_*` `KEY=VALUE` validator that refuses a `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` line, binds the key file to `LAYERX_NODE_SEQUENCER_PUBLIC_KEY` before it publishes a generation (first start, restart, every reset), reads the seed through a read-only descriptor it opens itself inside the subshell that execs `layerxd --serve`, and exports `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` into that daemon's environment only. The seed never appears on a command line, in the supervisor's own environment, or in any file under the data or run directory.

Every caller outside the supervisor that starts `layerxd --serve` from a bootstrap-generated `sequencer.env` is updated in the same change (second commit): `platform/hosted/node/sequencer-env.sh` provides `layerx_sequencer_environment`, which exports the `LAYERX_*` lines with the same validation, refuses a seed line, reads the key file and exports `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` only in the subshell that execs the daemon. `tests/daemon/program-admission.sh` (four launch sites, covering `make test-program-admission`, `test-program-simulate`, `test-daemon-maintenance-publication` and `tests/daemon/maintenance-crash.sh`), `tests/daemon/pay1.py` and `tests/daemon/owner-production.py` use it for the sequencer role; `tests/daemon/guarantor-integration.py` (`make test-daemon-guarantor-integration`) derives the same variable in Python from `LAYERX_NODE_SEQUENCER_KEY_FILE` before launching the daemon. These files are outside the row's owned paths; the edit is the caller update the seed relocation requires and touches nothing else in them. `tests/daemon/guarantor-publication-chain.py` sources `sequencer.env` only to run `lxp_test_guarantor_runtime`, which never reads the seed, and is unchanged.

`shareProcessNamespace: true` in `deployment.yaml` is left in place: the LNI `peer_credentials` check in `cmd/layerxd/lxp_daemon_lni.c` refuses a `SO_PEERCRED` pid that is not positive, and a sibling container in its own pid namespace, or a split pod, reports pid 0, so the boundary handshakes would be refused. The row's check and the daemon disagree here; both are left intact and the conflict is described under Conflicts and in `docs/wiki/HostedNode.md`.

## Files changed

- `platform/hosted/node/bootstrap.sh` — sequencer hunk: key path normalised and validated, data-directory and symlink refusals before `--force` wipes anything, `LAYERX_NODE_SEQUENCER_KEY_FILE` replaces `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` in `sequencer.env`, usage text.
- `platform/hosted/node/supervisor.sh` — `load_environment`, `sequencer_seed_hex`, `check_sequencer_environment`, `public_key_hex` helpers; `start_daemon` and `wait_for_daemon_ready` no longer source files; seed check before `publish_generation` on start and in `perform_reset` (marks `reset-failed` on refusal); `openssl`/`od` required for the sequencer role; header comment.
- `platform/hosted/node/sequencer-env.sh` — new: `layerx_sequencer_environment ENV_FILE` for callers outside the supervisor (strict `LAYERX_*` export, seed-line refusal, key file read through a private descriptor, `LAYERX_NODE_SEQUENCER_PRIVATE_KEY` exported for the exec'd daemon; returns 1 with a message on stderr instead of exporting anything partial).
- `platform/hosted/node/tests/node-test.sh` — after the LNI handshake: `sequencer.env` has no seed line and names the key file, no copy of the seed hex anywhere under the test tree, `/proc/<layerxd pid>/environ` carries the seed, `/proc/<layerxd pid>/cmdline` and the supervisor's environ do not.
- `platform/hosted/node/tests/sequencer-seed-test.py` — new: bootstrap outputs and no-seed-copy scan (raw, hex, upper-hex), relative path resolution, data-directory and symlinked-into-data-directory refusals (file must survive, so the check runs before the wipe), unreadable key refusal; supervisor refusals for a seed line in `sequencer.env`, a mismatched key, a missing key, a malformed key; supervisor binding the upper-case hex form of the same seed and publishing generation 1 only afterwards.
- `platform/Makefile.inc` — `platform-test-node` syntax-checks `sequencer-env.sh` and runs `python3 platform/hosted/node/tests/sequencer-seed-test.py` after `node-test.sh`.
- `tests/daemon/program-admission.sh` — the four `layerxd --serve` launch sites source `sequencer-env.sh` and call `layerx_sequencer_environment` instead of `set -a; source`; the `--availability-batches` overrides still follow the load and win.
- `tests/daemon/guarantor-integration.py` — `sequencer_seed_hex(env)` reads the key file named by `LAYERX_NODE_SEQUENCER_KEY_FILE` (32 raw bytes or 64 hex characters) and `daemon_env` carries `LAYERX_NODE_SEQUENCER_PRIVATE_KEY`.
- `tests/daemon/pay1.py`, `tests/daemon/owner-production.py` — the sequencer launcher uses `sequencer-env.sh`; the replica launcher is unchanged.
- `docs/wiki/HostedNode.md` — artefact table row, `sequencer.env` contents, new "Sequencer seed delivery" section including the refusals, the helper for callers outside the supervisor, and the `shareProcessNamespace` conflict.

## Design decisions

- The daemon (`cmd/layerxd/lxp_daemon_process.c`, `cmd/layerxd/lxp_daemon_lni.c`) reads the seed only from `LAYERX_NODE_SEQUENCER_PRIVATE_KEY`; `cmd/layerxd` is outside this row, so the supervisor is the deliverer: it owns the descriptor, verifies the public key, and the variable exists only in the exec'd daemon. Closing the remaining `/proc/<pid>/environ` exposure needs either `LAYERX_NODE_SEQUENCER_KEY_FD` plus `PR_SET_DUMPABLE` in the daemon or sequencer signing through the signer socket; both are listed under Follow-ups.
- The key path is recorded as given (made absolute against `$PWD`, not `readlink -f`) so a Kubernetes secret mount keeps its stable path across projected-volume rotations; the `readlink -f` form is used only for the data-directory refusal.
- No seed copy is made under the data directory; the reset re-reads the same key file, exactly as the k8s mount and the tests provide it.
- `sequencer-env.sh` is a separate sourceable file rather than a supervisor function so the daemon test scripts can adopt the new delivery without running the supervisor; it applies the same validation and returns instead of exiting so each caller's own `set -e` handling decides.
- `deployment.yaml` is unchanged: removing `shareProcessNamespace` or splitting the pod breaks every LNI handshake until the daemon's pid requirement changes.

## Static checks

- `bash -n platform/hosted/node/supervisor.sh platform/hosted/node/bootstrap.sh platform/hosted/node/sequencer-env.sh platform/hosted/node/tests/node-test.sh tests/daemon/program-admission.sh` — exit 0
- `python3 -m py_compile platform/hosted/node/tests/sequencer-seed-test.py tests/daemon/guarantor-integration.py tests/daemon/pay1.py tests/daemon/owner-production.py` — exit 0
- `git diff --check origin/main HEAD` — exit 0 (after rebase onto current `origin/main`)
- `shellcheck` — not installed, not run

## Build and test: not run in this lane

## Generated artifacts pending

none

## Conflicts

- Row deliverable "shareProcessNamespace removed or the pod split" is not met. `cmd/layerxd/lxp_daemon_lni.c` refuses an LNI peer whose `SO_PEERCRED` pid is not positive; a container outside the daemon's pid namespace presents pid 0, so removing `shareProcessNamespace` or splitting the pod would refuse every boundary handshake. `deployment.yaml` is left as is. Resolution needs a `cmd/layerxd` change (drop the positive-pid requirement, or move sequencer signing behind the signer socket) before the pod layout can change.

## Follow-ups

- `cmd/layerxd`: accept the seed from an inherited descriptor (`LAYERX_NODE_SEQUENCER_KEY_FD`), set `PR_SET_DUMPABLE` 0, refuse the environment form when the descriptor is present — or sign batch headers and receipts through the signer socket protocol in `platform/hosted/node/signer/client.py`. The supervisor already opens the descriptor and can stop exporting the variable once either lands; `sequencer-env.sh` would follow.
- `cmd/layerxd/lxp_daemon_lni.c` peer credentials: without positive-pid enforcement the pod could drop `shareProcessNamespace` (or be split), which is what fully isolates the daemon environment from uid 4020 processes in sibling containers.
- `platform/hosted/node/tests/bootstrap-test.py` and `node-test.sh` still lack `--genesis-metadata`; the new suite passes it itself and does not depend on that fix. `bootstrap-test.py` and `signer-test.py` remain unwired from any make target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
